### PR TITLE
Add URLs to component manifests

### DIFF
--- a/esp32_azure_iot_kit/idf_component.yml
+++ b/esp32_azure_iot_kit/idf_component.yml
@@ -1,5 +1,7 @@
 version: "0.0.7-alpha"
 description: Board Support Package for ESP32-Azure-IoT-Kit
+url: https://github.com/espressif/esp-bsp/tree/master/esp32_azure_iot_kit
+
 targets:
     - esp32
 

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,7 +1,10 @@
 version: "0.0.3"
 description: Board Support Package for ESP32-S2-Kaluga kit
+url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
+
 targets:
   - esp32s2
+
 dependencies:
   idf: ">=4.2"
 

--- a/esp_wrover_kit/idf_component.yml
+++ b/esp_wrover_kit/idf_component.yml
@@ -1,10 +1,13 @@
 version: "0.0.1"
 description: Board Support Package for ESP-WROVER-KIT
+url: https://github.com/espressif/esp-bsp/tree/master/esp_wrover_kit
+
 targets:
     - esp32
 
 dependencies:
   idf: ">=4.4" # esp_lcd component was added in v4.4
+
   lvgl/lvgl:
     version: "==8.0.2"
     public: true


### PR DESCRIPTION
These URLs can be shown in the UI, also it will be simpler to find the source of the component.

The question is, whether we should point to the root of the repo, or to the component directory inside