### PR TITLE
Remove usage of legacy FreeRTOS types

### DIFF
--- a/components/bh1750/bh1750.c
+++ b/components/bh1750/bh1750.c
@@ -31,7 +31,7 @@ static esp_err_t bh1750_write_byte(const bh1750_dev_t *const sens, const uint8_t
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -103,7 +103,7 @@ esp_err_t bh1750_get_data(bh1750_handle_t sensor, float *const data)
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
     if (ESP_OK != ret) {
         return ret;

--- a/components/bh1750/idf_component.yml
+++ b/components/bh1750/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: I2C driver for BH1750 light sensor
 url: https://github.com/espressif/esp-bsp/tree/master/components/bh1750
 dependencies:

--- a/components/bh1750/test/bh1750_test.c
+++ b/components/bh1750/test/bh1750_test.c
@@ -61,7 +61,7 @@ TEST_CASE("Sensor BH1750 test", "[bh1750][iot][sensor]")
     cmd_measure = BH1750_ONETIME_4LX_RES;
     ret = bh1750_set_measure_mode(bh1750, cmd_measure);
     TEST_ASSERT_EQUAL(ESP_OK, ret);
-    vTaskDelay(30 / portTICK_RATE_MS);
+    vTaskDelay(30 / portTICK_PERIOD_MS);
 
     ret = bh1750_get_data(bh1750, &bh1750_data);
     TEST_ASSERT_EQUAL(ESP_OK, ret);
@@ -71,7 +71,7 @@ TEST_CASE("Sensor BH1750 test", "[bh1750][iot][sensor]")
     cmd_measure = BH1750_CONTINUE_4LX_RES;
     ret = bh1750_set_measure_mode(bh1750, cmd_measure);
     TEST_ASSERT_EQUAL(ESP_OK, ret);
-    vTaskDelay(30 / portTICK_RATE_MS);
+    vTaskDelay(30 / portTICK_PERIOD_MS);
 
     ret = bh1750_get_data(bh1750, &bh1750_data);
     TEST_ASSERT_EQUAL(ESP_OK, ret);

--- a/components/es8311/es8311.c
+++ b/components/es8311/es8311.c
@@ -159,7 +159,7 @@ static int es8311_write_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t data)
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
     return ret;
 }
@@ -184,7 +184,7 @@ int es8311_read_reg(es8311_handle_t dev, uint8_t reg_addr)
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return data;

--- a/components/es8311/idf_component.yml
+++ b/components/es8311/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2-alpha"
+version: "0.0.3-alpha"
 description: Low power mono audio codec ES8311
 url: https://github.com/espressif/esp-bsp/tree/master/components/es8311
 dependencies:

--- a/components/fbm320/fbm320.c
+++ b/components/fbm320/fbm320.c
@@ -43,7 +43,7 @@ static esp_err_t fbm320_write(fbm320_handle_t sensor, const uint8_t reg_start_ad
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -68,7 +68,7 @@ static esp_err_t fbm320_read(fbm320_handle_t sensor, const uint8_t reg_start_add
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -163,7 +163,7 @@ esp_err_t fbm320_get_data(fbm320_handle_t sensor, const fbm320_measure_mode_t me
     if (ESP_OK != ret) {
         return ret;
     }
-    vTaskDelay(10 / portTICK_RATE_MS);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
     ret = fbm320_read_result(sensor, &temperature_raw);
     if (ESP_OK != ret) {
         return ret;
@@ -174,7 +174,7 @@ esp_err_t fbm320_get_data(fbm320_handle_t sensor, const fbm320_measure_mode_t me
     if (ESP_OK != ret) {
         return ret;
     }
-    vTaskDelay(10 / portTICK_RATE_MS);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
     ret = fbm320_read_result(sensor, &pressure_raw);
     if (ESP_OK != ret) {
         return ret;

--- a/components/fbm320/idf_component.yml
+++ b/components/fbm320/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: I2C driver for FBM320 digital barometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/fbm320
 dependencies:

--- a/components/hts221/hts221.c
+++ b/components/hts221/hts221.c
@@ -95,7 +95,7 @@ static esp_err_t hts221_write(hts221_handle_t sensor, const uint8_t reg_start_ad
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -125,7 +125,7 @@ static esp_err_t hts221_read(hts221_handle_t sensor, const uint8_t reg_start_add
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;

--- a/components/hts221/idf_component.yml
+++ b/components/hts221/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: I2C driver for HTS221 humidity and temperature sensor
 url: https://github.com/espressif/esp-bsp/tree/master/components/hts221
 dependencies:

--- a/components/mag3110/idf_component.yml
+++ b/components/mag3110/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: I2C driver for MAG3110 3-axis digital magnetometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/mag3110
 dependencies:

--- a/components/mag3110/mag3110.c
+++ b/components/mag3110/mag3110.c
@@ -47,7 +47,7 @@ static esp_err_t mag3110_write(mag3110_handle_t sensor, const uint8_t reg_start_
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -72,7 +72,7 @@ static esp_err_t mag3110_read(mag3110_handle_t sensor, const uint8_t reg_start_a
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -176,7 +176,7 @@ esp_err_t mag3110_calibrate(mag3110_handle_t sensor, const uint32_t cal_duration
     ret = mag3110_write(sensor, MAG3110_CTRL_REG1, ctrl_reg, sizeof(ctrl_reg));
     assert(ESP_OK == ret);
 
-    vTaskDelay(100 / portTICK_RATE_MS); // Wait for start-up
+    vTaskDelay(100 / portTICK_PERIOD_MS); // Wait for start-up
 
     const esp_timer_create_args_t cal_timer_config = {
         .callback = mag3110_timer_callback,
@@ -196,7 +196,7 @@ esp_err_t mag3110_calibrate(mag3110_handle_t sensor, const uint32_t cal_duration
 
     // Let the ESP_Timer collect the data
     // User must rotate the MAG3110 in all axis during this time
-    vTaskDelay(cal_duration_ms / portTICK_RATE_MS);
+    vTaskDelay(cal_duration_ms / portTICK_PERIOD_MS);
 
     ESP_LOGI("MAG3110", "Exiting calibration loop");
     ret = esp_timer_stop(cal_timer);
@@ -226,7 +226,7 @@ esp_err_t mag3110_calibrate(mag3110_handle_t sensor, const uint32_t cal_duration
 
     ESP_LOGD("MAG3110", "offset data %i %i %i", offset[0], offset[1], offset[2]);
 
-    vTaskDelay(100 / portTICK_RATE_MS); // Wait for shutdown
+    vTaskDelay(100 / portTICK_PERIOD_MS); // Wait for shutdown
 
     return ret;
 }

--- a/components/mpu6050/idf_component.yml
+++ b/components/mpu6050/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: I2C driver for MPU6050 gyroscope and accelerometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/mpu6050
 dependencies:

--- a/components/mpu6050/mpu6050.c
+++ b/components/mpu6050/mpu6050.c
@@ -47,7 +47,7 @@ static esp_err_t mpu6050_write(mpu6050_handle_t sensor, const uint8_t reg_start_
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -73,7 +73,7 @@ static esp_err_t mpu6050_read(mpu6050_handle_t sensor, const uint8_t reg_start_a
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;

--- a/components/ssd1306/idf_component.yml
+++ b/components/ssd1306/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3-alpha"
+version: "1.0.4-alpha"
 description: I2C driver for SSD1306 OLED display
 url: https://github.com/espressif/esp-bsp/tree/master/components/ssd1306
 dependencies:

--- a/components/ssd1306/ssd1306.c
+++ b/components/ssd1306/ssd1306.c
@@ -42,7 +42,7 @@ static esp_err_t ssd1306_write_data(ssd1306_handle_t dev, const uint8_t *const d
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(device->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(device->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;
@@ -64,7 +64,7 @@ static esp_err_t ssd1306_write_cmd(ssd1306_handle_t dev, const uint8_t *const da
     assert(ESP_OK == ret);
     ret = i2c_master_stop(cmd);
     assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(device->bus, cmd, 1000 / portTICK_RATE_MS);
+    ret = i2c_master_cmd_begin(device->bus, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     return ret;

--- a/components/ssd1306/test/ssd1306_test.c
+++ b/components/ssd1306/test/ssd1306_test.c
@@ -121,7 +121,7 @@ static void ssd1306_test_task(void *pvParameters)
         ret = ssd1306_show_time(dev);
         TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, ret, "SSD1306 show time returned error");
 
-        vTaskDelay(100 / portTICK_RATE_MS);
+        vTaskDelay(100 / portTICK_PERIOD_MS);
     }
     ESP_LOGI(TAG, "OLED cleaning-up...");
 
@@ -141,7 +141,7 @@ TEST_CASE("Device ssd1306 test", "[ssd1306][iot][device]")
 {
     test_running = true;
     xTaskCreate(&ssd1306_test_task, "ssd1306_test_task", 2048 * 2, NULL, 5, NULL);
-    vTaskDelay(10000 / portTICK_RATE_MS); // run the test for 10 seconds
+    vTaskDelay(10000 / portTICK_PERIOD_MS); // run the test for 10 seconds
     test_running = false;                 // stop the test
-    vTaskDelay(1000 / portTICK_RATE_MS);  // give the kernel some time to clean-up
+    vTaskDelay(1000 / portTICK_PERIOD_MS);  // give the kernel some time to clean-up
 }

--- a/esp32_azure_iot_kit/examples/sensors_example/main/sensors_example.c
+++ b/esp32_azure_iot_kit/examples/sensors_example/main/sensors_example.c
@@ -230,7 +230,7 @@ void ssd1306_show_task(void *pvParameters)
     ssd1306_clear_screen(ssd1306_dev, 0x00);
     ssd1306_show_signs(ssd1306_dev);
     while (1) {
-        if (xQueueReceive(q_page_num, &page_num, 1000 / portTICK_RATE_MS) == pdTRUE) {
+        if (xQueueReceive(q_page_num, &page_num, 1000 / portTICK_PERIOD_MS) == pdTRUE) {
             ssd1306_clear_screen(ssd1306_dev, 0x00);
             ssd1306_show_signs(ssd1306_dev);
         }
@@ -335,6 +335,6 @@ void app_main(void)
             bsp_buzzer_set(false);
         }
 
-        vTaskDelay(200 / portTICK_RATE_MS);
+        vTaskDelay(200 / portTICK_PERIOD_MS);
     }
 }

--- a/esp32_azure_iot_kit/idf_component.yml
+++ b/esp32_azure_iot_kit/idf_component.yml
@@ -12,25 +12,25 @@ dependencies:
 
   # components on the board
   hts221:
-    version: ">=1.1.1"
+    version: ">=1.1.2"
     public: true
 
   ssd1306:
-    version: ">=1.0.3-alpha"
+    version: ">=1.0.4-alpha"
     public: true
 
   bh1750:
-    version: ">=1.0.0"
+    version: ">=1.0.1"
     public: true
 
   fbm320:
-    version: ">=1.0.0"
+    version: ">=1.0.1"
     public: true
 
   mag3110:
-    version: ">=1.0.0"
+    version: ">=1.0.2"
     public: true
 
   mpu6050:
-    version: ">=1.0.0"
+    version: ">=1.0.1"
     public: true

--- a/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -183,7 +183,7 @@ void bsp_touchpad_init(intr_handler_t fn)
     ESP_ERROR_CHECK(touch_pad_fsm_start());
 
     /*!< Wait touch sensor init done and calibrate */
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(100 / portTICK_PERIOD_MS);
     for (int i = 0; i < TOUCH_BUTTON_NUM; i++) {
         bsp_touchpad_calibrate(bsp_touch_button[i], 0.1f);
     }

--- a/esp32_s2_kaluga_kit/examples/display_audio/main/bsp_kaluga_disp_audio_example.c
+++ b/esp32_s2_kaluga_kit/examples/display_audio/main/bsp_kaluga_disp_audio_example.c
@@ -189,7 +189,7 @@ static void audio_task(void *arg)
                     size_t bytes_received_from_i2s;
 
                     ESP_ERROR_CHECK(i2s_read(BSP_I2S_NUM, recording_buffer, BUFFER_SIZE, &bytes_received_from_i2s,
-                                             5000 / portTICK_RATE_MS));
+                                             5000 / portTICK_PERIOD_MS));
 
                     /* Write WAV file data */
                     size_t data_written = fwrite(recording_buffer, 1, bytes_received_from_i2s, record_file);
@@ -242,7 +242,7 @@ static void audio_task(void *arg)
                     /* Send it to I2S */
                     size_t i2s_bytes_written;
                     ESP_ERROR_CHECK(i2s_write(BSP_I2S_NUM, wav_bytes, bytes_read_from_spiffs, &i2s_bytes_written,
-                                              500 / portTICK_RATE_MS));
+                                              500 / portTICK_PERIOD_MS));
                     bytes_send_to_i2s += i2s_bytes_written;
                 }
 

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -13,7 +13,7 @@ dependencies:
     public: true
 
   es8311:
-    version: ">=0.0.2-alpha"
+    version: ">=0.0.3-alpha"
     public: true
 
   led_strip:

--- a/esp32_s2_kaluga_kit/include/esp32_s2_kaluga_kit.h
+++ b/esp32_s2_kaluga_kit/include/esp32_s2_kaluga_kit.h
@@ -43,7 +43,7 @@ extern "C" {
  *
  * After initialization of I2S, use BSP_I2S_NUM macro when reading/writing to I2S stream:
  * \code{.c}
- * i2s_write(BSP_I2S_NUM, wav_bytes, wav_bytes_len, &i2s_bytes_written, 500 / portTICK_RATE_MS);
+ * i2s_write(BSP_I2S_NUM, wav_bytes, wav_bytes_len, &i2s_bytes_written, 500 / portTICK_PERIOD_MS);
  * \endcode
  **************************************************************************************************/
 #define BSP_I2S_NUM           (I2S_NUM_0) // ESP32S2 has only 1 I2S peripheral


### PR DESCRIPTION
ESP-IDF v5.0 will disable the configENABLE_BACKWARD_COMPATIBILITY option by default, thus various legacy FreeRTOS API and data types will no longer be supported.

This PR  updates various components of the component registery to remove any usage of legacy FreeRTOS types.