### PR TITLE
ES8311: release 1.0.0

### DIFF
--- a/components/es8311/es8311.c
+++ b/components/es8311/es8311.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,7 +21,7 @@ typedef struct {
 } es8311_dev_t;
 
 /*
- * Clock coefficient structer
+ * Clock coefficient structure
  */
 struct _coeff_div {
     uint32_t mclk;        /* mclk frequency */
@@ -370,7 +370,7 @@ esp_err_t es8311_init(es8311_handle_t dev, const es8311_clock_config_t *const cl
     ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG12, 0x00); // power-up DAC - NOT default
     ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG13, 0x10); // Enable output to HP drive - NOT default
     ret |= es8311_write_reg(dev, ES8311_ADC_REG1C, 0x6A); // ADC Equalizer bypass, cancel DC offset in digital domain
-    ret |= es8311_write_reg(dev, ES8311_DAC_REG37, 0x48); // DAC ramprate and bypass DAC equalizer - NOT default
+    ret |= es8311_write_reg(dev, ES8311_DAC_REG37, 0x08); // Bypass DAC equalizer - NOT default
 
     return ret;
 }
@@ -430,6 +430,22 @@ esp_err_t es8311_voice_mute(es8311_handle_t dev, bool mute)
 esp_err_t es8311_microphone_gain_set(es8311_handle_t dev, es8311_mic_gain_t gain_db)
 {
     return es8311_write_reg(dev, ES8311_ADC_REG16, gain_db); // ADC gain scale up
+}
+
+esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade)
+{
+    uint8_t reg37 = es8311_read_reg(dev, ES8311_DAC_REG37);
+    reg37 &= 0x0F;
+    reg37 |= (fade << 4);
+    return es8311_write_reg(dev, ES8311_DAC_REG37, reg37);
+}
+
+esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade)
+{
+    uint8_t reg15 = es8311_read_reg(dev, ES8311_ADC_REG15);
+    reg15 &= 0x0F;
+    reg15 |= (fade << 4);
+    return es8311_write_reg(dev, ES8311_ADC_REG15, reg15);
 }
 
 void es8311_register_dump(es8311_handle_t dev)

--- a/components/es8311/es8311.c
+++ b/components/es8311/es8311.c
@@ -9,6 +9,7 @@
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include "esp_check.h"
 
 #include "es8311_reg.h"
 
@@ -142,52 +143,19 @@ static const struct _coeff_div coeff_div[] = {
     {1536000, 96000, 0x01, 0x03, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
 };
 
-static char *TAG = "ES8311";
+static const char *TAG = "ES8311";
 
-static int es8311_write_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t data)
+static inline esp_err_t es8311_write_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t data)
 {
     es8311_dev_t *es = (es8311_dev_t *) dev;
-    esp_err_t  ret;
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ret = i2c_master_start(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, es->dev_addr | I2C_MASTER_WRITE, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, reg_addr, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, data, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_stop(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
-    return ret;
+    const uint8_t write_buf[2] = {reg_addr, data};
+    return i2c_master_write_to_device(es->port, es->dev_addr, write_buf, sizeof(write_buf), pdMS_TO_TICKS(1000));
 }
 
-int es8311_read_reg(es8311_handle_t dev, uint8_t reg_addr)
+static inline esp_err_t es8311_read_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t *reg_value)
 {
     es8311_dev_t *es = (es8311_dev_t *) dev;
-    uint8_t data;
-    esp_err_t ret;
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ret = i2c_master_start(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, es->dev_addr | I2C_MASTER_WRITE, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, reg_addr, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_start(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, es->dev_addr | I2C_MASTER_READ, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_read_byte(cmd, &data, I2C_MASTER_LAST_NACK);
-    assert(ESP_OK == ret);
-    ret = i2c_master_stop(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(es->port, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
-
-    return data;
+    return i2c_master_write_read_device(es->port, es->dev_addr, &reg_addr, 1, reg_value, 1, pdMS_TO_TICKS(1000));
 }
 
 /*
@@ -206,7 +174,6 @@ static int get_coeff(uint32_t mclk, uint32_t rate)
 
 esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency, int sample_frequency)
 {
-    esp_err_t ret = ESP_OK;
     uint8_t regv;
 
     /* Get clock coefficients from coefficient table */
@@ -220,24 +187,26 @@ esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency
     const struct _coeff_div *const selected_coeff = &coeff_div[coeff];
 
     /* register 0x02 */
-    regv = es8311_read_reg(dev, ES8311_CLK_MANAGER_REG02) & 0x07;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG02, &regv), TAG, "I2C read/write error");
+    regv &= 0x07;
     regv |= (selected_coeff->pre_div - 1) << 5;
     regv |= selected_coeff->pre_multi << 3;
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG02, regv);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG02, regv), TAG, "I2C read/write error");
 
     /* register 0x03 */
     const uint8_t reg03 = (selected_coeff->fs_mode << 6) | selected_coeff->adc_osr;
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG03, reg03);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG03, reg03), TAG, "I2C read/write error");
 
     /* register 0x04 */
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG04, selected_coeff->dac_osr);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG04, selected_coeff->dac_osr), TAG, "I2C read/write error");
 
     /* register 0x05 */
     const uint8_t reg05 = ((selected_coeff->adc_div - 1) << 4) | (selected_coeff->dac_div - 1);
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG05, reg05);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG05, reg05), TAG, "I2C read/write error");
 
     /* register 0x06 */
-    regv = es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06) & 0xE0;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06, &regv), TAG, "I2C read/write error");
+    regv &= 0xE0;
 
     if (selected_coeff->bclk_div < 19) {
         regv |= (selected_coeff->bclk_div - 1) << 0;
@@ -245,22 +214,22 @@ esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency
         regv |= (selected_coeff->bclk_div) << 0;
     }
 
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, regv);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, regv), TAG, "I2C read/write error");
 
     /* register 0x07 */
-    regv = es8311_read_reg(dev, ES8311_CLK_MANAGER_REG07) & 0xC0;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG07, &regv), TAG, "I2C read/write error");
+    regv &= 0xC0;
     regv |= selected_coeff->lrck_h << 0;
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG07, regv);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG07, regv), TAG, "I2C read/write error");
 
     /* register 0x08 */
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG08, selected_coeff->lrck_l);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG08, selected_coeff->lrck_l), TAG, "I2C read/write error");
 
-    return ret;
+    return ESP_OK;
 }
 
 static esp_err_t es8311_clock_config(es8311_handle_t dev, const es8311_clock_config_t *const clk_cfg)
 {
-    esp_err_t ret = ESP_OK;
     uint8_t reg06;
     uint8_t reg01 = 0x3F; // Enable all clocks
 
@@ -272,15 +241,15 @@ static esp_err_t es8311_clock_config(es8311_handle_t dev, const es8311_clock_con
     if (clk_cfg->mclk_inverted) {
         reg01 |= BIT(6); // Invert MCLK pin
     }
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG01, reg01);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG01, reg01), TAG, "I2C read/write error");
 
-    reg06 = es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06);
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06, &reg06), TAG, "I2C read/write error");
     if (clk_cfg->sclk_inverted) {
         reg06 |= BIT(5);
     } else {
         reg06 &= ~BIT(5);
     }
-    ret |= es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, reg06);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, reg06), TAG, "I2C read/write error");
 
     /* Configure clock dividers */
     // 16 bit resolution and MCLK from SCLK pin is assumed here
@@ -313,23 +282,23 @@ static esp_err_t es8311_resolution_config(const es8311_resolution_t res, uint8_t
 
 static esp_err_t es8311_fmt_config(es8311_handle_t dev, const es8311_resolution_t res_in, const es8311_resolution_t res_out)
 {
-    esp_err_t ret = ESP_OK;
     uint8_t reg09 = 0; // SDP In
     uint8_t reg0a = 0; // SDP Out
 
     ESP_LOGI(TAG, "ES8311 in Slave mode and I2S format");
-    uint8_t reg00 = es8311_read_reg(dev, ES8311_RESET_REG00);
+    uint8_t reg00;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_RESET_REG00, &reg00), TAG, "I2C read/write error");
     reg00 &= 0xBF;
-    ret |= es8311_write_reg(dev, ES8311_RESET_REG00, reg00); // Slave serial port - default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, reg00), TAG, "I2C read/write error"); // Slave serial port - default
 
     /* Setup SDP In and Out resolution */
     es8311_resolution_config(res_in, &reg09);
     es8311_resolution_config(res_out, &reg0a);
 
-    ret |= es8311_write_reg(dev, ES8311_SDPIN_REG09, reg09);
-    ret |= es8311_write_reg(dev, ES8311_SDPOUT_REG0A, reg0a);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SDPIN_REG09, reg09), TAG, "I2C read/write error");
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SDPOUT_REG0A, reg0a), TAG, "I2C read/write error");
 
-    return ret;
+    return ESP_OK;
 }
 
 esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic)
@@ -347,32 +316,31 @@ esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic)
 
 esp_err_t es8311_init(es8311_handle_t dev, const es8311_clock_config_t *const clk_cfg, const es8311_resolution_t res_in, const es8311_resolution_t res_out)
 {
-    esp_err_t ret = ESP_OK;
     if (clk_cfg->sample_frequency <= 8000) {
         ESP_LOGE(TAG, "ES8311 init needs frequency > 8000Hz, such as 32000Hz, 44100Hz");
         return ESP_ERR_INVALID_ARG;
     }
 
     /* Reset ES8311 to its default */
-    ret |= es8311_write_reg(dev, ES8311_RESET_REG00, 0x1F);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x1F), TAG, "I2C read/write error");
     vTaskDelay(pdMS_TO_TICKS(20));
-    ret |= es8311_write_reg(dev, ES8311_RESET_REG00, 0x00);
-    ret |= es8311_write_reg(dev, ES8311_RESET_REG00, 0x80); // Power-on command
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x00), TAG, "I2C read/write error");
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x80), TAG, "I2C read/write error"); // Power-on command
 
     /* Setup clock: source, polarity and clock dividers */
-    ret |= es8311_clock_config(dev, clk_cfg);
+    ESP_RETURN_ON_ERROR(es8311_clock_config(dev, clk_cfg), TAG, "I2C read/write error");
 
     /* Setup audio format (fmt): master/slave, resolution, I2S */
-    ret |= es8311_fmt_config(dev, res_in, res_out);
+    ESP_RETURN_ON_ERROR(es8311_fmt_config(dev, res_in, res_out), TAG, "I2C read/write error");
 
-    ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG0D, 0x01); // Power up analog circuitry - NOT default
-    ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG0E, 0x02); // Enable analog PGA, enable ADC modulator - NOT default
-    ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG12, 0x00); // power-up DAC - NOT default
-    ret |= es8311_write_reg(dev, ES8311_SYSTEM_REG13, 0x10); // Enable output to HP drive - NOT default
-    ret |= es8311_write_reg(dev, ES8311_ADC_REG1C, 0x6A); // ADC Equalizer bypass, cancel DC offset in digital domain
-    ret |= es8311_write_reg(dev, ES8311_DAC_REG37, 0x08); // Bypass DAC equalizer - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG0D, 0x01), TAG, "I2C read/write error"); // Power up analog circuitry - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG0E, 0x02), TAG, "I2C read/write error"); // Enable analog PGA, enable ADC modulator - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG12, 0x00), TAG, "I2C read/write error"); // power-up DAC - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG13, 0x10), TAG, "I2C read/write error"); // Enable output to HP drive - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_ADC_REG1C, 0x6A), TAG, "I2C read/write error"); // ADC Equalizer bypass, cancel DC offset in digital domain
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_DAC_REG37, 0x08), TAG, "I2C read/write error"); // Bypass DAC equalizer - NOT default
 
-    return ret;
+    return ESP_OK;
 }
 
 void es8311_delete(es8311_handle_t dev)
@@ -404,7 +372,8 @@ esp_err_t es8311_voice_volume_set(es8311_handle_t dev, int volume, int *volume_s
 
 esp_err_t es8311_voice_volume_get(es8311_handle_t dev, int *volume)
 {
-    uint8_t reg32 = es8311_read_reg(dev, ES8311_DAC_REG32);
+    uint8_t reg32;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG32, &reg32), TAG, "I2C read/write error");
 
     if (reg32 == 0) {
         *volume = 0;
@@ -416,7 +385,8 @@ esp_err_t es8311_voice_volume_get(es8311_handle_t dev, int *volume)
 
 esp_err_t es8311_voice_mute(es8311_handle_t dev, bool mute)
 {
-    uint8_t reg31 = es8311_read_reg(dev, ES8311_DAC_REG31);
+    uint8_t reg31;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG31, &reg31), TAG, "I2C read/write error");
 
     if (mute) {
         reg31 |= BIT(6) | BIT(5);
@@ -434,7 +404,8 @@ esp_err_t es8311_microphone_gain_set(es8311_handle_t dev, es8311_mic_gain_t gain
 
 esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade)
 {
-    uint8_t reg37 = es8311_read_reg(dev, ES8311_DAC_REG37);
+    uint8_t reg37;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG37, &reg37), TAG, "I2C read/write error");
     reg37 &= 0x0F;
     reg37 |= (fade << 4);
     return es8311_write_reg(dev, ES8311_DAC_REG37, reg37);
@@ -442,7 +413,8 @@ esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade)
 
 esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade)
 {
-    uint8_t reg15 = es8311_read_reg(dev, ES8311_ADC_REG15);
+    uint8_t reg15;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_ADC_REG15, &reg15), TAG, "I2C read/write error");
     reg15 &= 0x0F;
     reg15 |= (fade << 4);
     return es8311_write_reg(dev, ES8311_ADC_REG15, reg15);
@@ -451,8 +423,9 @@ esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade)
 void es8311_register_dump(es8311_handle_t dev)
 {
     for (int reg = 0; reg < 0x4A; reg++) {
-        uint8_t value = es8311_read_reg(dev, reg);
-        ESP_LOGI(TAG, "REG:%02x: %02x", reg, value);
+        uint8_t value;
+        ESP_ERROR_CHECK(es8311_read_reg(dev, reg, &value));
+        printf("REG:%02x: %02x", reg, value);
     }
 }
 
@@ -460,6 +433,6 @@ es8311_handle_t es8311_create(const i2c_port_t port, const uint16_t dev_addr)
 {
     es8311_dev_t *sensor = (es8311_dev_t *) calloc(1, sizeof(es8311_dev_t));
     sensor->port = port;
-    sensor->dev_addr = dev_addr << 1;
+    sensor->dev_addr = dev_addr;
     return (es8311_handle_t) sensor;
 }

--- a/components/es8311/idf_component.yml
+++ b/components/es8311/idf_component.yml
@@ -2,4 +2,4 @@ version: "1.0.0"
 description: Low power mono audio codec ES8311
 url: https://github.com/espressif/esp-bsp/tree/master/components/es8311
 dependencies:
-  idf : ">=4.3"
+  idf : ">=4.4"

--- a/components/es8311/idf_component.yml
+++ b/components/es8311/idf_component.yml
@@ -1,5 +1,5 @@
-version: "0.0.3"
+version: "1.0.0"
 description: Low power mono audio codec ES8311
 url: https://github.com/espressif/esp-bsp/tree/master/components/es8311
 dependencies:
-  idf : ">=4.0"
+  idf : ">=4.3"

--- a/components/es8311/include/es8311.h
+++ b/components/es8311/include/es8311.h
@@ -65,11 +65,22 @@ typedef struct es8311_clock_config_t {
     bool mclk_inverted;
     bool sclk_inverted;
     bool mclk_from_mclk_pin; // true: from MCLK pin (pin no. 2), false: from SCLK pin (pin no. 6)
+    int  mclk_frequency;     // This parameter is ignored if MCLK is taken from SCLK pin
     int  sample_frequency;   // in Hz
 } es8311_clock_config_t;
 
 /**
  * @brief Initialize ES8311
+ *
+ * There are two ways of providing Master Clock (MCLK) signal to ES8311 in Slave Mode:
+ * 1. From MCLK pin:
+ *    For flexible scenarios. A clock signal from I2S master is routed to MCLK pin.
+ *    Its frequency must be defined in clk_cfg->mclk_frequency parameter.
+ * 2. From SCLK pin:
+ *    For simpler scenarios. ES8311 takes its clock from SCK pin. MCLK pin does not have to be connected.
+ *    In this case, res_in must equal res_out; clk_cfg->mclk_frequency parameter is ignored
+ *    and MCLK is calculated as MCLK = clk_cfg->sample_frequency * res_out * 2.
+ *    Not all sampling frequencies are supported in this mode.
  *
  * @param dev ES8311 handle
  * @param[in] clk_cfg Clock configuration

--- a/components/es8311/include/es8311.h
+++ b/components/es8311/include/es8311.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,6 +33,25 @@ typedef enum {
     ES8311_MIC_GAIN_42DB,
     ES8311_MIC_GAIN_MAX
 } es8311_mic_gain_t;
+
+typedef enum {
+    ES8311_FADE_OFF = 0,
+    ES8311_FADE_4LRCK, // 4LRCK means ramp 0.25dB/4LRCK
+    ES8311_FADE_8LRCK,
+    ES8311_FADE_16LRCK,
+    ES8311_FADE_32LRCK,
+    ES8311_FADE_64LRCK,
+    ES8311_FADE_128LRCK,
+    ES8311_FADE_256LRCK,
+    ES8311_FADE_512LRCK,
+    ES8311_FADE_1024LRCK,
+    ES8311_FADE_2048LRCK,
+    ES8311_FADE_4096LRCK,
+    ES8311_FADE_8192LRCK,
+    ES8311_FADE_16384LRCK,
+    ES8311_FADE_32768LRCK,
+    ES8311_FADE_65536LRCK
+} es8311_fade_t;
 
 typedef enum es8311_resolution_t {
     ES8311_RESOLUTION_16 = 16,
@@ -146,6 +165,28 @@ esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic);
  *     - Else I2C read/write error
  */
 esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency, int sample_frequency);
+
+/**
+ * @brief Configure fade in/out for ADC: voice
+ *
+ * @param dev ES8311 handle
+ * @param[in] fade Fade ramp rate
+ * @return
+ *     - ESP_OK success
+ *     - Else I2C read/write error
+ */
+esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade);
+
+/**
+ * @brief Configure fade in/out for DAC: microphone
+ *
+ * @param dev ES8311 handle
+ * @param[in] fade Fade ramp rate
+ * @return
+ *     - ESP_OK success
+ *     - Else I2C read/write error
+ */
+esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade);
 
 /**
  * @brief Create ES8311 object and return its handle

--- a/components/es8311/include/es8311.h
+++ b/components/es8311/include/es8311.h
@@ -157,8 +157,8 @@ esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic);
  * @note This function is called by es8311_init().
  *       Call this function explicitly only if you want to change sample frequency during runtime.
  * @param dev ES8311 handle
- * @param[in] mclk_frequency   MCLK frequency in Hz on MCLK or SCLK pin, depending bit register01[7].
- * @param[in] sample_frequency Required sample frequency in Hz, e.g. 44100, 22050...
+ * @param[in] mclk_frequency   MCLK frequency in [Hz] (MCLK or SCLK pin, depending on bit register01[7])
+ * @param[in] sample_frequency Required sample frequency in [Hz], e.g. 44100, 22050...
  * @return
  *     - ESP_OK success
  *     - ESP_ERR_INVALID_ARG cannot set clock dividers for given MCLK and sampling frequency

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.5)
 
 set(EXTRA_COMPONENT_DIRS "../components")
 
+include($ENV{IDF_PATH}/tools/cmake/version.cmake) # $ENV{IDF_VERSION} was added after v4.3...
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "4.4")
+    set(EXCLUDE_COMPONENTS "es8311")
+endif()
+
 # Set the components to include the tests for.
 set(TEST_COMPONENTS bh1750 ssd1306 mpu6050 mag3110 hts221 fbm320 CACHE STRING "List of components to test")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)


### PR DESCRIPTION
Notable changes:

- Version bumped to 1.0.0 (first stable API)
- There is no DAC ramp-up setup during initialization
- Ramp-ups for ADC and DAC are now configurable through dedicated API
- ES8311 can accepts MCLK signal from both MCLK pin (user must define its frequency) and SCK  pin
