### PR TITLE
Components: explicit the depencies on "driver" component

### DIFF
--- a/components/bh1750/CMakeLists.txt
+++ b/components/bh1750/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "bh1750.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/bh1750/idf_component.yml
+++ b/components/bh1750/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: I2C driver for BH1750 light sensor
 url: https://github.com/espressif/esp-bsp/tree/master/components/bh1750
 dependencies:

--- a/components/es8311/CMakeLists.txt
+++ b/components/es8311/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(
     SRCS "es8311.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
+    REQUIRES "driver"
 )

--- a/components/es8311/idf_component.yml
+++ b/components/es8311/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2"
+version: "0.0.3"
 description: Low power mono audio codec ES8311
 url: https://github.com/espressif/esp-bsp/tree/master/components/es8311
 dependencies:

--- a/components/fbm320/CMakeLists.txt
+++ b/components/fbm320/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "fbm320.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/fbm320/idf_component.yml
+++ b/components/fbm320/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: I2C driver for FBM320 digital barometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/fbm320
 dependencies:

--- a/components/hts221/CMakeLists.txt
+++ b/components/hts221/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "hts221.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/hts221/idf_component.yml
+++ b/components/hts221/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.2"
+version: "1.1.3"
 description: I2C driver for HTS221 humidity and temperature sensor
 url: https://github.com/espressif/esp-bsp/tree/master/components/hts221
 dependencies:

--- a/components/mag3110/CMakeLists.txt
+++ b/components/mag3110/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "mag3110.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/mpu6050/CMakeLists.txt
+++ b/components/mpu6050/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "mpu6050.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/mpu6050/idf_component.yml
+++ b/components/mpu6050/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: I2C driver for MPU6050 gyroscope and accelerometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/mpu6050
 dependencies:

--- a/components/ssd1306/CMakeLists.txt
+++ b/components/ssd1306/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "ssd1306.c" "ssd1306_fonts.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver"
 )

--- a/components/ssd1306/idf_component.yml
+++ b/components/ssd1306/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: I2C driver for SSD1306 OLED display
 url: https://github.com/espressif/esp-bsp/tree/master/components/ssd1306
 dependencies:


### PR DESCRIPTION
Currently, `esp-bsp` components rely on IDF's `components/{target}` to retrieve `driver` component:
```
           REQUIRES                REQUIRES
es8311 ----------------> esp32 ----------------> driver
```  
So, when `{target}` component will stop depending on `driver` component, `es8311` and all other components will fail to build.

This PR add an explicit `REQUIRES` to avoid this issue in the future.