### PR TITLE
ci: Override path for BSPs in examples

### DIFF
--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager
+          pip install idf-component-manager --upgrade
           cd examples
           for d in */; do
             pushd $d

--- a/examples/display/main/idf_component.yml
+++ b/examples/display/main/idf_component.yml
@@ -2,6 +2,6 @@ description: BSP Display example
 
 dependencies:
   idf: ">=4.4"
-  esp_wrover_kit: ">=1.0.0"
-  # esp32_s2_kaluga_kit: ">=1.0.0"
-  # esp-box: ">=1.0.0"
+  esp_wrover_kit:
+    version: ">=1.0.0"
+    override_path: "../../../esp_wrover_kit"

--- a/examples/display/main/idf_component.yml
+++ b/examples/display/main/idf_component.yml
@@ -3,5 +3,5 @@ description: BSP Display example
 dependencies:
   idf: ">=4.4"
   esp_wrover_kit:
-    version: ">=1.0.0"
+    version: "^1.0.0"
     override_path: "../../../esp_wrover_kit"

--- a/examples/display_audio/main/idf_component.yml
+++ b/examples/display_audio/main/idf_component.yml
@@ -1,5 +1,6 @@
 description: BSP Display and Audio example
 
 dependencies:
-  esp32_s2_kaluga_kit: ">=1.0.0"
-  # esp-box: ">=1.0.0"
+  esp32_s2_kaluga_kit:
+    version: ">=1.0.0"
+    override_path: "../../../esp32_s2_kaluga_kit"

--- a/examples/display_audio/main/idf_component.yml
+++ b/examples/display_audio/main/idf_component.yml
@@ -2,5 +2,5 @@ description: BSP Display and Audio example
 
 dependencies:
   esp32_s2_kaluga_kit:
-    version: ">=1.0.0"
+    version: "^1.0.0"
     override_path: "../../../esp32_s2_kaluga_kit"

--- a/examples/mqtt_example/main/idf_component.yml
+++ b/examples/mqtt_example/main/idf_component.yml
@@ -1,3 +1,5 @@
 description: BSP ESP32-Azure-IoT-Kit sensor example
 dependencies:
-  esp32_azure_iot_kit: "0.0.7"
+  esp32_azure_iot_kit:
+    version: "0.0.7"
+    override_path: "../../../esp32_azure_iot_kit"

--- a/examples/rainmaker_example/main/idf_component.yml
+++ b/examples/rainmaker_example/main/idf_component.yml
@@ -1,3 +1,5 @@
 description: BSP ESP32-Azure-IoT-Kit rainmaker example
 dependencies:
-  esp32_azure_iot_kit: "0.0.7"
+  esp32_azure_iot_kit:
+    version: "0.0.7"
+    override_path: "../../../esp32_azure_iot_kit"

--- a/examples/sensors_example/main/idf_component.yml
+++ b/examples/sensors_example/main/idf_component.yml
@@ -1,3 +1,5 @@
 description: BSP ESP32-Azure-IoT-Kit sensor example
 dependencies:
-  esp32_azure_iot_kit: "0.0.7"
+  esp32_azure_iot_kit:
+    version: "0.0.7"
+    override_path: "../../../esp32_azure_iot_kit"

--- a/examples/touchscreen_colorwheel/main/idf_component.yml
+++ b/examples/touchscreen_colorwheel/main/idf_component.yml
@@ -3,4 +3,6 @@ targets:
     - esp32s3
 dependencies:
   idf: ">=4.4"
-  esp-box: "^1.0"
+  esp-box:
+    version: "^1.0"
+    override_path: "../../../esp-box"


### PR DESCRIPTION
By using local components in examples, we make sure that we compile actual code from the specific PR (rather than already uploaded component in the component service)