### PR TITLE
esp_jpeg: Fixed unsupported MCU of tjpgd in ROM.

### DIFF
--- a/components/esp_jpeg/Kconfig
+++ b/components/esp_jpeg/Kconfig
@@ -2,7 +2,7 @@ menu "JPEG Decoder"
 
     config JD_USE_ROM
         bool "Use TinyJPG Decoder from ROM"
-        depends on !IDF_TARGET_ESP32S2
+        depends on (!IDF_TARGET_ESP32S2 && !IDF_TARGET_ESP32C2)
         default y
         help
             By default, Espressif SoCs use TJpg decoder implemented in ROM code. 

--- a/components/esp_jpeg/idf_component.yml
+++ b/components/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_jpeg/
 dependencies:


### PR DESCRIPTION
I forgot to add esp32c2 to Kconfig, that there is not tjpgd in ROM code. Fixed now.