### PR TITLE
lcd: fix wrong bpp size of rgb666 format

### DIFF
--- a/components/lcd/esp_lcd_gc9a01/esp_lcd_gc9a01.c
+++ b/components/lcd/esp_lcd_gc9a01/esp_lcd_gc9a01.c
@@ -36,7 +36,7 @@ typedef struct {
     bool reset_level;
     int x_gap;
     int y_gap;
-    unsigned int bits_per_pixel;
+    uint8_t fb_bits_per_pixel;
     uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
     uint8_t colmod_cal; // save surrent value of LCD_CMD_COLMOD register
 } gc9a01_panel_t;
@@ -69,12 +69,16 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
         break;
     }
 
+    uint8_t fb_bits_per_pixel = 0;
     switch (panel_dev_config->bits_per_pixel) {
-    case 16:
+    case 16: // RGB565
         gc9a01->colmod_cal = 0x55;
+        fb_bits_per_pixel = 16;
         break;
-    case 18:
+    case 18: // RGB666
         gc9a01->colmod_cal = 0x66;
+        // each color component (R/G/B) should occupy the 6 high bits of a byte, which means 3 full bytes are required for a pixel
+        fb_bits_per_pixel = 24;
         break;
     default:
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported pixel width");
@@ -82,7 +86,7 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
     }
 
     gc9a01->io = io;
-    gc9a01->bits_per_pixel = panel_dev_config->bits_per_pixel;
+    gc9a01->fb_bits_per_pixel = fb_bits_per_pixel;
     gc9a01->reset_gpio_num = panel_dev_config->reset_gpio_num;
     gc9a01->reset_level = panel_dev_config->flags.reset_active_high;
     gc9a01->base.del = panel_gc9a01_del;
@@ -249,7 +253,7 @@ static esp_err_t panel_gc9a01_draw_bitmap(esp_lcd_panel_t *panel, int x_start, i
         (y_end - 1) & 0xFF,
     }, 4);
     // transfer frame buffer
-    size_t len = (x_end - x_start) * (y_end - y_start) * gc9a01->bits_per_pixel / 8;
+    size_t len = (x_end - x_start) * (y_end - y_start) * gc9a01->fb_bits_per_pixel / 8;
     esp_lcd_panel_io_tx_color(io, LCD_CMD_RAMWR, color_data, len);
 
     return ESP_OK;

--- a/components/lcd/esp_lcd_gc9a01/idf_component.yml
+++ b/components/lcd/esp_lcd_gc9a01/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: ESP LCD GC9A01
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_gc9a01
 dependencies:

--- a/components/lcd/esp_lcd_ili9341/idf_component.yml
+++ b/components/lcd/esp_lcd_ili9341/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: ESP LCD ILI9341
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_ili9341
 dependencies:


### PR DESCRIPTION
# Checklist for new Board Support package or Component

- [x] Component contains License
- [x] Component contains README.md
- [x] Project [README.md](../README.md) updated
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
- [x] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
After morris found and fixed this issue in IDF, here is fix for other LCD components.
