### PR TITLE
ci: add a job to generate SquareLine package (BSP-186)

### DIFF
--- a/.github/workflows/squareline.yml
+++ b/.github/workflows/squareline.yml
@@ -1,0 +1,45 @@
+name: squareline
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'SquareLine/**'
+      - '.github/workflows/squareline.yml'
+
+jobs:
+  create-squareline-packages:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate the packages
+        run: |
+          cd SquareLine
+          python3 gen.py -o out_dir
+      - uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: SquareLine/out_dir/espressif/
+
+  update-release:
+    runs-on: ubuntu-20.04
+    needs: [ create-squareline-packages ]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: espressif
+      - name: Make the release archive
+        run: |
+          zip -r esp-bsp-squareline-latest.zip espressif
+      # - Update (force-push) 'squareline-latest' tag to the commit that is used in the workflow.
+      # - Upload artifacts generated in the previous job.
+      - name: Update release
+        uses: pyTooling/Actions/releaser@r0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            *.zip
+          tag: squareline-latest


### PR DESCRIPTION
# Change description

This PR adds a CI job to generate the SquareLine package and publish it as a release artifact.

The job runs on every commit on the `master` branch and generates the package.
Then it updates `squareline-latest` tag to point to the latest commit on `master` and uploads the release package to the associated release on Github.

You can find the example here: https://github.com/igrr/esp-bsp/releases/tag/squareline-latest.
The description of the release has to be written manually, once. On each commit to `master`, only the artifact is updated.

Note that with this approach, the release artifact has constant path (https://github.com/igrr/esp-bsp/releases/download/squareline-latest/esp-bsp-squareline-latest.zip) so we can mention it in documentation as well.

The downside of this approach is that the release is updated for every commit, not only for commits where we "bump" the version of the BSP components. We'd have to start using git tags if we want to build SquareLine packages only for BSP component releases.
