### PR TITLE
Add GT1151 touch controller into components (BSP-210)

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
-          directories: "esp32_azure_iot_kit;esp32_s2_kaluga_kit;esp_wrover_kit;esp-box;esp32_s3_usb_otg;esp32_s3_eye;components/bh1750;components/es8311;components/fbm320;components/hts221;components/mag3110;components/mpu6050;components/ssd1306;components/lcd_touch/esp_lcd_touch;components/lcd_touch/esp_lcd_touch_ft5x06;components/lcd_touch/esp_lcd_touch_gt911;components/lcd_touch/esp_lcd_touch_tt21100;components/lcd/esp_lcd_gc9a01;components/lcd/esp_lcd_ili9341;components/lcd/esp_lcd_ra8875;components/lcd_touch/esp_lcd_touch_stmpe610;components/lcd/esp_lcd_sh1107"
+          directories: "esp32_azure_iot_kit;esp32_s2_kaluga_kit;esp_wrover_kit;esp-box;esp32_s3_usb_otg;esp32_s3_eye;components/bh1750;components/es8311;components/fbm320;components/hts221;components/mag3110;components/mpu6050;components/ssd1306;components/lcd_touch/esp_lcd_touch;components/lcd_touch/esp_lcd_touch_ft5x06;components/lcd_touch/esp_lcd_touch_gt911;components/lcd_touch/esp_lcd_touch_tt21100;components/lcd_touch/esp_lcd_touch_gt1151;components/lcd/esp_lcd_gc9a01;components/lcd/esp_lcd_ili9341;components/lcd/esp_lcd_ra8875;components/lcd_touch/esp_lcd_touch_stmpe610;components/lcd/esp_lcd_sh1107"
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/components/lcd_touch/esp_lcd_touch_gt1151/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "esp_lcd_touch_gt1151.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" "esp_lcd_touch")

--- a/components/lcd_touch/esp_lcd_touch_gt1151/README.md
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/README.md
@@ -1,0 +1,61 @@
+# ESP LCD Touch GT1151 Controller
+
+Implementation of the GT1151 touch controller with esp_lcd_touch component.
+
+| Touch controller | Communication interface | Component name | Link to datasheet |
+| :--------------: | :---------------------: | :------------: | :---------------: |
+| GT1151           | I2C                     | esp_lcd_touch_gt1151 | [datasheet](https://datasheetspdf.com/pdf-file/954783/GOODIX/GT1151/1) |
+
+## Add to project
+
+Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
+You can add them to your project via `idf.py add-dependancy`, e.g.
+```
+    idf.py add-dependency esp_lcd_touch_gt1151==1.0.0
+```
+
+Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
+
+## Example use
+
+Initialization of the touch component.
+
+```
+    esp_lcd_panel_io_i2c_config_t io_config = ESP_LCD_TOUCH_IO_I2C_GT1151_CONFIG();
+
+    esp_lcd_touch_config_t tp_cfg = {
+        .x_max = CONFIG_LCD_HRES,
+        .y_max = CONFIG_LCD_VRES,
+        .rst_gpio_num = -1,
+        .int_gpio_num = -1,
+        .levels = {
+            .reset = 0,
+            .interrupt = 0,
+        },
+        .flags = {
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0,
+        },
+    };
+
+    esp_lcd_touch_handle_t tp;
+    esp_lcd_touch_new_i2c_gt1151(io_handle, &tp_cfg, &tp);
+```
+
+Read data from the touch controller and store it in RAM memory. It should be called regularly in poll.
+
+```
+    esp_lcd_touch_read_data(tp);
+```
+
+Get one X and Y coordinates with strength of touch.
+
+```
+    uint16_t touch_x[1];
+    uint16_t touch_y[1];
+    uint16_t touch_strength[1];
+    uint8_t touch_cnt = 0;
+
+    bool touchpad_pressed = esp_lcd_touch_get_coordinates(tp, touch_x, touch_y, &touch_strength, &touch_cnt, 1);
+```

--- a/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
@@ -1,0 +1,235 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "driver/i2c.h"
+#include "esp_system.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_touch.h"
+
+static const char *TAG = "gt1151";
+
+#define READ_XY_REG        (0x814E)
+#define PRODUCT_ID_REG     (0x8140)
+
+#define MAX_TOUCH_NUM      (10)
+/* Buffer Length = StatusReg(1) + TouchData(8 * TouchNum) + KeyValue(1) + Checksum(1) */
+#define DATA_BUFF_LEN(touch_num)    (1 + 8 * (touch_num) + 2)
+#define IS_NUM_OR_CHAR(x)           (((x) >= 'A' && (x) <= 'Z') || ((x) >= '0' && (x) <= '9'))
+
+static esp_err_t read_data(esp_lcd_touch_handle_t tp);
+static bool get_xy(esp_lcd_touch_handle_t tp, uint16_t *x, uint16_t *y, uint16_t *strength, uint8_t *point_num, uint8_t max_point_num);
+static esp_err_t del(esp_lcd_touch_handle_t tp);
+
+static esp_err_t i2c_read_bytes(esp_lcd_touch_handle_t tp, uint16_t reg, uint8_t *data, uint8_t len);
+static esp_err_t i2c_write_byte(esp_lcd_touch_handle_t tp, uint16_t reg, uint8_t data);
+
+static esp_err_t reset(esp_lcd_touch_handle_t tp);
+static esp_err_t read_product_id(esp_lcd_touch_handle_t tp);
+
+esp_err_t esp_lcd_touch_new_i2c_gt1151(const esp_lcd_panel_io_handle_t io, const esp_lcd_touch_config_t *config, esp_lcd_touch_handle_t *tp)
+{
+    ESP_RETURN_ON_FALSE(io, ESP_ERR_INVALID_ARG, TAG, "Invalid io");
+    ESP_RETURN_ON_FALSE(config, ESP_ERR_INVALID_ARG, TAG, "Invalid config");
+    ESP_RETURN_ON_FALSE(tp, ESP_ERR_INVALID_ARG, TAG, "Invalid touch handle");
+
+    /* Prepare main structure */
+    esp_err_t ret = ESP_OK;
+    esp_lcd_touch_handle_t gt1151 = calloc(1, sizeof(esp_lcd_touch_t));
+    ESP_GOTO_ON_FALSE(gt1151, ESP_ERR_NO_MEM, err, TAG, "Touch handle malloc failed");
+
+    /* Communication interface */
+    gt1151->io = io;
+    /* Only supported callbacks are set */
+    gt1151->read_data = read_data;
+    gt1151->get_xy = get_xy;
+    gt1151->del = del;
+    /* Mutex */
+    gt1151->data.lock.owner = portMUX_FREE_VAL;
+    /* Save config */
+    memcpy(&gt1151->config, config, sizeof(esp_lcd_touch_config_t));
+
+    /* Prepare pin for touch interrupt */
+    if (gt1151->config.int_gpio_num != GPIO_NUM_NC) {
+        const gpio_config_t int_gpio_config = {
+            .mode = GPIO_MODE_INPUT,
+            .pin_bit_mask = BIT64(gt1151->config.int_gpio_num)
+        };
+        ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");
+    }
+    /* Prepare pin for touch controller reset */
+    if (gt1151->config.rst_gpio_num != GPIO_NUM_NC) {
+        const gpio_config_t rst_gpio_config = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = BIT64(gt1151->config.rst_gpio_num)
+        };
+        ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");
+    }
+    /* Reset controller */
+    ESP_GOTO_ON_ERROR(reset(gt1151), err, TAG, "Reset failed");
+    /* Read product id */
+    ESP_GOTO_ON_ERROR(read_product_id(gt1151), err, TAG, "Read product id failed");
+    *tp = gt1151;
+
+    return ESP_OK;
+err:
+    if (gt1151) {
+        del(gt1151);
+    }
+    ESP_LOGE(TAG, "Initialization failed!");
+    return ret;
+}
+
+static esp_err_t read_data(esp_lcd_touch_handle_t tp)
+{
+    typedef struct {
+        uint8_t touch_id : 4;
+        uint8_t : 4;
+        uint16_t x;
+        uint16_t y;
+        uint16_t strength;
+        uint8_t useless;
+    } __attribute__((packed)) touch_record_t;
+
+    typedef struct {
+        uint8_t touch_cnt : 4;
+        uint8_t : 4;
+        touch_record_t touch_record[0];
+    } __attribute__((packed)) touch_report_t;
+
+    uint8_t touch_cnt;
+    ESP_RETURN_ON_ERROR(i2c_read_bytes(tp, READ_XY_REG, &touch_cnt, sizeof(touch_cnt)), TAG, "I2C read failed!");
+    touch_cnt &= 0x0f;
+    /* Any touch data? */
+    if (touch_cnt > MAX_TOUCH_NUM || touch_cnt == 0) {
+        i2c_write_byte(tp, READ_XY_REG, 0);
+        return ESP_OK;
+    }
+
+    uint8_t buf[DATA_BUFF_LEN(MAX_TOUCH_NUM)];
+    /* Read all points */
+    ESP_RETURN_ON_ERROR( i2c_read_bytes(tp, READ_XY_REG, buf, DATA_BUFF_LEN(touch_cnt)), TAG, "I2C read failed");
+    /* Clear all */
+    i2c_write_byte(tp, READ_XY_REG, 0);
+    /* Caculate checksum */
+    uint8_t checksum = 0;
+    for (int i = 0; i < DATA_BUFF_LEN(touch_cnt); i++) {
+        checksum += buf[i];
+    }
+    ESP_RETURN_ON_FALSE(!checksum, ESP_ERR_INVALID_CRC, TAG, "Checksum error");
+
+    touch_report_t *touch_report = (touch_report_t *)buf;
+    taskENTER_CRITICAL(&tp->data.lock);
+    /* Expect Number of touched points */
+    touch_cnt = (touch_cnt > CONFIG_ESP_LCD_TOUCH_MAX_POINTS ? CONFIG_ESP_LCD_TOUCH_MAX_POINTS : touch_cnt);
+    tp->data.points = touch_cnt;
+
+    /* Fill all coordinates */
+    for (int i = 0; i < touch_cnt; i++) {
+        tp->data.coords[i].x = touch_report->touch_record[i].x;
+        tp->data.coords[i].y = touch_report->touch_record[i].y;
+        tp->data.coords[i].strength = touch_report->touch_record[i].strength;
+    }
+    taskEXIT_CRITICAL(&tp->data.lock);
+
+    return ESP_OK;
+}
+
+static bool get_xy(esp_lcd_touch_handle_t tp, uint16_t *x, uint16_t *y, uint16_t *strength, uint8_t *point_num, uint8_t max_point_num)
+{
+    taskENTER_CRITICAL(&tp->data.lock);
+    /* Count of points */
+    *point_num = (tp->data.points > max_point_num ? max_point_num : tp->data.points);
+    for (size_t i = 0; i < *point_num; i++) {
+        x[i] = tp->data.coords[i].x;
+        y[i] = tp->data.coords[i].y;
+
+        if (strength) {
+            strength[i] = tp->data.coords[i].strength;
+        }
+    }
+    /* Invalidate */
+    tp->data.points = 0;
+    taskEXIT_CRITICAL(&tp->data.lock);
+
+    return (*point_num > 0);
+}
+
+static esp_err_t del(esp_lcd_touch_handle_t tp)
+{
+    /* Reset GPIO pin settings */
+    if (tp->config.int_gpio_num != GPIO_NUM_NC) {
+        gpio_reset_pin(tp->config.int_gpio_num);
+    }
+    if (tp->config.rst_gpio_num != GPIO_NUM_NC) {
+        gpio_reset_pin(tp->config.rst_gpio_num);
+    }
+    /* Release memory */
+    free(tp);
+
+    return ESP_OK;
+}
+
+static esp_err_t reset(esp_lcd_touch_handle_t tp)
+{
+    if (tp->config.rst_gpio_num != GPIO_NUM_NC) {
+        ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, !tp->config.levels.reset), TAG, "GPIO set level failed");
+        vTaskDelay(pdMS_TO_TICKS(10));
+        ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, tp->config.levels.reset), TAG, "GPIO set level failed");
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t read_product_id(esp_lcd_touch_handle_t tp)
+{
+    uint8_t buf[11] = {0};
+    uint8_t checksum = 0;
+    ESP_RETURN_ON_ERROR(i2c_read_bytes(tp, PRODUCT_ID_REG, buf, sizeof(buf)), TAG, "I2C read failed");
+    for (int i = 0; i < sizeof(buf); i++) {
+        checksum += buf[i];
+    }
+    /* First 3 bytes must be number or char, and sensor id != 0xFF */
+    ESP_RETURN_ON_FALSE(checksum, ESP_ERR_INVALID_CRC, TAG, "Checksum error");
+    ESP_RETURN_ON_FALSE(
+        IS_NUM_OR_CHAR(buf[0]) && IS_NUM_OR_CHAR(buf[1]) && IS_NUM_OR_CHAR(buf[2]) && buf[10] != 0xFF,
+        ESP_ERR_INVALID_CRC, TAG, "Product id format error");
+
+    uint32_t mask_id, patch_id, sensor_id;
+    char product_id[5] = {0};
+    mask_id = (uint32_t) ((buf[7] << 16) | (buf[8] << 8) | buf[9]);
+    patch_id = (uint32_t) ((buf[4] << 16) | (buf[5] << 8) | buf[6]);
+    memcpy(product_id, buf, 4);
+    sensor_id = buf[10] & 0x0F;
+    ESP_LOGI(
+        TAG, "IC version: GT%s_%06" PRIX32 "(Patch)_%04" PRIX32 "(Mask)_%02" PRIX32 "(SensorID)",
+        product_id, patch_id, mask_id >> 8, sensor_id);
+    return ESP_OK;
+}
+
+static esp_err_t i2c_read_bytes(esp_lcd_touch_handle_t tp, uint16_t reg, uint8_t *data, uint8_t len)
+{
+    ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "Invalid data");
+
+    return esp_lcd_panel_io_rx_param(tp->io, reg, data, len);
+}
+
+static esp_err_t i2c_write_byte(esp_lcd_touch_handle_t tp, uint16_t reg, uint8_t data)
+{
+    // *INDENT-OFF*
+    return esp_lcd_panel_io_tx_param(tp->io, reg, (uint8_t[]){data}, 1);
+    // *INDENT-ON*
+}

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,0 +1,7 @@
+version: "1.0.0"
+description: ESP LCD Touch GT1151 - touch controller GT1151
+url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
+dependencies:
+  idf: ">=4.4.2"
+  esp_lcd_touch:
+    version: "^1.0"

--- a/components/lcd_touch/esp_lcd_touch_gt1151/include/esp_lcd_touch_gt1151.h
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/include/esp_lcd_touch_gt1151.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_lcd_touch.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create a new GT1151 touch driver
+ *
+ * @note  The I2C communication should be initialized before use this function.
+ *
+ * @param io LCD panel IO handle, it should be created by `esp_lcd_new_panel_io_i2c()`
+ * @param config Touch panel configuration
+ * @param tp Touch panel handle
+ * @return
+ *      - ESP_OK: on success
+ */
+esp_err_t esp_lcd_touch_new_i2c_gt1151(const esp_lcd_panel_io_handle_t io, const esp_lcd_touch_config_t *config, esp_lcd_touch_handle_t *tp);
+
+/**
+ * @brief I2C address of the GT1151 controller
+ *
+ */
+#define ESP_LCD_TOUCH_IO_I2C_GT1151_ADDRESS     (0x14)
+
+/**
+ * @brief Touch IO configuration structure
+ *
+ */
+#define ESP_LCD_TOUCH_IO_I2C_GT1151_CONFIG()             \
+    {                                                    \
+        .dev_addr = ESP_LCD_TOUCH_IO_I2C_GT1151_ADDRESS, \
+        .control_phase_bytes = 1,                        \
+        .dc_bit_offset = 0,                              \
+        .lcd_cmd_bits = 16,                              \
+        .flags =                                         \
+        {                                                \
+            .disable_control_phase = 1,                  \
+        }                                                \
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/lcd_touch/esp_lcd_touch_gt1151/license.txt
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
# Checklist for new Board Support package or Component

- [x] Component contains License
- [x] Component contains README.md
- [x] Project [README.md](../README.md) updated
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
- [x] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Add a new touch controller named GT1151 into the components. It's one of the peripherals of ESP32-S3-LCD-EV-BOARD.
