### PR TITLE
Reorder initializers to match struct (BSP-228)

### DIFF
--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -69,8 +69,8 @@ typedef struct {
     {                               \
         .task_priority = 4,   \
         .task_stack = 4096,   \
-        .timer_period_ms = 5, \
         .task_affinity = -1,    \
+        .timer_period_ms = 5, \
     }
 
 /**


### PR DESCRIPTION
This is necessary to fix C++ usage:
```
In file included from Esp32OlcbLcd/main/display.cpp:16:
Esp32OlcbLcd/main/display.cpp: In function 'void initialize_display()':
Esp32OlcbLcd/managed_components/espressif__esp_lvgl_port/include/esp_lvgl_port.h:74:5: warning: missing initializer for member 'lvgl_port_cfg_t::task_affinity' [-Wmissing-field-initializers]
   74 |     }
      |     ^
Esp32OlcbLcd/main/display.cpp:245:41: note: in expansion of macro 'ESP_LVGL_PORT_INIT_CONFIG'
  245 |     const lvgl_port_cfg_t lvgl_config = ESP_LVGL_PORT_INIT_CONFIG();
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
managed_components/espressif__esp_lvgl_port/include/esp_lvgl_port.h:74:5: error: designator order for field 'lvgl_port_cfg_t::task_affinity' does not match declaration order in 'const lvgl_port_cfg_t'
   74 |     }
      |     ^
main/display.cpp:245:41: note: in expansion of macro 'ESP_LVGL_PORT_INIT_CONFIG'
  245 |     const lvgl_port_cfg_t lvgl_config = ESP_LVGL_PORT_INIT_CONFIG();
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

# Checklist for new Board Support package or Component

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Project [README.md](../README.md) updated
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
- [ ] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
