### PR TITLE
lcd: ILI9341 color fix

### DIFF
--- a/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
+++ b/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
@@ -212,7 +212,7 @@ static const lcd_init_cmd_t vendor_specific_init[] = {
     /* Entry mode set, Low vol detect disabled, normal display */
     {0xB7, {0x07}, 1},
     /* Display function control */
-    {0xB6, {0x0A, 0x02}, 2},
+    {0xB6, {0x08, 0x82, 0x27}, 3},
     /* Sleep out */
     {LCD_CMD_SLPOUT, {0}, 0x80},
     /* Display on */

--- a/components/lcd/esp_lcd_ili9341/idf_component.yml
+++ b/components/lcd/esp_lcd_ili9341/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: ESP LCD ILI9341
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_ili9341
 dependencies:


### PR DESCRIPTION
Fixed color setting in ILI9341 LCD component. 
It is fix for this issue: https://github.com/espressif/esp-idf/issues/10242