### PR TITLE
tca9554: Added I2C addresses for A version of the expander.

### DIFF
--- a/components/io_expander/esp_io_expander_tca9554/README.md
+++ b/components/io_expander/esp_io_expander_tca9554/README.md
@@ -1,10 +1,10 @@
-# ESP IO Expander Chip TCA9554
+# ESP IO Expander Chip TCA9554(A)
 
 Implementation of the TCA9554 io expander chip with esp_io_expander component.
 
 | Chip             | Communication interface | Component name | Link to datasheet |
 | :--------------: | :---------------------: | :------------: | :---------------: |
-| TCA9554          | I2C                     | esp_io_expander_tca9554 | [datasheet](https://www.ti.com/lit/gpn/tca9554) |
+| TCA9554(A)       | I2C                     | esp_io_expander_tca9554 | [datasheet](https://www.ti.com/lit/gpn/tca9554) |
 
 ## Add to project
 

--- a/components/io_expander/esp_io_expander_tca9554/idf_component.yml
+++ b/components/io_expander/esp_io_expander_tca9554/idf_component.yml
@@ -1,5 +1,5 @@
-version: "1.0.0"
-description: ESP IO Expander - tca9554
+version: "1.0.1"
+description: ESP IO Expander - TCA9554(A)
 url: https://github.com/espressif/esp-bsp/tree/master/components/io_expander/esp_io_expander_tca9554
 dependencies:
   idf: ">=4.4.2"

--- a/components/io_expander/esp_io_expander_tca9554/include/esp_io_expander_tca9554.h
+++ b/components/io_expander/esp_io_expander_tca9554/include/esp_io_expander_tca9554.h
@@ -57,6 +57,33 @@ esp_err_t esp_io_expander_new_i2c_tca9554(i2c_port_t i2c_num, uint32_t i2c_addre
 #define ESP_IO_EXPANDER_I2C_TCA9554_ADDRESS_110    (0x26)
 #define ESP_IO_EXPANDER_I2C_TCA9554_ADDRESS_111    (0x27)
 
+
+/**
+ * @brief I2C address of the TCA9554A
+ *
+ * The 8-bit address format is as follows:
+ *
+ *                (Slave Address)
+ *     ┌─────────────────┷─────────────────┐
+ *  ┌─────┐─────┐─────┐─────┐─────┐─────┐─────┐─────┐
+ *  |  0  |  1  |  1  |  1  | A2  | A1  | A0  | R/W |
+ *  └─────┘─────┘─────┘─────┘─────┘─────┘─────┘─────┘
+ *     └────────┯────────┘     └─────┯──────┘
+ *           (Fixed)        (Hareware Selectable)
+ *
+ * And the 7-bit slave address is the most important data for users.
+ * For example, if a chip's A0,A1,A2 are connected to GND, it's 7-bit slave address is 0111000b(0x38).
+ * Then users can use `ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_000` to init it.
+ */
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_000    (0x38)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_001    (0x39)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_010    (0x3A)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_011    (0x3B)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_100    (0x3C)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_101    (0x3D)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_110    (0x3E)
+#define ESP_IO_EXPANDER_I2C_TCA9554A_ADDRESS_111    (0x3F)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added I2C addresses for TCA9554A into header file.