### PR TITLE
BSP: Add examples to component manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Best way to start with ESP-BSP is trying one of the [examples](examples) on your
 | [display_audio_photo](examples/display_audio_photo) | ESP-BOX |
 | [display_rotation](examples/display_rotation) | ESP-BOX |
 | [display_lvgl_demos](examples/display_lvgl_demos) | ESP32-S3-LCD-EV-BOARD |
+| [touchscreen_colorwheel](examples/touchscreen_colorwheel) | ESP-BOX |
 | [mqtt_example](examples/mqtt_example) | Azure-IoT-kit |
-| [rainmaker_example](examples/rainmaker_example) | Azure-IoT-kit |
 | [sensors_example](examples/sensors_example) | Azure-IoT-kit |
 
 ### BSP headers

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.1"
+version: "2.1.2"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 
@@ -16,3 +16,8 @@ dependencies:
   lvgl/lvgl:
     version: "^8"
     public: true
+
+examples:
+  - path: ../examples/display_audio_photo
+  - path: ../examples/display_rotation
+  - path: ../examples/touchscreen_colorwheel

--- a/esp32_azure_iot_kit/idf_component.yml
+++ b/esp32_azure_iot_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: Board Support Package for ESP32-Azure-IoT-Kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_azure_iot_kit
 
@@ -32,3 +32,7 @@ dependencies:
   mpu6050:
     version: "^1.0.0"
     public: true
+
+examples:
+  - path: ../examples/mqtt_example
+  - path: ../examples/sensors_example

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.1"
+version: "2.1.2"
 description: Board Support Package for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
 
@@ -27,3 +27,7 @@ dependencies:
   esp32-camera:
     version: "^2.0.2"
     public: true
+
+examples:
+  - path: ../examples/display_audio
+  - path: ../examples/display_camera

--- a/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
+++ b/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
@@ -251,10 +251,12 @@ esp_err_t bsp_i2c_deinit(void);
  * LVGL is used as graphics library. LVGL is NOT thread safe, therefore the user must take LVGL mutex
  * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
  * bsp_display_unlock().
+ *
+ * @note Default SPI clock is set to 40MHz. On some displays shipped with Kaluga kit, 80MHz can be achieved
  **************************************************************************************************/
 #define BSP_LCD_H_RES              (320)
 #define BSP_LCD_V_RES              (240)
-#define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
+#define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
 /**

--- a/esp32_s3_lcd_ev_board/idf_component.yml
+++ b/esp32_s3_lcd_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Board Support Package for ESP32-S3-LCD-EV-BOARD
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_lcd_ev_board
 
@@ -31,3 +31,6 @@ dependencies:
   lvgl/lvgl:
     version: "^8"
     public: true
+
+examples:
+  - path: ../examples/display_lvgl_demos

--- a/esp_wrover_kit/idf_component.yml
+++ b/esp_wrover_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.1"
+version: "1.3.2"
 description: Board Support Package for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/esp_wrover_kit
 
@@ -11,3 +11,6 @@ dependencies:
   lvgl/lvgl:
     version: "^8"
     public: true
+
+examples:
+  - path: ../examples/display


### PR DESCRIPTION
# Change description
Latest idf-component-manager release allows us to upload examples with the SW package.

All BSPs with example now use this feature.
