### PR TITLE
SquareLine: Add some compile options for main Cmake of common

### DIFF
--- a/SquareLine/common/main/CMakeLists.txt
+++ b/SquareLine/common/main/CMakeLists.txt
@@ -3,3 +3,5 @@ file(GLOB_RECURSE SRC_UI ${CMAKE_SOURCE_DIR} "ui/*.c")
 
 idf_component_register(SRCS "main.c" ${SRC_UI}
                     INCLUDE_DIRS "." "ui")
+
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-unused-variable -DLV_LVGL_H_INCLUDE_SIMPLE)


### PR DESCRIPTION
# Checklist for new Board Support package or Component

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Project [README.md](../README.md) updated
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
- [ ] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
* Add `-Wno-unused-variable` and `-DLV_LVGL_H_INCLUDE_SIMPLE` two compile options in main CMakeLists.txt of common
* Solve the compile warning and error when using Squareline
