### PR TITLE
lcd_touch: Add FreeRTOS includes into header file.

### DIFF
--- a/components/lcd_touch/esp_lcd_touch/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: ESP LCD Touch - main component for using touch screen controllers
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
+++ b/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
@@ -16,6 +16,8 @@
 #include "esp_err.h"
 #include "driver/gpio.h"
 #include "esp_lcd_panel_io.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -59,42 +59,42 @@ static const touch_pad_t bsp_touch_button[TOUCH_BUTTON_NUM] = {
 const button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_REC,
         .adc_button_config.min = 2310, // middle is 2410mV
         .adc_button_config.max = 2510
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_MODE,
         .adc_button_config.min = 1880, // middle is 1980mV
         .adc_button_config.max = 2080
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_PLAY,
         .adc_button_config.min = 1550, // middle is 1650mV
         .adc_button_config.max = 1750
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_SET,
         .adc_button_config.min = 1010, // middle is 1110mV
         .adc_button_config.max = 1210
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_VOLDOWN,
         .adc_button_config.min = 720, // middle is 820mV
         .adc_button_config.max = 920
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_5, // ADC1 channel 5 is GPIO6
+        .adc_button_config.adc_channel = ADC_CHANNEL_5, // ADC1 channel 5 is GPIO6
         .adc_button_config.button_index = BSP_BUTTON_VOLUP,
         .adc_button_config.min = 280, // middle is 380mV
         .adc_button_config.max = 480

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.1"
+version: "2.1.2"
 description: Board Support Package for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
 

--- a/esp32_s3_eye/esp32_s3_eye.c
+++ b/esp32_s3_eye/esp32_s3_eye.c
@@ -57,28 +57,28 @@ sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 const button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_0, // ADC1 channel 0 is GPIO1
+        .adc_button_config.adc_channel = ADC_CHANNEL_0, // ADC1 channel 0 is GPIO1
         .adc_button_config.button_index = BSP_BUTTON_MENU,
         .adc_button_config.min = 2310, // middle is 2410mV
         .adc_button_config.max = 2510
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_0, // ADC1 channel 0 is GPIO1
+        .adc_button_config.adc_channel = ADC_CHANNEL_0, // ADC1 channel 0 is GPIO1
         .adc_button_config.button_index = BSP_BUTTON_PLAY,
         .adc_button_config.min = 1880, // middle is 1980mV
         .adc_button_config.max = 2080
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_0, // ADC1 channel 0 is GPIO1
+        .adc_button_config.adc_channel = ADC_CHANNEL_0, // ADC1 channel 0 is GPIO1
         .adc_button_config.button_index = BSP_BUTTON_DOWN,
         .adc_button_config.min = 720, // middle is 820mV
         .adc_button_config.max = 920
     },
     {
         .type = BUTTON_TYPE_ADC,
-        .adc_button_config.adc_channel = ADC1_CHANNEL_0, // ADC1 channel 0 is GPIO1
+        .adc_button_config.adc_channel = ADC_CHANNEL_0, // ADC1 channel 0 is GPIO1
         .adc_button_config.button_index = BSP_BUTTON_UP,
         .adc_button_config.min = 280, // middle is 380mV
         .adc_button_config.max = 480

--- a/esp32_s3_eye/idf_component.yml
+++ b/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: Board Support Package for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_eye
 


### PR DESCRIPTION
Fix for issue #87. 
Fixed ADC channel constants after iot_button updated to ADC NG driver (compatible with IDF5.0).