### PR TITLE
lcd_touch_tt21100: Fixes  esp_lcd_touch_get_coordinates() arg in README.md (BSP-243)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_tt21100/README.md
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/README.md
@@ -59,7 +59,7 @@ Get one X and Y coordinates with strength of touch.
     uint16_t touch_strength[1];
     uint8_t touch_cnt = 0;
 
-    bool touchpad_pressed = esp_lcd_touch_get_coordinates(tp, touch_x, touch_y, touch_btn, &touch_cnt, 1);
+    bool touchpad_pressed = esp_lcd_touch_get_coordinates(tp, touch_x, touch_y, touch_strength, &touch_cnt, 1);
 ```
 
 


### PR DESCRIPTION
# Change description

Just a quick fix in readme.md document about the example call to esp_lcd_touch_get_coordinates().