### PR TITLE
bsp: Support to mount spiffs for esp-box bsp (BSP-245)

### DIFF
--- a/esp-box/CMakeLists.txt
+++ b/esp-box/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "esp-box.c"
     INCLUDE_DIRS "include"
-    REQUIRES driver
+    REQUIRES driver spiffs
     PRIV_REQUIRES esp_timer esp_lcd esp_lcd_touch
 )

--- a/esp-box/Kconfig
+++ b/esp-box/Kconfig
@@ -26,6 +26,32 @@ menu "Board Support Package"
             default 100000
     endmenu
 
+    menu "SPIFFS - Virtual File System"
+        config BSP_SPIFFS_FORMAT_ON_MOUNT_FAIL
+            bool "Format SPIFFS if mounting fails"
+            default n
+            help
+                Format SPIFFS if it fails to mount the filesystem.
+
+        config BSP_SPIFFS_MOUNT_POINT
+            string "SPIFFS mount point"
+            default "/spiffs"
+            help
+                Mount point of SPIFFS in the Virtual File System.
+
+        config BSP_SPIFFS_PARTITION_LABEL
+            string "Partition label of SPIFFS"
+            default "storage"
+            help
+                Partition label which stores SPIFFS.
+
+        config BSP_SPIFFS_MAX_FILES
+            int "Max files supported for SPIFFS VFS"
+            default 5
+            help
+                Supported max files for SPIFFS in the Virtual File System.
+    endmenu
+
     menu "Display"
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
         int "LEDC channel index"

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.2"
+version: "2.1.3"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 

--- a/esp-box/include/bsp/esp-box.h
+++ b/esp-box/include/bsp/esp-box.h
@@ -219,6 +219,44 @@ esp_err_t bsp_i2c_deinit(void);
 
 /**************************************************************************************************
  *
+ * SPIFFS
+ *
+ * After mounting the SPIFFS, it can be accessed with stdio functions ie.:
+ * \code{.c}
+ * FILE* f = fopen(BSP_MOUNT_POINT"/hello.txt", "w");
+ * fprintf(f, "Hello World!\n");
+ * fclose(f);
+ * \endcode
+ **************************************************************************************************/
+#define BSP_MOUNT_POINT      CONFIG_BSP_SPIFFS_MOUNT_POINT
+
+/**
+ * @brief Mount SPIFFS to virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_register was already called
+ *      - ESP_ERR_NO_MEM if memory can not be allocated
+ *      - ESP_FAIL if partition can not be mounted
+ *      - other error codes
+ */
+esp_err_t bsp_spiffs_mount(void);
+
+/**
+ * @brief Unmount SPIFFS from virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_NOT_FOUND if the partition table does not contain SPIFFS partition with given label
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_unregister was already called
+ *      - ESP_ERR_NO_MEM if memory can not be allocated
+ *      - ESP_FAIL if partition can not be mounted
+ *      - other error codes
+ */
+esp_err_t bsp_spiffs_unmount(void);
+
+/**************************************************************************************************
+ *
  * LCD interface
  *
  * ESP-BOX is shipped with 2.4inch ST7789 display controller.


### PR DESCRIPTION
Just a quick port from https://github.com/espressif/esp-box/blob/master/components/bsp/src/storage/bsp_spiffs.c, since espressif/esp-box will totally use the esp-box bsp from esp-bsp. Closes #107 .
