### PR TITLE
esp_lvgl_port: Add LVGL file system support (BSP-244)

### DIFF
--- a/components/esp_lvgl_port/CMakeLists.txt
+++ b/components/esp_lvgl_port/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "esp_lvgl_port.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES "esp_timer")
+idf_component_register(SRCS "esp_lvgl_port_fs.c" "esp_lvgl_port.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES "esp_timer")

--- a/components/esp_lvgl_port/esp_lvgl_port_fs.c
+++ b/components/esp_lvgl_port/esp_lvgl_port_fs.c
@@ -1,0 +1,256 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dirent.h>
+#include <stdio.h>
+
+#include "esp_err.h"
+#include "esp_log.h"
+
+#include "freertos/FreeRTOS.h"
+
+#include "esp_lvgl_port.h"
+
+static const char *TAG = "lv_port_fs";
+
+static void fs_init(void);
+
+static void *fs_open (lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mode);
+static lv_fs_res_t fs_close (lv_fs_drv_t *drv, void *file_p);
+static lv_fs_res_t fs_read (lv_fs_drv_t *drv, void *file_p, void *buf, uint32_t btr, uint32_t *br);
+static lv_fs_res_t fs_write(lv_fs_drv_t *drv, void *file_p, const void *buf, uint32_t btw, uint32_t *bw);
+static lv_fs_res_t fs_seek (lv_fs_drv_t *drv, void *file_p, uint32_t pos, lv_fs_whence_t whence);
+static lv_fs_res_t fs_tell (lv_fs_drv_t *drv, void *file_p, uint32_t *pos_p);
+
+static void *fs_dir_open (lv_fs_drv_t *drv, const char *path);
+static lv_fs_res_t fs_dir_read (lv_fs_drv_t *drv, void *rddir_p, char *fn);
+static lv_fs_res_t fs_dir_close (lv_fs_drv_t *drv, void *rddir_p);
+
+esp_err_t lvgl_port_fs_init(void)
+{
+    static bool lvgl_fs_inited = false;
+
+    if (lvgl_fs_inited) {
+        ESP_LOGI(TAG, "LVGL FS has been inited.");
+        return ESP_OK;
+    }
+
+    lvgl_fs_inited = true;
+
+    /*----------------------------------------------------
+     * Initialize your storage device and File System
+     * -------------------------------------------------*/
+    fs_init();
+
+    /*---------------------------------------------------
+     * Register the file system interface in LVGL
+     *--------------------------------------------------*/
+
+    /*Add a simple drive to open images*/
+    static lv_fs_drv_t fs_drv;
+    lv_fs_drv_init(&fs_drv);
+
+    /*Set up fields...*/
+    fs_drv.letter = 'S';
+    fs_drv.open_cb = fs_open;
+    fs_drv.close_cb = fs_close;
+    fs_drv.read_cb = fs_read;
+    fs_drv.write_cb = fs_write;
+    fs_drv.seek_cb = fs_seek;
+    fs_drv.tell_cb = fs_tell;
+
+    fs_drv.dir_close_cb = fs_dir_close;
+    fs_drv.dir_open_cb = fs_dir_open;
+    fs_drv.dir_read_cb = fs_dir_read;
+
+    lv_fs_drv_register(&fs_drv);
+
+    return ESP_OK;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/*Initialize your Storage device and File system.*/
+static void fs_init(void)
+{
+    /*E.g. for FatFS initialize the SD card and FatFS itself*/
+
+    /*You code here*/
+}
+
+/**
+ * Open a file
+ * @param drv       pointer to a driver where this function belongs
+ * @param path      path to the file beginning with the driver letter (e.g. S:/folder/file.txt)
+ * @param mode      read: FS_MODE_RD, write: FS_MODE_WR, both: FS_MODE_RD | FS_MODE_WR
+ * @return          a file descriptor or NULL on error
+ */
+static void *fs_open (lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mode)
+{
+    void *f = NULL;
+
+    if (mode == LV_FS_MODE_WR) {
+        /*Open a file for write*/
+        f = fopen(path, "w");
+    } else if (mode == LV_FS_MODE_RD) {
+        /*Open a file for read*/
+        f = fopen(path, "r");
+    } else if (mode == (LV_FS_MODE_WR | LV_FS_MODE_RD)) {
+        /*Open a file for read and write*/
+        f = fopen(path, "r+");
+    }
+
+    return (FILE *) f;
+}
+
+/**
+ * Close an opened file
+ * @param drv       pointer to a driver where this function belongs
+ * @param file_p    pointer to a file_t variable. (opened with lv_ufs_open)
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_close (lv_fs_drv_t *drv, void *file_p)
+{
+    lv_fs_res_t res = LV_FS_RES_OK;
+
+    /*Add your code here*/
+    if (EOF == fclose((FILE *) file_p)) {
+        ESP_LOGE(TAG, "Failed close file");
+    }
+
+    return res;
+}
+
+/**
+ * Read data from an opened file
+ * @param drv       pointer to a driver where this function belongs
+ * @param file_p    pointer to a file_t variable.
+ * @param buf       pointer to a memory block where to store the read data
+ * @param btr       number of Bytes To Read
+ * @param br        the real number of read bytes (Byte Read)
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_read (lv_fs_drv_t *drv, void *file_p, void *buf, uint32_t btr, uint32_t *br)
+{
+    (void) drv;
+
+    *br = fread(buf, 1, btr, (FILE *) file_p);
+
+    return LV_FS_RES_OK;
+}
+
+/**
+ * Write into a file
+ * @param drv       pointer to a driver where this function belongs
+ * @param file_p    pointer to a file_t variable
+ * @param buf       pointer to a buffer with the bytes to write
+ * @param btr       Bytes To Write
+ * @param br        the number of real written bytes (Bytes Written). NULL if unused.
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_write(lv_fs_drv_t *drv, void *file_p, const void *buf, uint32_t btw, uint32_t *bw)
+{
+    (void) drv;
+
+    *bw = fwrite(buf, 1, btw, (FILE *) file_p);
+
+    return LV_FS_RES_OK;
+}
+
+/**
+ * Set the read write pointer. Also expand the file size if necessary.
+ * @param drv       pointer to a driver where this function belongs
+ * @param file_p    pointer to a file_t variable. (opened with lv_ufs_open )
+ * @param pos       the new position of read write pointer
+ * @param whence    tells from where to interpret the `pos`. See @lv_fs_whence_t
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_seek (lv_fs_drv_t *drv, void *file_p, uint32_t pos, lv_fs_whence_t whence)
+{
+    (void) drv;
+
+    int ret_val = fseek((FILE *) file_p, pos, whence);
+
+    if (0 != ret_val) {
+        return LV_FS_RES_UNKNOWN;
+    }
+
+    return LV_FS_RES_OK;
+}
+/**
+ * Give the position of the read write pointer
+ * @param drv       pointer to a driver where this function belongs
+ * @param file_p    pointer to a file_t variable.
+ * @param pos_p     pointer to to store the result
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_tell (lv_fs_drv_t *drv, void *file_p, uint32_t *pos_p)
+{
+    (void) drv;
+
+    *pos_p = ftell((FILE *) file_p);
+
+    return LV_FS_RES_OK;
+}
+
+/**
+ * Initialize a 'lv_fs_dir_t' variable for directory reading
+ * @param drv       pointer to a driver where this function belongs
+ * @param path      path to a directory
+ * @return          pointer to the directory read descriptor or NULL on error
+ */
+static void *fs_dir_open (lv_fs_drv_t *drv, const char *path)
+{
+    (void) drv;
+
+    DIR *d = NULL;
+
+    d = opendir(path);
+
+    if (NULL == d) {
+        return (void *)LV_FS_RES_UNKNOWN;
+    }
+
+    return d;
+}
+
+/**
+ * Read the next filename form a directory.
+ * The name of the directories will begin with '/'
+ * @param drv       pointer to a driver where this function belongs
+ * @param rddir_p   pointer to an initialized 'lv_fs_dir_t' variable
+ * @param fn        pointer to a buffer to store the filename
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_dir_read (lv_fs_drv_t *drv, void *rddir_p, char *fn)
+{
+    lv_fs_res_t res = LV_FS_RES_NOT_IMP;
+
+    readdir((DIR *) rddir_p);
+
+    return res;
+}
+
+/**
+ * Close the directory reading
+ * @param drv       pointer to a driver where this function belongs
+ * @param rddir_p   pointer to an initialized 'lv_fs_dir_t' variable
+ * @return          LV_FS_RES_OK: no error or  any error from @lv_fs_res_t enum
+ */
+static lv_fs_res_t fs_dir_close (lv_fs_drv_t *drv, void *rddir_p)
+{
+    (void) drv;
+
+    int ret_val = closedir(rddir_p);
+
+    if (0 != ret_val) {
+        return LV_FS_RES_UNKNOWN;
+    }
+
+    return LV_FS_RES_OK;
+}

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.1.0"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -104,6 +104,16 @@ esp_err_t lvgl_port_init(const lvgl_port_cfg_t *cfg);
 esp_err_t lvgl_port_deinit(void);
 
 /**
+ * @brief Initialize LVGL FS
+ *
+ * @note This function initialize LVGL file system support.
+ *
+ * @return
+ *      - ESP_OK                    on success
+ */
+esp_err_t lvgl_port_fs_init(void);
+
+/**
  * @brief Add display handling to LVGL
  *
  * @note Allocated memory in this function is not free in deinit. You must call lvgl_port_remove_disp for free all memory!


### PR DESCRIPTION
Just a quick port from https://github.com/espressif/esp-box/blob/master/components/lvgl/lv_port/lv_port_fs.c, since espressif/esp-box will totally use the esp-box bsp from esp-bsp. Close #108 .