### PR TITLE
Add MPU6050 ISR support (BSP-251)

### DIFF
--- a/components/mpu6050/README.md
+++ b/components/mpu6050/README.md
@@ -1,6 +1,40 @@
-# Component: MPU6050
+# MPU6050 Driver Component
 
 [![Component Registry](https://components.espressif.com/components/espressif/mpu6050/badge.svg)](https://components.espressif.com/components/espressif/mpu6050)
 
- * C driver for MPU6050 gyroscope and accelerometer.
- * See [datasheet](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Datasheet1.pdf).
+C driver for Invensense MPU6050 6-axis gyroscope and accelerometer based on I2C communication.
+
+## Features
+
+- Get 3-axis accelerometer and 3-axis gyroscope data, either raw or as floating point values. 
+- Read temperature from MPU6050 internal temperature sensor.
+- Configure gyroscope and accelerometer sensitivity.
+- MPU6050 power down mode.
+- Support for MPU6050 interrupt generation when data ready (occurs each time a write to all sensor data registers has been completed).  
+
+## Important Notes
+
+- Keep in mind that MPU6050 I2C address depends on the level of its AD0 pin (9) (0x68 when low, 0x69 when high).
+- In order to receive MPU6050 interrupts, its INT pin (12) must be conneced to a GPIO on the ESP32. 
+
+## Limitations
+
+- Only I2C communication is supported.
+- Driver has not been tested with MPU 6000 yet.
+- 9-axis support through MPU6050 I2C aux is not supported.
+- If MPU6050 interrupts are used, it is recommended to not read data using I2C directly from the ISR. 
+
+## Get Started
+
+This driver, along with many other components from this repository, can be used as a package from [Espressif's IDF Component Registry](https://components.espressif.com). To include this driver in your project, run the following idf.py from the project's root directory:
+
+```
+    idf.py add-dependency "espressif/mpu6050^1.1.1"
+```
+
+Another option is to manually create a `idf_component.yml` file. You can find more about using .yml files for components from [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
+
+## See Also
+* [Sensors example, including the MPU6050 driver](https://github.com/espressif/esp-bsp/tree/master/examples/sensors_example)
+* [MPU6050 datasheet](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Datasheet1.pdf)
+* [MPU6000 and MPU6050 register map](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf)

--- a/components/mpu6050/idf_component.yml
+++ b/components/mpu6050/idf_component.yml
@@ -1,5 +1,5 @@
-version: "1.1.1"
-description: I2C driver for MPU6050 gyroscope and accelerometer
+version: "1.2.0"
+description: I2C driver for MPU6050 6-axis gyroscope and accelerometer
 url: https://github.com/espressif/esp-bsp/tree/master/components/mpu6050
 dependencies:
   idf : ">=4.0"

--- a/components/mpu6050/include/mpu6050.h
+++ b/components/mpu6050/include/mpu6050.h
@@ -205,11 +205,13 @@ esp_err_t mpu6050_enable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_s
 
 esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources);
 
-uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
+esp_err_t mpu6050_get_interrupt_status(mpu6050_handle_t sensor, uint8_t *const out_intr_status);
 
-uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
+inline uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
 
-uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
+inline uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
+
+inline uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Read raw accelerometer measurements

--- a/components/mpu6050/include/mpu6050.h
+++ b/components/mpu6050/include/mpu6050.h
@@ -295,7 +295,7 @@ esp_err_t mpu6050_get_interrupt_status(mpu6050_handle_t sensor, uint8_t *const o
  *      - 0: The interrupt was not produced due to data ready
  *      - Any other positive integer: Interrupt was a DATA_READY interrupt 
  */
-inline uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
+extern uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Determine if the last mpu6050 interrupt was an I2C master interrupt.
@@ -306,7 +306,7 @@ inline uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
  *      - 0: The interrupt is not an I2C master interrupt
  *      - Any other positive integer: Interrupt was an I2C master interrupt 
  */
-inline uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
+extern uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Determine if the last mpu6050 interrupt was triggered by a fifo overflow.
@@ -317,7 +317,7 @@ inline uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
  *      - 0: The interrupt is not a fifo overflow interrupt
  *      - Any other positive integer: Interrupt was triggered by a fifo overflow 
  */
-inline uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
+extern uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Read raw accelerometer measurements

--- a/components/mpu6050/include/mpu6050.h
+++ b/components/mpu6050/include/mpu6050.h
@@ -37,37 +37,38 @@ typedef enum {
 } mpu6050_gyro_fs_t;
 
 typedef enum {
-    INTERRUPT_PIN_ACTIVE_HIGH = 0,
-    INTERRUPT_PIN_ACTIVE_LOW  = 1
+    INTERRUPT_PIN_ACTIVE_HIGH = 0,          /*!< The mpu6050 sets its INT pin HIGH on interrupt */
+    INTERRUPT_PIN_ACTIVE_LOW  = 1           /*!< The mpu6050 sets its INT pin LOW on interrupt */
 } mpu6050_int_pin_active_level_t;
 
 typedef enum {
-    INTERRUPT_PIN_PUSH_PULL   = 0,
-    INTERRUPT_PIN_OPEN_DRAIN  = 1
+    INTERRUPT_PIN_PUSH_PULL   = 0,          /*!< The mpu6050 configures its INT pin as push-pull */
+    INTERRUPT_PIN_OPEN_DRAIN  = 1           /*!< The mpu6050 configures its INT pin as open drain*/
 } mpu6050_int_pin_mode_t;
 
 typedef enum {
-    INTERRUPT_LATCH_50US            = 0,
-    INTERRUPT_LATCH_UNTIL_CLEARED   = 1
+    INTERRUPT_LATCH_50US            = 0,    /*!< The mpu6050 produces a 50 microsecond pulse on interrupt */
+    INTERRUPT_LATCH_UNTIL_CLEARED   = 1     /*!< The mpu6050 latches its INT pin to its active level, until interrupt is cleared */
 } mpu6050_int_latch_t;
 
 typedef enum {
-    INTERRUPT_CLEAR_ON_ANY_READ     = 0,
-    INTERRUPT_CLEAR_ON_STATUS_READ  = 1
+    INTERRUPT_CLEAR_ON_ANY_READ     = 0,    /*!< INT_STATUS register bits are cleared on any register read */
+    INTERRUPT_CLEAR_ON_STATUS_READ  = 1     /*!< INT_STATUS register bits are cleared only by reading INT_STATUS value*/
 } mpu6050_int_clear_t;
 
 typedef struct {
-    gpio_num_t interrupt_pin;
-    mpu6050_int_pin_active_level_t active_level;
-    mpu6050_int_pin_mode_t pin_mode;
-    mpu6050_int_latch_t interrupt_latch;
-    mpu6050_int_clear_t interrupt_clear_behavior;
+    gpio_num_t interrupt_pin;                       /*!< GPIO connected to mpu6050 INT pin       */
+    mpu6050_int_pin_active_level_t active_level;    /*!< Active level of mpu6050 INT pin         */
+    mpu6050_int_pin_mode_t pin_mode;                /*!< Push-pull or open drain mode for INT pin*/
+    mpu6050_int_latch_t interrupt_latch;            /*!< The interrupt pulse behavior of INT pin */
+    mpu6050_int_clear_t interrupt_clear_behavior;   /*!< Interrupt status clear behavior         */
 } mpu6050_int_config_t;
 
-extern const uint8_t MPU6050_DATA_RDY_INT_BIT;
-extern const uint8_t MPU6050_I2C_MASTER_INT_BIT;
-extern const uint8_t MPU6050_FIFO_OVERFLOW_INT_BIT;
-extern const uint8_t MPU6050_MOT_DETECT_INT_BIT;
+extern const uint8_t MPU6050_DATA_RDY_INT_BIT;      /*!< DATA READY interrupt bit               */
+extern const uint8_t MPU6050_I2C_MASTER_INT_BIT;    /*!< I2C MASTER interrupt bit               */
+extern const uint8_t MPU6050_FIFO_OVERFLOW_INT_BIT; /*!< FIFO Overflow interrupt bit            */
+extern const uint8_t MPU6050_MOT_DETECT_INT_BIT;    /*!< MOTION DETECTION interrupt bit         */
+extern const uint8_t MPU6050_ALL_INTERRUPTS;        /*!< All interrupts supported by mpu6050    */
 
 typedef struct {
     int16_t raw_acce_x;
@@ -197,20 +198,125 @@ esp_err_t mpu6050_get_acce_sensitivity(mpu6050_handle_t sensor, float *const acc
  */
 esp_err_t mpu6050_get_gyro_sensitivity(mpu6050_handle_t sensor, float *const gyro_sensitivity);
 
+/**
+ * @brief Configure INT pin behavior and setup target GPIO.
+ * 
+ * @param sensor object handle of mpu6050
+ * @param interrupt_configuration mpu6050 INT pin configuration parameters
+ * 
+ * @return 
+ *      - ESP_OK Success
+ *      - ESP_ERR_INVALID_ARG A parameter is NULL or incorrect
+ *      - ESP_FAIL Failed to configure INT pin on mpu6050 
+ */
 esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t* const interrupt_configuration);
 
+/**
+ * @brief Register an Interrupt Service Routine to handle mpu6050 interrupts.
+ * 
+ * @param sensor object handle of mpu6050
+ * @param isr function to handle interrupts produced by mpu6050
+ * 
+ * @return 
+ *      - ESP_OK Success
+ *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
+ *      - ESP_FAIL Failed to register ISR 
+ */
 esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr);
 
+/**
+ * @brief Enable specific interrupts from mpu6050
+ * 
+ * @param sensor object handle of mpu6050
+ * @param interrupt_sources bit mask with interrupt sources to enable
+ * 
+ * This function does not disable interrupts not set in interrupt_sources. To disable
+ * specific mpu6050 interrupts, use mpu6050_disable_interrupts().
+ * 
+ * To enable all mpu6050 interrupts, pass MPU6050_ALL_INTERRUPTS as the argument
+ * for interrupt_sources.
+ * 
+ * @return 
+ *      - ESP_OK Success
+ *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
+ *      - ESP_FAIL Failed to enable interrupt sources on mpu6050
+ */
 esp_err_t mpu6050_enable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources);
 
+/**
+ * @brief Disable specific interrupts from mpu6050
+ * 
+ * @param sensor object handle of mpu6050
+ * @param interrupt_sources bit mask with interrupt sources to disable
+ * 
+ * This function does not enable interrupts not set in interrupt_sources. To enable
+ * specific mpu6050 interrupts, use mpu6050_enable_interrupts(). 
+ * 
+ * To disable all mpu6050 interrupts, pass MPU6050_ALL_INTERRUPTS as the  
+ * argument for interrupt_sources.
+ * 
+ * @return 
+ *      - ESP_OK Success
+ *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
+ *      - ESP_FAIL Failed to enable interrupt sources on mpu6050
+ */
 esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources);
 
+/**
+ * @brief Get the interrupt status of mpu6050
+ * 
+ * @param sensor object handle of mpu6050
+ * @param out_intr_status[out] bit mask that is assigned a value representing the interrupts triggered by the mpu6050
+ * 
+ * This function can be used by the mpu6050 ISR to determine the source of 
+ * the mpu6050 interrupt that it is handling. 
+ * 
+ * After this function returns, the bits set in out_intr_status are 
+ * the sources of the latest interrupt triggered by the mpu6050. For example,
+ * if MPU6050_DATA_RDY_INT_BIT is set in out_intr_status, the last interrupt
+ * from the mpu6050 was a DATA READY interrupt.
+ * 
+ * The behavior of the INT_STATUS register of the mpu6050 may change depending on 
+ * the value of mpu6050_int_clear_t used on interrupt configuration.
+ * 
+ * @return 
+ *      - ESP_OK Success
+ *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
+ *      - ESP_FAIL Failed to retrieve interrupt status from mpu6050
+ */
 esp_err_t mpu6050_get_interrupt_status(mpu6050_handle_t sensor, uint8_t *const out_intr_status);
 
+/**
+ * @brief Determine if the last mpu6050 interrupt was due to data ready.
+ * 
+ * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
+ * 
+ * @return 
+ *      - 0: The interrupt was not produced due to data ready
+ *      - Any other positive integer: Interrupt was a DATA_READY interrupt 
+ */
 inline uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
 
+/**
+ * @brief Determine if the last mpu6050 interrupt was an I2C master interrupt.
+ * 
+ * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
+ * 
+ * @return 
+ *      - 0: The interrupt is not an I2C master interrupt
+ *      - Any other positive integer: Interrupt was an I2C master interrupt 
+ */
 inline uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
 
+/**
+ * @brief Determine if the last mpu6050 interrupt was triggered by a fifo overflow.
+ * 
+ * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
+ * 
+ * @return 
+ *      - 0: The interrupt is not a fifo overflow interrupt
+ *      - Any other positive integer: Interrupt was triggered by a fifo overflow 
+ */
 inline uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
 
 /**

--- a/components/mpu6050/include/mpu6050.h
+++ b/components/mpu6050/include/mpu6050.h
@@ -200,43 +200,43 @@ esp_err_t mpu6050_get_gyro_sensitivity(mpu6050_handle_t sensor, float *const gyr
 
 /**
  * @brief Configure INT pin behavior and setup target GPIO.
- * 
+ *
  * @param sensor object handle of mpu6050
  * @param interrupt_configuration mpu6050 INT pin configuration parameters
- * 
- * @return 
+ *
+ * @return
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_ARG A parameter is NULL or incorrect
- *      - ESP_FAIL Failed to configure INT pin on mpu6050 
+ *      - ESP_FAIL Failed to configure INT pin on mpu6050
  */
-esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t* const interrupt_configuration);
+esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t *const interrupt_configuration);
 
 /**
  * @brief Register an Interrupt Service Routine to handle mpu6050 interrupts.
- * 
+ *
  * @param sensor object handle of mpu6050
  * @param isr function to handle interrupts produced by mpu6050
- * 
- * @return 
+ *
+ * @return
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
- *      - ESP_FAIL Failed to register ISR 
+ *      - ESP_FAIL Failed to register ISR
  */
 esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr);
 
 /**
  * @brief Enable specific interrupts from mpu6050
- * 
+ *
  * @param sensor object handle of mpu6050
  * @param interrupt_sources bit mask with interrupt sources to enable
- * 
+ *
  * This function does not disable interrupts not set in interrupt_sources. To disable
  * specific mpu6050 interrupts, use mpu6050_disable_interrupts().
- * 
+ *
  * To enable all mpu6050 interrupts, pass MPU6050_ALL_INTERRUPTS as the argument
  * for interrupt_sources.
- * 
- * @return 
+ *
+ * @return
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
  *      - ESP_FAIL Failed to enable interrupt sources on mpu6050
@@ -245,17 +245,17 @@ esp_err_t mpu6050_enable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_s
 
 /**
  * @brief Disable specific interrupts from mpu6050
- * 
+ *
  * @param sensor object handle of mpu6050
  * @param interrupt_sources bit mask with interrupt sources to disable
- * 
+ *
  * This function does not enable interrupts not set in interrupt_sources. To enable
- * specific mpu6050 interrupts, use mpu6050_enable_interrupts(). 
- * 
- * To disable all mpu6050 interrupts, pass MPU6050_ALL_INTERRUPTS as the  
+ * specific mpu6050 interrupts, use mpu6050_enable_interrupts().
+ *
+ * To disable all mpu6050 interrupts, pass MPU6050_ALL_INTERRUPTS as the
  * argument for interrupt_sources.
- * 
- * @return 
+ *
+ * @return
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
  *      - ESP_FAIL Failed to enable interrupt sources on mpu6050
@@ -264,22 +264,22 @@ esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_
 
 /**
  * @brief Get the interrupt status of mpu6050
- * 
+ *
  * @param sensor object handle of mpu6050
  * @param out_intr_status[out] bit mask that is assigned a value representing the interrupts triggered by the mpu6050
- * 
- * This function can be used by the mpu6050 ISR to determine the source of 
- * the mpu6050 interrupt that it is handling. 
- * 
- * After this function returns, the bits set in out_intr_status are 
+ *
+ * This function can be used by the mpu6050 ISR to determine the source of
+ * the mpu6050 interrupt that it is handling.
+ *
+ * After this function returns, the bits set in out_intr_status are
  * the sources of the latest interrupt triggered by the mpu6050. For example,
  * if MPU6050_DATA_RDY_INT_BIT is set in out_intr_status, the last interrupt
  * from the mpu6050 was a DATA READY interrupt.
- * 
- * The behavior of the INT_STATUS register of the mpu6050 may change depending on 
+ *
+ * The behavior of the INT_STATUS register of the mpu6050 may change depending on
  * the value of mpu6050_int_clear_t used on interrupt configuration.
- * 
- * @return 
+ *
+ * @return
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_ARG A parameter is NULL or not valid
  *      - ESP_FAIL Failed to retrieve interrupt status from mpu6050
@@ -288,34 +288,34 @@ esp_err_t mpu6050_get_interrupt_status(mpu6050_handle_t sensor, uint8_t *const o
 
 /**
  * @brief Determine if the last mpu6050 interrupt was due to data ready.
- * 
+ *
  * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
- * 
- * @return 
+ *
+ * @return
  *      - 0: The interrupt was not produced due to data ready
- *      - Any other positive integer: Interrupt was a DATA_READY interrupt 
+ *      - Any other positive integer: Interrupt was a DATA_READY interrupt
  */
 extern uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Determine if the last mpu6050 interrupt was an I2C master interrupt.
- * 
+ *
  * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
- * 
- * @return 
+ *
+ * @return
  *      - 0: The interrupt is not an I2C master interrupt
- *      - Any other positive integer: Interrupt was an I2C master interrupt 
+ *      - Any other positive integer: Interrupt was an I2C master interrupt
  */
 extern uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status);
 
 /**
  * @brief Determine if the last mpu6050 interrupt was triggered by a fifo overflow.
- * 
+ *
  * @param interrupt_status mpu6050 interrupt status, obtained by invoking mpu6050_get_interrupt_status()
- * 
- * @return 
+ *
+ * @return
  *      - 0: The interrupt is not a fifo overflow interrupt
- *      - Any other positive integer: Interrupt was triggered by a fifo overflow 
+ *      - Any other positive integer: Interrupt was triggered by a fifo overflow
  */
 extern uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status);
 

--- a/components/mpu6050/mpu6050.c
+++ b/components/mpu6050/mpu6050.c
@@ -214,7 +214,7 @@ esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_c
 
     uint8_t int_pin_cfg = 0x00;
 
-    ret = mpu6050_read(sensor, MPU6050_INT_PIN_CFG, &int_pin_cfg, 1);
+    ret = mpu6050_read(sensor, MPU6050_INTR_PIN_CFG, &int_pin_cfg, 1);
 
     if (ESP_OK != ret) {
         return ret;
@@ -236,7 +236,7 @@ esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_c
         int_pin_cfg |= BIT4;
     }
 
-    ret = mpu6050_write(sensor, MPU6050_INT_PIN_CFG, &int_pin_cfg, 1);
+    ret = mpu6050_write(sensor, MPU6050_INTR_PIN_CFG, &int_pin_cfg, 1);
 
     if (ESP_OK != ret) {
         return ret;
@@ -274,7 +274,7 @@ esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr)
     ret = gpio_isr_handler_add(
         sensor_device->int_pin,
         isr, 
-        (void *) sensor_device
+        (void *) sensor
     );
 
     if (ESP_OK != ret) {
@@ -321,7 +321,7 @@ esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_
     if (0 != (enabled_interrupts & interrupt_sources)) {
         enabled_interrupts &= (~interrupt_sources);
 
-        ret = mpu6050_write(sensor, MPU6050_INTR_ENABLE)
+        ret = mpu6050_write(sensor, MPU6050_INTR_ENABLE, &enabled_interrupts, 1);
     }
 
     return ret;

--- a/components/mpu6050/mpu6050.c
+++ b/components/mpu6050/mpu6050.c
@@ -18,9 +18,9 @@
 /* MPU6050 register */
 #define MPU6050_GYRO_CONFIG         0x1Bu
 #define MPU6050_ACCEL_CONFIG        0x1Cu
-#define MPU6050_INT_PIN_CFG         0x37u
-#define MPU6050_INT_ENABLE          0x38u
-#define MPU6050_INT_STATUS          0x3Au
+#define MPU6050_INTR_PIN_CFG         0x37u
+#define MPU6050_INTR_ENABLE          0x38u
+#define MPU6050_INTR_STATUS          0x3Au
 #define MPU6050_ACCEL_XOUT_H        0x3Bu
 #define MPU6050_GYRO_XOUT_H         0x43u
 #define MPU6050_TEMP_XOUT_H         0x41u
@@ -204,37 +204,156 @@ esp_err_t mpu6050_get_gyro_sensitivity(mpu6050_handle_t sensor, float *const gyr
 
 esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t* const interrupt_configuration)
 {
-    return ESP_FAIL;
+    esp_err_t ret;
+
+    if (NULL == interrupt_configuration)
+    {
+        ret = ESP_ERR_INVALID_ARG;
+        return ret;
+    }
+
+    uint8_t int_pin_cfg = 0x00;
+
+    ret = mpu6050_read(sensor, MPU6050_INT_PIN_CFG, &int_pin_cfg, 1);
+
+    if (ESP_OK != ret) {
+        return ret;
+    }
+
+    if (INTERRUPT_PIN_ACTIVE_LOW == interrupt_configuration->active_level) {
+        int_pin_cfg |= BIT7;
+    }
+
+    if (INTERRUPT_PIN_OPEN_DRAIN == interrupt_configuration->pin_mode) {
+        int_pin_cfg |= BIT6;
+    }
+
+    if (INTERRUPT_LATCH_UNTIL_CLEARED == interrupt_configuration->interrupt_latch) {
+        int_pin_cfg |= BIT5;
+    }
+
+    if (INTERRUPT_CLEAR_ON_ANY_READ == interrupt_configuration->interrupt_clear_behavior) {
+        int_pin_cfg |= BIT4;
+    }
+
+    ret = mpu6050_write(sensor, MPU6050_INT_PIN_CFG, &int_pin_cfg, 1);
+
+    if (ESP_OK != ret) {
+        return ret;
+    }
+
+    gpio_int_type_t gpio_intr_type;
+    
+    if (INTERRUPT_PIN_ACTIVE_LOW == interrupt_configuration->active_level) {
+        gpio_intr_type = GPIO_INTR_NEGEDGE;
+    } else {
+        gpio_intr_type = GPIO_INTR_POSEDGE;
+    }
+
+    gpio_config_t int_gpio_config = {
+        .mode = GPIO_MODE_INPUT,
+        .intr_type = gpio_intr_type,
+        .pin_bit_mask = (BIT0 << interrupt_configuration->interrupt_pin) 
+    };
+
+    ret = gpio_config(&int_gpio_config);
+
+    return ret;
 }
 
 esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr)
 {
-    return ESP_FAIL;
+    esp_err_t ret;
+    mpu6050_dev_t *sensor_device = (mpu6050_dev_t *) sensor;
+
+    if (NULL == sensor_device) {
+        ret = ESP_ERR_INVALID_ARG;
+        return ret;
+    }
+
+    ret = gpio_isr_handler_add(
+        sensor_device->int_pin,
+        isr, 
+        (void *) sensor_device
+    );
+
+    if (ESP_OK != ret) {
+        return ret;
+    }
+
+    ret = gpio_intr_enable(sensor_device->int_pin);
+
+    return ret;
 }
 
 esp_err_t mpu6050_enable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources)
 {
-    return ESP_FAIL;
+    esp_err_t ret;
+    uint8_t enabled_interrupts = 0x00;
+
+    ret = mpu6050_read(sensor, MPU6050_INTR_ENABLE, &enabled_interrupts, 1);
+
+    if (ESP_OK != ret) {
+        return ret;
+    }
+
+    if (enabled_interrupts != interrupt_sources) {
+
+        enabled_interrupts |= interrupt_sources;
+
+        ret = mpu6050_write(sensor, MPU6050_INTR_ENABLE, &enabled_interrupts, 1);
+    }
+
+    return ret;
 }
 
 esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources)
 {
-    return ESP_FAIL;
+    esp_err_t ret;
+    uint8_t enabled_interrupts = 0x00;
+
+    ret = mpu6050_read(sensor, MPU6050_INTR_ENABLE, &enabled_interrupts, 1);
+
+    if (ESP_OK != ret) {
+        return ret;
+    }
+
+    if (0 != (enabled_interrupts & interrupt_sources)) {
+        enabled_interrupts &= (~interrupt_sources);
+
+        ret = mpu6050_write(sensor, MPU6050_INTR_ENABLE)
+    }
+
+    return ret;
 }
 
-uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status)
+esp_err_t mpu6050_get_interrupt_status(mpu6050_handle_t sensor, uint8_t *const out_intr_status)
 {
-    return 0x00u;
+    esp_err_t ret;
+
+    if (NULL == out_intr_status) {
+        ret = ESP_ERR_INVALID_ARG;
+        return ret;
+    }
+
+    ret = mpu6050_read(sensor, MPU6050_INTR_STATUS, out_intr_status, 1);
+
+    return ret;
 }
 
-uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status)
+inline uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status)
 {
-    return 0x00u;
+    return (MPU6050_DATA_RDY_INT_BIT == (MPU6050_DATA_RDY_INT_BIT & interrupt_status));
 }
 
-uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status)
+inline uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status)
 {
-    return 0x00u;
+    return (uint8_t) (MPU6050_I2C_MASTER_INT_BIT == (MPU6050_I2C_MASTER_INT_BIT & interrupt_status));
+}
+
+inline uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status)
+{
+    return (uint8_t) (MPU6050_FIFO_OVERFLOW_INT_BIT == (MPU6050_FIFO_OVERFLOW_INT_BIT & interrupt_status));
 }
 
 esp_err_t mpu6050_get_raw_acce(mpu6050_handle_t sensor, mpu6050_raw_acce_value_t *const raw_acce_value)

--- a/components/mpu6050/mpu6050.c
+++ b/components/mpu6050/mpu6050.c
@@ -18,14 +18,24 @@
 /* MPU6050 register */
 #define MPU6050_GYRO_CONFIG         0x1Bu
 #define MPU6050_ACCEL_CONFIG        0x1Cu
+#define MPU6050_INT_PIN_CFG         0x37u
+#define MPU6050_INT_ENABLE          0x38u
+#define MPU6050_INT_STATUS          0x3Au
 #define MPU6050_ACCEL_XOUT_H        0x3Bu
 #define MPU6050_GYRO_XOUT_H         0x43u
 #define MPU6050_TEMP_XOUT_H         0x41u
 #define MPU6050_PWR_MGMT_1          0x6Bu
 #define MPU6050_WHO_AM_I            0x75u
 
+const uint8_t MPU6050_DATA_RDY_INT_BIT =      (uint8_t) BIT0;
+const uint8_t MPU6050_I2C_MASTER_INT_BIT =    (uint8_t) BIT3;
+const uint8_t MPU6050_FIFO_OVERFLOW_INT_BIT = (uint8_t) BIT4;
+const uint8_t MPU6050_MOT_DETECT_INT_BIT =    (uint8_t) BIT6;
+const uint8_t MPU6050_ALL_INTERRUPTS = (MPU6050_DATA_RDY_INT_BIT | MPU6050_I2C_MASTER_INT_BIT | MPU6050_FIFO_OVERFLOW_INT_BIT | MPU6050_MOT_DETECT_INT_BIT);
+
 typedef struct {
     i2c_port_t bus;
+    gpio_num_t int_pin;
     uint16_t dev_addr;
     uint32_t counter;
     float dt;  /*!< delay time between two measurements, dt should be small (ms level) */
@@ -190,6 +200,41 @@ esp_err_t mpu6050_get_gyro_sensitivity(mpu6050_handle_t sensor, float *const gyr
         break;
     }
     return ret;
+}
+
+esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t* const interrupt_configuration)
+{
+    return ESP_FAIL;
+}
+
+esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr)
+{
+    return ESP_FAIL;
+}
+
+esp_err_t mpu6050_enable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources)
+{
+    return ESP_FAIL;
+}
+
+esp_err_t mpu6050_disable_interrupts(mpu6050_handle_t sensor, uint8_t interrupt_sources)
+{
+    return ESP_FAIL;
+}
+
+uint8_t mpu6050_is_data_ready_interrupt(uint8_t interrupt_status)
+{
+    return 0x00u;
+}
+
+uint8_t mpu6050_is_i2c_master_interrupt(uint8_t interrupt_status)
+{
+    return 0x00u;
+}
+
+uint8_t mpu6050_is_fifo_overflow_interrupt(uint8_t interrupt_status)
+{
+    return 0x00u;
 }
 
 esp_err_t mpu6050_get_raw_acce(mpu6050_handle_t sensor, mpu6050_raw_acce_value_t *const raw_acce_value)

--- a/components/mpu6050/mpu6050.c
+++ b/components/mpu6050/mpu6050.c
@@ -202,18 +202,17 @@ esp_err_t mpu6050_get_gyro_sensitivity(mpu6050_handle_t sensor, float *const gyr
     return ret;
 }
 
-esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t* const interrupt_configuration)
+esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_config_t *const interrupt_configuration)
 {
     esp_err_t ret = ESP_OK;
 
-    if (NULL == interrupt_configuration)
-    {
+    if (NULL == interrupt_configuration) {
         ret = ESP_ERR_INVALID_ARG;
         return ret;
     }
 
     if (GPIO_IS_VALID_GPIO(interrupt_configuration->interrupt_pin)) {
-        // Set GPIO connected to MPU6050 INT pin only when user configures interrupts. 
+        // Set GPIO connected to MPU6050 INT pin only when user configures interrupts.
         mpu6050_dev_t *sensor_device = (mpu6050_dev_t *) sensor;
         sensor_device->int_pin = interrupt_configuration->interrupt_pin;
     } else {
@@ -252,7 +251,7 @@ esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_c
     }
 
     gpio_int_type_t gpio_intr_type;
-    
+
     if (INTERRUPT_PIN_ACTIVE_LOW == interrupt_configuration->active_level) {
         gpio_intr_type = GPIO_INTR_NEGEDGE;
     } else {
@@ -262,7 +261,7 @@ esp_err_t mpu6050_config_interrupts(mpu6050_handle_t sensor, const mpu6050_int_c
     gpio_config_t int_gpio_config = {
         .mode = GPIO_MODE_INPUT,
         .intr_type = gpio_intr_type,
-        .pin_bit_mask = (BIT0 << interrupt_configuration->interrupt_pin) 
+        .pin_bit_mask = (BIT0 << interrupt_configuration->interrupt_pin)
     };
 
     ret = gpio_config(&int_gpio_config);
@@ -281,10 +280,10 @@ esp_err_t mpu6050_register_isr(mpu6050_handle_t sensor, const mpu6050_isr_t isr)
     }
 
     ret = gpio_isr_handler_add(
-        sensor_device->int_pin,
-        ((gpio_isr_t) *(isr)), 
-        ((void *) sensor)
-    );
+              sensor_device->int_pin,
+              ((gpio_isr_t) * (isr)),
+              ((void *) sensor)
+          );
 
     if (ESP_OK != ret) {
         return ret;


### PR DESCRIPTION
# Change description

- Include new functions to setup and enable interrupts produced by the MPU6050 on different events (mainly `DATA_READY` at the moment, see notes below).
- Add new definitions for registers, types and enumerations used to configure and handle interrupts triggered by the MPU6050.
- Update component README.md with more information about the sensor, mention ISR support and add links to the register map and the sensors example.

# Notes
Since the driver does not yet support FiFo or I2C sensor slaves, interrupts by `FIFO_OVERFLOW` and `I2C_MST_INT` are not produced by the MPU6050. If necessary, these driver features could be implemented in the future. 

I decided not to include `MOTION_DETECT` interrupt support yet, because there is conflicting information on this feature from different MPU6050 register map and datasheet revisions.

Closes #109 
