### PR TITLE
Build examples for multiple BSPs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,8 @@
-# Checklist for new Board Support package or Component
+# ESP-BSP Pull Request checklist
 
-- [ ] Component contains License
-- [ ] Component contains README.md
-- [ ] Project [README.md](../README.md) updated
-- [ ] Component contains idf_component.yml file with `url` field defined
-- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
-- [ ] New files were added to CI build job
-- [ ] _Optional:_ Component contains unit tests
+> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
+
+- [ ] Version of modified component bumped
 - [ ] CI passing
 
 # Change description

--- a/.github/PULL_REQUEST_TEMPLATE/pr_template_bsp.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template_bsp.md
@@ -1,0 +1,14 @@
+# Checklist for new Board Support package or Component
+
+- [ ] Component contains License
+- [ ] Component contains README.md
+- [ ] Project [README.md](../README.md) updated
+- [ ] Component contains idf_component.yml file with `url` field defined
+- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
+- [ ] New files were added to CI build job
+- [ ] New BSP definitions added to [build_example_for_all_bsps.sh](./build_example_for_all_bsps.sh) and to [bsp_ext.py](../examples/bsp_ext.py)
+- [ ] _Optional:_ Component contains unit tests
+- [ ] CI passing
+
+# Change description
+_Please describe your change here_

--- a/.github/build_example_for_all_bsps.sh
+++ b/.github/build_example_for_all_bsps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+# BSP dictionary. README strings -> component names
+# Don't forget to update this variable and examples/bsp_ext.py when adding new BSP
+declare -A bsp_dictionary
+bsp_dictionary['Wrover kit']='esp_wrover_kit'
+bsp_dictionary['ESP-BOX']='esp-box'
+bsp_dictionary['Azure IoT kit']='esp32_azure_iot_kit'
+bsp_dictionary['Kaluga kit']='esp32_s2_kaluga_kit'
+bsp_dictionary['ESP32-S3-EYE']='esp32_s3_eye'
+bsp_dictionary['ESP32-S3-USB-OTG']='esp32_s3_usb_otg'
+bsp_dictionary['ESP32-S3-LCD-EV-BOARD']='esp32_s3_lcd_ev_board'
+bsp_dictionary['ESP32-S3-Korvo-2']='esp32_s3_korvo_2'
+
+# Read supported BSPs line from README
+bsp_line=$(head -n 1 README.md)
+
+# Find supported BSPs
+declare -a supported_bsps=()
+echo "Detected supported BSPs for $1:"
+for key in "${!bsp_dictionary[@]}"; do
+  if [[ "$bsp_line" == *"$key"* ]]; then
+    supported_bsps+=("${bsp_dictionary[$key]}")
+    echo "${bsp_dictionary[$key]}"
+  fi
+done
+
+# Build example for all supported BSPs
+for bsp in ${supported_bsps[@]}; do
+  echo "Building $1 for $bsp"
+  idf.py set-bsp $bsp
+  idf.py -B build_$bsp build
+done

--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -5,9 +5,23 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  build:
+  examples_list:
+    name: List all BSP examples
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(ls -d examples/*/ | jq -R -s -c 'split("\n")[:-1]')"
+
+  examples_build:
+    name: Build
+    needs: examples_list
     strategy:
+      fail-fast: false
       matrix:
+        example: ${{ fromJson(needs.examples_list.outputs.matrix) }}
         idf_ver: ["latest"]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
@@ -15,14 +29,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: Build ESP-BSP examples
+      - name: Build ESP-BSP ${{ matrix.example }} with IDF-${{ matrix.idf_ver }}
+        working-directory: '${{ matrix.example }}'
         shell: bash
+        env:
+          IDF_EXTRA_ACTIONS_PATH: ../
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager --upgrade
-          cd examples
-          for d in */; do
-            pushd $d
-            idf.py build
-            popd
-          done
+          pip install idf-component-manager ruamel.yaml --upgrade
+          chmod +x ${GITHUB_WORKSPACE}/.github/build_example_for_all_bsps.sh
+          ${GITHUB_WORKSPACE}/.github/build_example_for_all_bsps.sh ${{ matrix.example }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,6 +3,10 @@ name: Build Test Application
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - 'components/**'
+      - 'test_app/**'
+      - '.github/workflows/build_test.yml'
 
 jobs:
   build:
@@ -20,9 +24,9 @@ jobs:
       - name: Build ESP-BSP Test Application
         env:
           IDF_TARGET: ${{ matrix.idf_target }}
+        working-directory: test_app
         shell: bash
         run: |
-          cd test_app
           . ${IDF_PATH}/export.sh
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When you want to use a BSP in a real project, it is highly recommended to disabl
 ESP-IDF v5.0 brings a lot of new features, but, as the bump in major version suggests, also a lot of breaking changes.
 
 ESP-BSP is kept up-to-date with the latest ESP-IDF version, but some breaking changes in ESP-BSP API are inevitable.
-Usually, BSPs compatible with IDF v5.0 are version 2. If you want to use BSP with IDF v4.4 you can still use version 1 of the particular BSP.
+Usually, BSPs compatible with IDF v5.0 are version 2. If you want to use BSP with IDF v4.4 you can still use version 1 of the particular BSP. If you are interested in BSP examples for IDF v4.4, you can git checkout tag `examples_v4.4`.
 
 More information about ESP-IDF breaking changes can be found in the [official migration guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/index.html).
 
@@ -70,6 +70,18 @@ More information about ESP-IDF breaking changes can be found in the [official mi
 More information about idf-component-manager can be found in [Espressif API guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html)
 or [PyPi registry](https://pypi.org/project/idf-component-manager/).
 
+### Compiling project for multiple BSPs
+
+> :warning: **Experimental feature**: This feature is under development!
+
+A single project can be run on multiple different development boards, if the boards contain the features required by the project (such as audio, display, camera...).
+For this purpose, `idf.py` is extended by [examples/bsp_ext.py](examples/bsp_ext.py) which allows you to set a BSP for your project by running following command e.g.:
+```
+idf.py set-bsp esp_wrover_kit
+```
+You can find more information about idf.py extensions [here](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/README.md).
+
+> Note: This feature is not yet integrated to idf.py by default. If you want to use it, you must set your environmental variable `IDF_EXTRA_ACTIONS_PATH` to path to your `bsp_ext.py`.
 ## Contributing to ESP-BSP
 
 Please check [CONTRIBUTING.md](CONTRIBUTING.md) if you'd like to contribute to ESP-BSP.

--- a/examples/bsp_ext.py
+++ b/examples/bsp_ext.py
@@ -1,0 +1,63 @@
+import os
+from pathlib import Path
+
+
+def action_extensions(base_actions, project_path=os.getcwd()):
+    """ Describes extension for Board Support Packages. """
+
+    try:
+        import ruamel.yaml
+    except ImportError:
+        print("!! ruamel.yaml package is not installed. No BSP extension is added !!")
+        return -1
+
+    def bsp_short_name(bsp):
+        return bsp.split('/')[-1]
+
+    def set_bsp_callback(action: str, ctx, args, **kwargs: str) -> None:
+        yaml = ruamel.yaml.YAML()
+        # List of supported BSPs and their targets
+        # Don't forget to update this dictionary and build_example_for_all_bsps.sh when adding new BSP
+        bsps = {
+            'esp_wrover_kit'       : 'esp32',
+            'esp32_azure_iot_kit'  : 'esp32',
+            'esp32_s2_kaluga_kit'  : 'esp32s2',
+            'esp32_s3_eye'         : 'esp32s3',
+            'esp32_s3_lcd_ev_board': 'esp32s3',
+            'esp32_s3_usb_otg'     : 'esp32s3',
+            'esp-box'              : 'esp32s3',
+            'esp32_s3_korvo_2'     : 'esp32s3',
+            }
+        manifest_path  = Path(project_path) / 'main' / 'idf_component.yml'
+        manifest = yaml.load(manifest_path)
+
+        # Remove all BSPs
+        for dep in list(manifest['dependencies']):
+            if bsp_short_name(dep) in bsps:
+                del manifest['dependencies'][dep]
+
+        # Add one we need
+        manifest['dependencies'].insert(0, kwargs['bsp'], {'version': '*', 'override_path': ('../../../' + bsp_short_name(kwargs['bsp']))})
+        yaml.dump(manifest, manifest_path)
+
+        # Set-target according to the BSP
+        base_actions['actions']['set-target']['callback']('set-target', ctx, args, bsps[bsp_short_name(kwargs['bsp'])] )
+
+    extensions = {
+        'actions': {
+            'set-bsp': {
+                'callback': set_bsp_callback,
+                'help': 'Utility to set Board Support Package for a project.',
+                'options': [],
+                'order_dependencies': [],
+                'arguments': [
+                    {
+                        'names': ['bsp'],
+                        'required': True,
+                    },
+                ],
+            },
+        },
+    }
+
+    return extensions

--- a/examples/display/README.md
+++ b/examples/display/README.md
@@ -1,5 +1,5 @@
-| Supported Boards | Wrover kit |
-| ---------------- | ---------- |
+| Supported Boards | Wrover kit | ESP-BOX | Kaluga kit | ESP32-S3-EYE | ESP32-S3-USB-OTG | ESP32-S3-LCD-EV-BOARD |
+| ---------------- | ---------- | ------- | ---------- | ------------ | ---------------- | --------------------- |
 
 # BSP: Display example
 

--- a/examples/display_audio_photo/README.md
+++ b/examples/display_audio_photo/README.md
@@ -1,5 +1,5 @@
-| Supported Targets | ESP-BOX (ESP32-S3) |
-| ----------------- | ------------------ |
+| Supported Targets | ESP-BOX (ESP32-S3) | ESP32-S3-LCD-EV-BOARD | ESP32-S3-Korvo-2 |
+| ----------------- | ------------------ | --------------------- | ---------------- |
 
 # ESP-BOX Display Audio Photo Example
 

--- a/examples/display_audio_photo/main/CMakeLists.txt
+++ b/examples/display_audio_photo/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "bsp_espbox_disp_example.c" "app_disp_fs.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "spiffs" "vfs" "es8311" "esp_jpeg")
+                    REQUIRES "spiffs" "vfs")

--- a/examples/display_camera/README.md
+++ b/examples/display_camera/README.md
@@ -1,5 +1,5 @@
-| Supported Targets | Kaluga-kit (ESP32-S2) |
-| ----------------- | --------------------- |
+| Supported Targets | ESP32-S3-EYE | ESP32-S3-Korvo-2 | Kaluga kit (ESP32-S2) |
+| ----------------- | ------------ | ---------------- | --------------------- |
 
 # Display + camera example
 
@@ -7,9 +7,9 @@ This example shows how you can obtain frames from camera a display them on LCD.
 
 By default, the camera interface has following settings:
 * Double-buffering (1 frame is being flushed onto the display, while another one is being fetched from the camera)
-* Frames in external PSRAM: ESP32-S2 has limited internal RAM, so frames from camera are saved to external RAM.
+* Frames in external PSRAM: to save internal RAM, frames from camera are saved to external RAM.
 * EDMA is used for transferring data from camera to the PSRAM
-* RGB565 color and QVFGA definition. We use the same image parameters as the display has, so we don't have to convert image formats between camera and the display.
+* RGB565 color and definition same as display. We use the same image parameters as the display has, so we don't have to convert image formats between camera and the display.
 
 This very simple example continuously fetches image frames from camera and displays them on LCD using LVGL's canvas widget.
 

--- a/examples/display_camera/main/idf_component.yml
+++ b/examples/display_camera/main/idf_component.yml
@@ -2,6 +2,6 @@ description: BSP Display and camera example
 
 dependencies:
   idf: ">=4.4"
-  esp32_s2_kaluga_kit:
+  esp32_s3_korvo_2:
     version: "*"
-    override_path: "../../../esp32_s2_kaluga_kit"
+    override_path: "../../../esp32_s3_korvo_2"

--- a/examples/display_camera/sdkconfig.defaults
+++ b/examples/display_camera/sdkconfig.defaults
@@ -1,7 +1,7 @@
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #
-CONFIG_IDF_TARGET="esp32s2"
+CONFIG_IDF_TARGET="esp32s3"
 CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
 CONFIG_SPIRAM=y
 CONFIG_SPIRAM_SPEED_80M=y

--- a/examples/display_lvgl_demos/README.md
+++ b/examples/display_lvgl_demos/README.md
@@ -1,5 +1,5 @@
-| Supported Targets | ESP32-S3-LCD-EV-BOARD |
-| ----------------- | --------------------- |
+| Supported Boards | ESP-BOX | Kaluga kit | ESP32-S3-EYE | ESP32-S3-LCD-EV-BOARD |
+| ---------------- | ------- | ---------- | ------------ | --------------------- |
 
 # Display LVGL Demos
 

--- a/examples/display_rotation/README.md
+++ b/examples/display_rotation/README.md
@@ -1,5 +1,5 @@
-| Supported Targets | ESP-BOX (ESP32-S3) |
-| ----------------- | ------------------ |
+| Supported Targets | ESP-BOX (ESP32-S3) | ESP32-S3-LCD-EV-BOARD | ESP32-S3-Korvo-2 |
+| ----------------- | ------------------ | --------------------- | ---------------- |
 
 # ESP-BOX Display Rotation Example
 

--- a/examples/touchscreen_colorwheel/README.md
+++ b/examples/touchscreen_colorwheel/README.md
@@ -1,5 +1,5 @@
-| Supported Targets | ESP-BOX (ESP32-S3) |
-| ----------------- | ------------------ |
+| Supported Targets | ESP-BOX (ESP32-S3) | ESP32-S3-LCD-EV-BOARD | ESP32-S3-Korvo-2 |
+| ----------------- | ------------------ | --------------------- | ---------------- |
 
 # ESP-BOX Touch Screen Color Wheel Example
 


### PR DESCRIPTION
# TODOs:

- [x] Project [README.md](../README.md) updated
- [x] CI passing

# Change description

Many examples in this repo should be able to run on multiple BSPs. Add this option to READMEs and CI tests

There are 3 major changes
1. `idf.py` command is extended with a check, that allows only 1 BSP to be in the project's dependencis (changes in `bsp_ext.py`)
2. The CI reads supported BSPs for the given example from its README.md and builds the example for all the BSPS (changes in `build_all_examples.sh`)
3. Examples are build in parallel, to speed up the process (changes in `build_example.yml`)

Currently, only the following examples can be build for multiple BSPs:
* display
* display_camera
* display_lvgl_demos
* display_rotation
* display_audio_photo
* touchscreen_colorwheel

The following examples support only one board:
* mqtt_example: requires sensors present only on Azure kit
* sensors_example: requires sensors present only on Azure kit
* display_audio: requires buttons interface present only on Kaluga kit

**Point for discussion:**
How do we ensure that the example really works with all the supported BSPs?

Closes #30 
