### PR TITLE
bsp: Added LCD support into ESP32-S3-Korvo-2 Board Support Package

### DIFF
--- a/esp32_s3_korvo_2/Kconfig
+++ b/esp32_s3_korvo_2/Kconfig
@@ -5,7 +5,7 @@ menu "Board Support Package"
         default y
         help
             Error check assert the application before returning the error code.
-            
+
     menu "I2C"
         config BSP_I2C_NUM
             int "I2C peripheral index"
@@ -25,7 +25,7 @@ menu "Board Support Package"
             default 400000 if BSP_I2C_FAST_MODE
             default 100000
     endmenu
-    
+
     menu "uSD card - Virtual File System"
         config BSP_SD_FORMAT_ON_MOUNT_FAIL
             bool "Format uSD card if mounting fails"
@@ -41,29 +41,6 @@ menu "Board Support Package"
 
     endmenu
 
-    menu "Display"
-        config BSP_DISPLAY_LVGL_TASK_PRIORITY
-            int "LVGL task priority"
-            default 2
-            help
-                The Board Support Package will create a task that will periodically handle LVGL operation in lv_timer_handler().
-
-        config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
-        int "LEDC channel index"
-        default 1
-        range 0 7
-        help
-            LEDC channel is used to generate PWM signal that controls display brightness.
-            Set LEDC index that should be used.
-
-        config BSP_DISPLAY_LVGL_TICK
-        int "LVGL tick period"
-        default 5
-        range 1 100
-        help
-            Period of LVGL tick timer.
-    endmenu
-    
     config BSP_I2S_NUM
         int "I2S peripheral index"
         default 1

--- a/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -19,29 +19,23 @@
 //#include "esp_adc/adc_cali_scheme.h"
 
 #include "bsp/esp32_s3_korvo_2.h"
+#include "esp_lcd_ili9341.h"
 #include "esp_io_expander_tca9554.h"
 #include "esp_lcd_touch_tt21100.h"
+#include "esp_lvgl_port.h"
 #include "esp_vfs_fat.h"
-#include "lvgl.h"
 #include "bsp_err_check.h"
 
-/* Display is not tested yet, because HW is not in stock. */
-#define BSP_DISPLAY_ENABLED 0
 /* Battery voltage measurement is disabled, because it waits for update button component. */
 #define BSP_BATTERY_ENABLED 0
 
 static const char *TAG = "S3-KORVO-2";
 
-#if BSP_DISPLAY_ENABLED
-static lv_disp_draw_buf_t disp_buf; // Contains internal graphic buffer(s) called draw buffer(s)
-static lv_disp_drv_t disp_drv;      // Contains callback functions
-static esp_lcd_touch_handle_t tp;   // LCD touch handle
-static SemaphoreHandle_t lvgl_mux;  // LVGL mutex
-#endif
 static esp_io_expander_handle_t io_expander = NULL; // IO expander tca9554 handle
 //static adc_oneshot_unit_handle_t adc1_handle; // ADC1 handle; for USB voltage measurement
 //static adc_cali_handle_t adc1_cali_handle; // ADC1 calibration handle
 sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
+static esp_lcd_touch_handle_t tp;   // LCD touch handle
 
 const button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
     {
@@ -157,7 +151,7 @@ esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config, i2s_chan_handle_t *
     BSP_ERROR_CHECK_RETURN_ERR(i2s_new_channel(&chan_cfg, tx_channel, rx_channel));
 
     /* Setup I2S channels */
-    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_STEREO_CFG(22050);
+    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
     const i2s_std_config_t *p_i2s_cfg = &std_cfg_default;
     if (i2s_config != NULL) {
         p_i2s_cfg = i2s_config;
@@ -203,131 +197,11 @@ esp_io_expander_handle_t bsp_io_expander_init(void)
     return io_expander;
 }
 
-
-#if BSP_DISPLAY_ENABLED
-
 // Bit number used to represent command and parameter
 #define LCD_CMD_BITS           8
 #define LCD_PARAM_BITS         8
-#define LVGL_TICK_PERIOD_MS    CONFIG_BSP_DISPLAY_LVGL_TICK
-#define LCD_LEDC_CH            CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
 
-static void bsp_touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
-{
-    esp_lcd_touch_handle_t tp = (esp_lcd_touch_handle_t) indev_drv->user_data;
-    uint16_t touchpad_x[1] = {0};
-    uint16_t touchpad_y[1] = {0};
-    uint8_t touchpad_cnt = 0;
-
-    assert(tp);
-
-
-    /* Read data from touch controller into memory */
-    esp_lcd_touch_read_data(tp);
-
-    /* Read data from touch controller */
-    bool touchpad_pressed = esp_lcd_touch_get_coordinates(tp, touchpad_x, touchpad_y, NULL, &touchpad_cnt, 1);
-
-    if (touchpad_pressed && touchpad_cnt > 0) {
-        data->point.x = touchpad_x[0];
-        data->point.y = touchpad_y[0];
-        data->state = LV_INDEV_STATE_PRESSED;
-    } else {
-        data->state = LV_INDEV_STATE_RELEASED;
-    }
-}
-
-static bool lvgl_port_flush_ready(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata, void *user_ctx)
-{
-    lv_disp_drv_t *disp_driver = (lv_disp_drv_t *)user_ctx;
-    lv_disp_flush_ready(disp_driver);
-    return false;
-}
-
-static void lvgl_port_flush_callback(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map)
-{
-    esp_lcd_panel_handle_t panel_handle = (esp_lcd_panel_handle_t) drv->user_data;
-    const int offsetx1 = area->x1;
-    const int offsetx2 = area->x2;
-    const int offsety1 = area->y1;
-    const int offsety2 = area->y2;
-    // copy a buffer's content to a specific area of the display
-    esp_lcd_panel_draw_bitmap(panel_handle, offsetx1, offsety1, offsetx2 + 1, offsety2 + 1, color_map);
-}
-
-static void lvgl_port_update_callback(lv_disp_drv_t *drv)
-{
-    esp_lcd_panel_handle_t panel_handle = (esp_lcd_panel_handle_t) drv->user_data;
-
-    switch (drv->rotated) {
-    case LV_DISP_ROT_NONE:
-        // Rotate LCD display
-        esp_lcd_panel_swap_xy(panel_handle, false);
-        esp_lcd_panel_mirror(panel_handle, true, true);
-        // Rotate LCD touch
-        esp_lcd_touch_set_mirror_y(tp, false);
-        esp_lcd_touch_set_mirror_x(tp, true);
-        break;
-    case LV_DISP_ROT_90:
-        // Rotate LCD display
-        esp_lcd_panel_swap_xy(panel_handle, true);
-        esp_lcd_panel_mirror(panel_handle, true, false);
-        // Rotate LCD touch
-        esp_lcd_touch_set_mirror_y(tp, false);
-        esp_lcd_touch_set_mirror_x(tp, true);
-        break;
-    case LV_DISP_ROT_180:
-        // Rotate LCD display
-        esp_lcd_panel_swap_xy(panel_handle, false);
-        esp_lcd_panel_mirror(panel_handle, false, false);
-        // Rotate LCD touch
-        esp_lcd_touch_set_mirror_y(tp, false);
-        esp_lcd_touch_set_mirror_x(tp, true);
-        break;
-    case LV_DISP_ROT_270:
-        // Rotate LCD display
-        esp_lcd_panel_swap_xy(panel_handle, true);
-        esp_lcd_panel_mirror(panel_handle, false, true);
-        // Rotate LCD touch
-        esp_lcd_touch_set_mirror_y(tp, false);
-        esp_lcd_touch_set_mirror_x(tp, true);
-        break;
-    }
-}
-
-static void lvgl_port_tick_increment(void *arg)
-{
-    /* Tell LVGL how many milliseconds have elapsed */
-    lv_tick_inc(LVGL_TICK_PERIOD_MS);
-}
-
-static esp_err_t lvgl_port_tick_init(void)
-{
-    // Tick interface for LVGL (using esp_timer to generate 2ms periodic event)
-    const esp_timer_create_args_t lvgl_tick_timer_args = {
-        .callback = &lvgl_port_tick_increment,
-        .name = "LVGL tick"
-    };
-    esp_timer_handle_t lvgl_tick_timer = NULL;
-    BSP_ERROR_CHECK_RETURN_ERR(esp_timer_create(&lvgl_tick_timer_args, &lvgl_tick_timer));
-    return esp_timer_start_periodic(lvgl_tick_timer, LVGL_TICK_PERIOD_MS * 1000);
-}
-
-static void lvgl_port_task(void *arg)
-{
-    ESP_LOGI(TAG, "Starting LVGL task");
-    while (1) {
-        bsp_display_lock(0);
-        uint32_t task_delay_ms = lv_timer_handler();
-        bsp_display_unlock();
-        if (task_delay_ms > 500) {
-            task_delay_ms = 500;
-        }
-        vTaskDelay(pdMS_TO_TICKS(task_delay_ms));
-    }
-}
-
-static lv_disp_t *lvgl_port_display_init(void)
+static lv_disp_t *bsp_display_lcd_init(void)
 {
     BSP_NULL_CHECK(bsp_io_expander_init(), NULL);
     BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_dir(io_expander, BSP_LCD_IO_CS, IO_EXPANDER_OUTPUT));
@@ -356,71 +230,59 @@ static lv_disp_t *lvgl_port_display_init(void)
         .lcd_param_bits = LCD_PARAM_BITS,
         .spi_mode = 0,
         .trans_queue_depth = 10,
-        .on_color_trans_done = lvgl_port_flush_ready,
-        .user_ctx = &disp_drv,
     };
+
     // Attach the LCD to the SPI bus
     BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, &io_handle));
 
-    ESP_LOGD(TAG, "Install LCD driver of st7789");
+    ESP_LOGD(TAG, "Install LCD driver of ILI9341");
     esp_lcd_panel_handle_t panel_handle = NULL;
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST, // Shared with Touch reset
         .color_space = ESP_LCD_COLOR_SPACE_BGR,
         .bits_per_pixel = 16,
     };
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_ili9341(io_handle, &panel_config, &panel_handle));
 
     // Reset LCD
-    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LCD_IO_RST, 1));
-    vTaskDelay(pdMS_TO_TICKS(10));
     BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LCD_IO_RST, 0));
+    vTaskDelay(pdMS_TO_TICKS(10));
+    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LCD_IO_RST, 1));
     vTaskDelay(pdMS_TO_TICKS(10));
 
     // Enable display
-    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LCD_IO_CS, 1));
+    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LCD_IO_CS, 0));
 
     esp_lcd_panel_init(panel_handle);
     esp_lcd_panel_mirror(panel_handle, true, true);
     esp_lcd_panel_disp_on_off(panel_handle, true);
 
-    // alloc draw buffers used by LVGL
-    // it's recommended to choose the size of the draw buffer(s) to be at least 1/10 screen sized
-    lv_color_t *buf1 = heap_caps_malloc(BSP_LCD_H_RES * 50 * sizeof(lv_color_t), MALLOC_CAP_DMA);
-    BSP_NULL_CHECK(buf1, NULL);
-    lv_color_t *buf2 = heap_caps_malloc(BSP_LCD_H_RES * 50 * sizeof(lv_color_t), MALLOC_CAP_DMA);
-    BSP_NULL_CHECK_GOTO(buf2, ERR);
-    // initialize LVGL draw buffers
-    lv_disp_draw_buf_init(&disp_buf, buf1, buf2, BSP_LCD_H_RES * 50);
+    /* Add LCD screen */
+    ESP_LOGD(TAG, "Add LCD screen");
+    const lvgl_port_display_cfg_t disp_cfg = {
+        .io_handle = io_handle,
+        .panel_handle = panel_handle,
+        .buffer_size = BSP_LCD_H_RES * 50,
+        .double_buffer = true,
+        .hres = BSP_LCD_H_RES,
+        .vres = BSP_LCD_V_RES,
+        .monochrome = false,
+        /* Rotation values must be same as used in esp_lcd for initial settings of the screen */
+        .rotation = {
+            .swap_xy = false,
+            .mirror_x = true,
+            .mirror_y = true,
+        },
+        .flags = {
+            .buff_dma = true,
+        }
+    };
 
-    ESP_LOGD(TAG, "Register display driver to LVGL");
-    lv_disp_drv_init(&disp_drv);
-    disp_drv.hor_res = BSP_LCD_H_RES;
-    disp_drv.ver_res = BSP_LCD_V_RES;
-    disp_drv.flush_cb = lvgl_port_flush_callback;
-    disp_drv.drv_update_cb = lvgl_port_update_callback;
-    disp_drv.draw_buf = &disp_buf;
-    disp_drv.user_data = panel_handle;
-    return lv_disp_drv_register(&disp_drv);
-
-#if (!CONFIG_BSP_ERROR_CHECK)
-ERR:
-    if (buf1) {
-        free(buf1);
-    }
-    if (buf2) {
-        free(buf2);
-    }
-
-    return NULL;
-#endif
+    return lvgl_port_add_disp(&disp_cfg);
 }
 
-static esp_err_t lvgl_port_indev_init(void)
+static lv_indev_t *bsp_display_indev_init(lv_disp_t *disp)
 {
-    static lv_indev_drv_t indev_drv_tp;
-    lv_indev_t *indev_touchpad;
-
     /* Initialize touch */
     const esp_lcd_touch_config_t tp_cfg = {
         .x_max = BSP_LCD_H_RES,
@@ -439,21 +301,18 @@ static esp_err_t lvgl_port_indev_init(void)
     };
     esp_lcd_panel_io_handle_t tp_io_handle = NULL;
     const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_TT21100_CONFIG();
-    BSP_ERROR_CHECK_RETURN_ERR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle));
-    BSP_ERROR_CHECK_RETURN_ERR(esp_lcd_touch_new_i2c_tt21100(tp_io_handle, &tp_cfg, &tp));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_touch_new_i2c_tt21100(tp_io_handle, &tp_cfg, &tp));
     assert(tp);
 
-    /* Register a touchpad input device */
-    lv_indev_drv_init(&indev_drv_tp);
-    indev_drv_tp.type = LV_INDEV_TYPE_POINTER;
-    indev_drv_tp.read_cb = bsp_touchpad_read;
-    indev_drv_tp.user_data = tp;
-    indev_touchpad = lv_indev_drv_register(&indev_drv_tp);
-    BSP_NULL_CHECK(indev_touchpad, ESP_ERR_NO_MEM);
+    /* Add touch input (for selected screen) */
+    const lvgl_port_touch_cfg_t touch_cfg = {
+        .disp = disp,
+        .handle = tp,
+    };
 
-    return ESP_OK;
+    return lvgl_port_add_touch(&touch_cfg);
 }
-#endif //BSP_DISPLAY_ENABLED
 
 esp_err_t bsp_display_brightness_set(int brightness_percent)
 {
@@ -473,48 +332,30 @@ esp_err_t bsp_display_backlight_on(void)
 
 lv_disp_t *bsp_display_start(void)
 {
-#if BSP_DISPLAY_ENABLED
-    lv_init();
-    lv_disp_t *disp = lvgl_port_display_init();
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_indev_init());
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_tick_init());
-    lvgl_mux = xSemaphoreCreateMutex();
-    BSP_NULL_CHECK(lvgl_mux, NULL);
-    xTaskCreate(lvgl_port_task, "LVGL task", 4096, NULL, CONFIG_BSP_DISPLAY_LVGL_TASK_PRIORITY, NULL);
+    lv_disp_t *disp = NULL;
+    const lvgl_port_cfg_t lvgl_cfg = ESP_LVGL_PORT_INIT_CONFIG();
+    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&lvgl_cfg));
+
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
+
+    BSP_NULL_CHECK(bsp_display_indev_init(disp), NULL);
+
     return disp;
-#else
-    ESP_LOGW(TAG, "Display is disabled, because it is not tested yet!");
-    return NULL;
-#endif
 }
 
 void bsp_display_rotate(lv_disp_t *disp, lv_disp_rot_t rotation)
 {
-#if BSP_DISPLAY_ENABLED
     lv_disp_set_rotation(disp, rotation);
-#else
-    ESP_LOGW(TAG, "Display is disabled, because it is not tested yet!");
-#endif
 }
 
 bool bsp_display_lock(uint32_t timeout_ms)
 {
-#if BSP_DISPLAY_ENABLED
-    assert(lvgl_mux && "bsp_display_start must be called first");
-
-    const TickType_t timeout_ticks = (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
-    return xSemaphoreTake(lvgl_mux, timeout_ticks) == pdTRUE;
-#else
-    return pdFALSE;
-#endif
+    return lvgl_port_lock(timeout_ms);
 }
 
 void bsp_display_unlock(void)
 {
-#if BSP_DISPLAY_ENABLED
-    assert(lvgl_mux && "bsp_display_start must be called first");
-    xSemaphoreGive(lvgl_mux);
-#endif
+    lvgl_port_unlock();
 }
 
 esp_err_t bsp_voltage_init(void)
@@ -576,4 +417,27 @@ esp_err_t bsp_led_set(const bsp_led_t led_io, const bool on)
 {
     BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, led_io, !on));
     return ESP_OK;
+}
+
+esp_err_t bsp_button_init(const bsp_button_t btn)
+{
+    return ESP_OK;
+}
+
+bool bsp_button_get(const bsp_button_t btn)
+{
+    if (btn == BSP_BUTTON_MAIN) {
+#if (CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS > 0)
+        uint8_t home_btn_val = 0x00;
+        assert(tp);
+
+        esp_lcd_touch_get_button_state(tp, 0, &home_btn_val);
+        return home_btn_val ? true : false;
+#else
+        ESP_LOGE(TAG, "Button main is inaccessible");
+        return false;
+#endif
+    }
+
+    return false;
 }

--- a/esp32_s3_korvo_2/idf_component.yml
+++ b/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "1.0.0"
 description: Board Support Package for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_korvo_2
 
@@ -7,8 +7,12 @@ targets:
 
 dependencies:
   idf: ">=5.0"
+  esp_lcd_ili9341: "^1"
   esp_lcd_touch_tt21100: "^1"
-  esp_io_expander_tca9554: "^1"
+
+  esp_io_expander_tca9554:
+    version: "^1"
+    public: true
 
   es7210:
     version: "^1"
@@ -26,6 +30,6 @@ dependencies:
     version: "^2"
     public: true
 
-  lvgl/lvgl:
-    version: "^8"
+  esp_lvgl_port:
+    version: ^1
     public: true

--- a/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -92,7 +92,8 @@ extern "C" {
  * \endcode
  **************************************************************************************************/
 typedef enum {
-    BSP_BUTTON_REC = 0,
+    BSP_BUTTON_MAIN = 0,
+    BSP_BUTTON_REC,
     BSP_BUTTON_MUTE,
     BSP_BUTTON_PLAY,
     BSP_BUTTON_SET,
@@ -451,6 +452,34 @@ esp_err_t bsp_display_backlight_off(void);
  * @param[in] rotation Angle of the display rotation
  */
 void bsp_display_rotate(lv_disp_t *disp, lv_disp_rot_t rotation);
+
+/**************************************************************************************************
+ *
+ * Button
+ *
+ **************************************************************************************************/
+
+/**
+ * @brief Set button's GPIO as input
+ *
+ * @param[in] btn Button to be initialized
+ * @return
+ *     - ESP_OK Success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ */
+esp_err_t bsp_button_init(const bsp_button_t btn);
+
+/**
+ * @brief Get button's state
+ *
+ * Note: For LCD panel button which is defined as BSP_BUTTON_MAIN, bsp_display_start should
+ *       be called before call this function.
+ *
+ * @param[in] btn Button to read
+ * @return true  Button pressed
+ * @return false Button released
+ */
+bool bsp_button_get(const bsp_button_t btn);
 
 /**************************************************************************************************
  *

--- a/esp32_s3_korvo_2/priv_include/bsp_err_check.h
+++ b/esp32_s3_korvo_2/priv_include/bsp_err_check.h
@@ -46,6 +46,12 @@ extern "C" {
         }                                 \
     } while(0)
 
+#define BSP_NULL_CHECK(x, ret) do { \
+        if ((x) == NULL) {          \
+            return ret;             \
+        }                           \
+    } while(0)
+
 #define BSP_NULL_CHECK_GOTO(x, goto_tag) do { \
         if ((x) == NULL) {      \
             goto goto_tag;      \

--- a/examples/display_audio_photo/main/CMakeLists.txt
+++ b/examples/display_audio_photo/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "bsp_espbox_disp_example.c" "app_disp_fs.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "esp-box" "spiffs" "vfs" "es8311" "esp_jpeg")
+                    REQUIRES "spiffs" "vfs" "es8311" "esp_jpeg")


### PR DESCRIPTION
Added LCD support into Korvo-2 BSP. 
I decided change the audio settings back to mono. 

Tested with:
- display_rotation
- display_camera
- display_audio_photo
