### PR TITLE
esp_lvgl_port: Add maximum time in ms for sleep LVGL task.

### DIFF
--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -30,7 +30,8 @@ extern "C" {
 typedef struct {
     int task_priority;      /*!< LVGL task priority */
     int task_stack;         /*!< LVGL task stack size */
-    int task_affinity;        /*!< LVGL task pinned to core (-1 is no affinity) */
+    int task_affinity;      /*!< LVGL task pinned to core (-1 is no affinity) */
+    int task_max_sleep_ms;  /*!< Maximum sleep in LVGL task */
     int timer_period_ms;    /*!< LVGL timer tick period in ms */
 } lvgl_port_cfg_t;
 
@@ -78,10 +79,11 @@ typedef struct {
  */
 #define ESP_LVGL_PORT_INIT_CONFIG() \
     {                               \
-        .task_priority = 4,   \
-        .task_stack = 4096,   \
-        .task_affinity = -1,    \
-        .timer_period_ms = 5, \
+        .task_priority = 4,       \
+        .task_stack = 4096,       \
+        .task_affinity = -1,      \
+        .task_max_sleep_ms = 500, \
+        .timer_period_ms = 5,     \
     }
 
 /**


### PR DESCRIPTION
There is another minor change in LVGL port, which we need for `esp32_s3_eye` BSP. We need to not sleep during the LVGL task. I added a maximum time in ms, for which the task can sleep.