### PR TITLE
bsp: Fixed compilation error missing lcd touch header in EV board.

### DIFF
--- a/esp32_s3_lcd_ev_board/CMakeLists.txt
+++ b/esp32_s3_lcd_ev_board/CMakeLists.txt
@@ -11,5 +11,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES esp_timer esp_lcd
+    PRIV_REQUIRES esp_timer esp_lcd esp_lcd_touch
 )


### PR DESCRIPTION
After the last changes, the EV board is not working (not compilable).