### PR TITLE
lcd_touch: Add pulbic for all touch components.

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,7 +1,8 @@
-version: "1.0.0"
+version: "1.0.1"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
     version: "^1.0"
+    public: true

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,7 +1,8 @@
-version: "1.0.3"
+version: "1.0.4"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
     version: "^1.0"
+    public: true

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,7 +1,8 @@
-version: "1.0.3"
+version: "1.0.4"
 description: ESP LCD Touch GT1151 - touch controller GT1151
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
     version: "^1.0"
+    public: true

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,7 +1,8 @@
-version: "1.0.5"
+version: "1.0.6"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
     version: "^1.0"
+    public: true

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
@@ -1,6 +1,8 @@
-version: "1.0.3"
+version: "1.0.4"
 description: ESP LCD Touch STMPE610 - touch controller STMPE610
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lcd_touch_stmpe610
 dependencies:
   idf: ">=5.0"
-  esp_lcd_touch: "^1.0"
+  esp_lcd_touch:
+    version: "^1.0"
+    public: true

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,7 +1,8 @@
-version: "1.0.5"
+version: "1.0.6"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
     version: "^1.0"
+    public: true


### PR DESCRIPTION
Some types from esp_lcd_touch is used and this component must be as public in all touch components.