### PR TITLE
esp_lvgl_port: change init config to use pdTICKS_TO_MS (BSP-275)

### DIFF
--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -93,13 +93,13 @@ typedef struct {
  * @brief LVGL port configuration structure
  *
  */
-#define ESP_LVGL_PORT_INIT_CONFIG() \
-    {                               \
-        .task_priority = 4,       \
-        .task_stack = 4096,       \
-        .task_affinity = -1,      \
-        .task_max_sleep_ms = 500, \
-        .timer_period_ms = 5,     \
+#define ESP_LVGL_PORT_INIT_CONFIG()            \
+    {                                          \
+        .task_priority = 4,                    \
+        .task_stack = 4096,                    \
+        .task_affinity = -1,                   \
+        .task_max_sleep_ms = pdTICKS_TO_MS(5), \
+        .timer_period_ms = pdTICKS_TO_MS(1),   \
     }
 
 /**


### PR DESCRIPTION
Disclamer: I'm newbie in C and lvgl

with 100hz tick rate setting
timer_period_ms = currently 5ms is 0 ticks

and task_max_sleep_ms 500ms is too much

I created rtos task where I show/hide colon symbol every 1sec (I'm using `xTaskDelayUntil(&last_wakeup, pdMS_TO_TICKS(1000));`)
I spend quite some time figuring out why my clock colon symbol was not rendering at rate of 1sec
with timer_period_ms=500ms setting, colon symbol was flashing every 1050ms, and when time debt of 50ms overlap 500ms, it was rendering again

so basically delay was:
1050 - colon appear
1050 - colon disappear
1050 - appear
450 - disappear
1050 - appear
1050 - disappear

I looked at other lvgl ports, and found that
`lv_tick_inc()` should be invoked as short as possible, usually every 1ms
and
`lv_timer_handler()` should be every 5ms

with proposed settings, tick will be 10ms and timer handler will be 50ms
my colon is now rendering consistently around every 1sec

The problem lays down in `_lv_disp_refr_timer()` function
If you configure lvgl settings to show fps counter or memory monitor, then timer is not paused, and you will end up with refresh rate that you set in settings - so no visible problems here
But if you don't use those, timer gets paused, and function `lv_timer_handler()` in `lvgl_port_task()` returns 0xffffffff `task_delay_ms` until next refresh, which is shortened by `task_max_sleep_ms` to 500ms

maybe better approach would be to put this numbers into KConfig