### PR TITLE
bsp: Proposal of LCD API

### DIFF
--- a/esp-box/CMakeLists.txt
+++ b/esp-box/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver spiffs
-    PRIV_REQUIRES esp_timer esp_lcd esp_lcd_touch
+    PRIV_REQUIRES esp_lcd
 )

--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -4,18 +4,19 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-#include "esp_timer.h"
 #include "driver/gpio.h"
 #include "driver/ledc.h"
 #include "driver/spi_master.h"
 #include "esp_err.h"
 #include "esp_log.h"
+#include "esp_check.h"
 #include "esp_spiffs.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 
 #include "bsp/esp-box.h"
+#include "bsp/display.h"
 #include "esp_lcd_touch_tt21100.h"
 #include "esp_lvgl_port.h"
 #include "bsp_err_check.h"
@@ -133,8 +134,65 @@ esp_err_t bsp_audio_poweramp_enable(bool enable)
 #define LCD_PARAM_BITS         8
 #define LCD_LEDC_CH            CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
 
-static lv_disp_t *bsp_display_lcd_init(void)
+static esp_err_t bsp_display_brightness_init(void)
 {
+    // Setup LEDC peripheral for PWM backlight control
+    const ledc_channel_config_t LCD_backlight_channel = {
+        .gpio_num = BSP_LCD_BACKLIGHT,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = LCD_LEDC_CH,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = 1,
+        .duty = 0,
+        .hpoint = 0
+    };
+    const ledc_timer_config_t LCD_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_10_BIT,
+        .timer_num = 1,
+        .freq_hz = 5000,
+        .clk_cfg = LEDC_AUTO_CLK
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&LCD_backlight_channel));
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_brightness_set(int brightness_percent)
+{
+    if (brightness_percent > 100) {
+        brightness_percent = 100;
+    }
+    if (brightness_percent < 0) {
+        brightness_percent = 0;
+    }
+
+    ESP_LOGI(TAG, "Setting LCD backlight: %d%%", brightness_percent);
+    uint32_t duty_cycle = (1023 * brightness_percent) / 100; // LEDC resolution set to 10bits, thus: 100% = 1023
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH, duty_cycle));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH));
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_backlight_off(void)
+{
+    return bsp_display_brightness_set(0);
+}
+
+esp_err_t bsp_display_backlight_on(void)
+{
+    return bsp_display_brightness_set(100);
+}
+
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
+{
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
         .sclk_io_num = BSP_LCD_PCLK,
@@ -144,10 +202,9 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .quadhd_io_num = GPIO_NUM_NC,
         .max_transfer_sz = BSP_LCD_H_RES * 80 * sizeof(uint16_t),
     };
-    BSP_ERROR_CHECK_RETURN_NULL(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO));
+    ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
     ESP_LOGD(TAG, "Install panel IO");
-    esp_lcd_panel_io_handle_t io_handle = NULL;
     const esp_lcd_panel_io_spi_config_t io_config = {
         .dc_gpio_num = BSP_LCD_DC,
         .cs_gpio_num = BSP_LCD_CS,
@@ -157,22 +214,38 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .spi_mode = 0,
         .trans_queue_depth = 10,
     };
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, ret_io), err, TAG, "New panel IO failed");
 
-    // Attach the LCD to the SPI bus
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, &io_handle));
-
-    ESP_LOGD(TAG, "Install LCD driver of st7789");
-    esp_lcd_panel_handle_t panel_handle = NULL;
+    ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST, // Shared with Touch reset
         .color_space = ESP_LCD_COLOR_SPACE_BGR,
         .bits_per_pixel = 16,
     };
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
-    esp_lcd_panel_reset(panel_handle);
-    esp_lcd_panel_init(panel_handle);
-    esp_lcd_panel_mirror(panel_handle, true, true);
+    esp_lcd_panel_reset(*ret_panel);
+    esp_lcd_panel_init(*ret_panel);
+    esp_lcd_panel_mirror(*ret_panel, true, true);
+    return ret;
+
+err:
+    if (*ret_panel) {
+        esp_lcd_panel_del(*ret_panel);
+    }
+    if (*ret_io) {
+        esp_lcd_panel_io_del(*ret_io);
+    }
+    spi_bus_free(BSP_LCD_SPI_NUM);
+    return ret;
+}
+
+static lv_disp_t *bsp_display_lcd_init(void)
+{
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&panel_handle, &io_handle));
+
     esp_lcd_panel_disp_on_off(panel_handle, true);
 
     /* Add LCD screen */
@@ -232,65 +305,10 @@ static lv_indev_t *bsp_display_indev_init(lv_disp_t *disp)
     return lvgl_port_add_touch(&touch_cfg);
 }
 
-static esp_err_t bsp_display_brightness_init(void)
-{
-    // Setup LEDC peripheral for PWM backlight control
-    const ledc_channel_config_t LCD_backlight_channel = {
-        .gpio_num = BSP_LCD_BACKLIGHT,
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .channel = LCD_LEDC_CH,
-        .intr_type = LEDC_INTR_DISABLE,
-        .timer_sel = 1,
-        .duty = 0,
-        .hpoint = 0
-    };
-    const ledc_timer_config_t LCD_backlight_timer = {
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .duty_resolution = LEDC_TIMER_10_BIT,
-        .timer_num = 1,
-        .freq_hz = 5000,
-        .clk_cfg = LEDC_AUTO_CLK
-    };
-
-    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
-    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&LCD_backlight_channel));
-
-    return ESP_OK;
-}
-
-esp_err_t bsp_display_brightness_set(int brightness_percent)
-{
-    if (brightness_percent > 100) {
-        brightness_percent = 100;
-    }
-    if (brightness_percent < 0) {
-        brightness_percent = 0;
-    }
-
-    ESP_LOGI(TAG, "Setting LCD backlight: %d%%", brightness_percent);
-    uint32_t duty_cycle = (1023 * brightness_percent) / 100; // LEDC resolution set to 10bits, thus: 100% = 1023
-    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH, duty_cycle));
-    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH));
-
-    return ESP_OK;
-}
-
-esp_err_t bsp_display_backlight_off(void)
-{
-    return bsp_display_brightness_set(0);
-}
-
-esp_err_t bsp_display_backlight_on(void)
-{
-    return bsp_display_brightness_set(100);
-}
-
 lv_disp_t *bsp_display_start(void)
 {
     const lvgl_port_cfg_t lvgl_cfg = ESP_LVGL_PORT_INIT_CONFIG();
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&lvgl_cfg));
-
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
 
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.1"
+version: "2.3.0"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 

--- a/esp-box/include/bsp/display.h
+++ b/esp-box/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp32_s2_kaluga_kit/CMakeLists.txt
+++ b/esp32_s2_kaluga_kit/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES esp_lcd esp_timer
+    PRIV_REQUIRES esp_lcd
 )

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.3"
+version: "2.2.0"
 description: Board Support Package for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
 

--- a/esp32_s2_kaluga_kit/include/bsp/display.h
+++ b/esp32_s2_kaluga_kit/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp32_s3_eye/CMakeLists.txt
+++ b/esp32_s3_eye/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES fatfs esp_lcd esp_timer
+    PRIV_REQUIRES fatfs esp_lcd
 )

--- a/esp32_s3_eye/esp32_s3_eye.c
+++ b/esp32_s3_eye/esp32_s3_eye.c
@@ -5,14 +5,12 @@
  */
 
 #include <stdio.h>
-#include "bsp/esp32_s3_eye.h"
 #include "esp_vfs_fat.h"
-#include "esp_timer.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_log.h"
-#include "esp_lvgl_port.h"
+#include "esp_check.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -21,7 +19,10 @@
 #include "driver/ledc.h"
 #include "driver/i2c.h"
 
+#include "bsp/esp32_s3_eye.h"
 #include "bsp_err_check.h"
+#include "bsp/display.h"
+#include "esp_lvgl_port.h"
 
 static const char *TAG = "S3-EYE";
 
@@ -179,8 +180,12 @@ esp_err_t bsp_display_backlight_on(void)
     return bsp_display_brightness_set(100);
 }
 
-static lv_disp_t *bsp_display_lcd_init(void)
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
         .sclk_io_num = BSP_LCD_SPI_CLK,
@@ -190,10 +195,9 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .quadhd_io_num = GPIO_NUM_NC,
         .max_transfer_sz = LVGL_BUFF_SIZE_PIX * sizeof(lv_color_t),
     };
-    BSP_ERROR_CHECK_RETURN_NULL(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO));
+    ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
     ESP_LOGD(TAG, "Install panel IO");
-    esp_lcd_panel_io_handle_t io_handle = NULL;
     const esp_lcd_panel_io_spi_config_t io_config = {
         .dc_gpio_num = BSP_LCD_DC,
         .cs_gpio_num = BSP_LCD_SPI_CS,
@@ -203,21 +207,39 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .spi_mode = 2,
         .trans_queue_depth = 10,
     };
-    // Attach the LCD to the SPI bus
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, &io_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, ret_io), err, TAG, "New panel IO failed");
 
     ESP_LOGD(TAG, "Install LCD driver");
-    esp_lcd_panel_handle_t panel_handle = NULL;
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
         .color_space = ESP_LCD_COLOR_SPACE_RGB,
         .bits_per_pixel = 16,
     };
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
-    esp_lcd_panel_reset(panel_handle);
-    esp_lcd_panel_init(panel_handle);
-    esp_lcd_panel_invert_color(panel_handle, true);
+
+    esp_lcd_panel_reset(*ret_panel);
+    esp_lcd_panel_init(*ret_panel);
+    esp_lcd_panel_invert_color(*ret_panel, true);
+    return ret;
+
+err:
+    if (*ret_panel) {
+        esp_lcd_panel_del(*ret_panel);
+    }
+    if (*ret_io) {
+        esp_lcd_panel_io_del(*ret_io);
+    }
+    spi_bus_free(BSP_LCD_SPI_NUM);
+    return ret;
+}
+
+static lv_disp_t *bsp_display_lcd_init(void)
+{
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&panel_handle, &io_handle));
+
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
     esp_lcd_panel_disp_off(panel_handle, false);
 #else
@@ -251,7 +273,6 @@ static lv_disp_t *bsp_display_lcd_init(void)
 lv_disp_t *bsp_display_start(void)
 {
     lv_disp_t *disp = NULL;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
     const lvgl_port_cfg_t lvgl_cfg = {
         .task_priority = CONFIG_BSP_DISPLAY_LVGL_TASK_PRIORITY,
         .task_stack = 4096,

--- a/esp32_s3_eye/idf_component.yml
+++ b/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.1.0"
 description: Board Support Package for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_eye
 

--- a/esp32_s3_eye/include/bsp/display.h
+++ b/esp32_s3_eye/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp32_s3_korvo_2/CMakeLists.txt
+++ b/esp32_s3_korvo_2/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES fatfs esp_timer esp_lcd esp_lcd_touch esp_adc
+    PRIV_REQUIRES fatfs esp_lcd esp_adc
 )

--- a/esp32_s3_korvo_2/idf_component.yml
+++ b/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 description: Board Support Package for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_korvo_2
 

--- a/esp32_s3_korvo_2/include/bsp/display.h
+++ b/esp32_s3_korvo_2/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -231,7 +231,7 @@ esp_err_t bsp_audio_poweramp_enable(const bool enable);
  *
  * After initialization of I2C, use BSP_I2C_NUM macro when creating I2C devices drivers ie.:
  * \code{.c}
- * es8311_handle_t es8311_dev = es8311_create(BSP_I2C_NUM, ES8311_ADDRRES_0);
+ * es8311_handle_t es8311_dev = es8311_create(BSP_I2C_NUM, ES8311_ADDRESS_0);
  * \endcode
  **************************************************************************************************/
 #define BSP_I2C_NUM     CONFIG_BSP_I2C_NUM
@@ -267,10 +267,11 @@ esp_err_t bsp_i2c_deinit(void);
 /**
  * @brief Init IO expander chip TCA9554
  *
+ * @note I2C must be already initialized by bsp_i2c_init()
  * @note If the device was already initialized, users can also call it to get handle
  * @note This function will be called in `bsp_display_start()`
  *
- * @return Pointer to device handle or NULL when error occured
+ * @return Pointer to device handle or NULL when error occurred
  */
 esp_io_expander_handle_t bsp_io_expander_init(void);
 
@@ -412,34 +413,33 @@ void bsp_display_unlock(void);
 /**
  * @brief Set display's brightness
  *
- * Brightness is controlled with PWM signal to a pin controling backlight.
+ * @attention ESP32-S3 Korvo v2 board has backlight control connected through IO expander, so brightness control is not supported.
  *
  * @param[in] brightness_percent Brightness in [%]
  * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
+ *      - ESP_ERR_NOT_SUPPORTED Always
  */
 esp_err_t bsp_display_brightness_set(int brightness_percent);
 
 /**
  * @brief Turn on display backlight
  *
- * Display must be already initialized by calling bsp_display_start()
+ * @note I2C must be already initialized by bsp_i2c_init()
  *
  * @return
  *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
+ *      - ESP_ERR_INVALID_STATE Could not init IO expander
  */
 esp_err_t bsp_display_backlight_on(void);
 
 /**
  * @brief Turn off display backlight
  *
- * Display must be already initialized by calling bsp_display_start()
+ * @note I2C must be already initialized by bsp_i2c_init()
  *
  * @return
  *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
+ *      - ESP_ERR_INVALID_STATE Could not init IO expander
  */
 esp_err_t bsp_display_backlight_off(void);
 
@@ -490,9 +490,12 @@ bool bsp_button_get(const bsp_button_t btn);
 /**
  * @brief Set LED's GPIOs as output push-pull
  *
+ * @note I2C must be already initialized by bsp_i2c_init()
+ *
  * @return
  *     - ESP_OK Success
- *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_ERR_INVALID_STATE Could not init IO expander
+ *     - ESP_ERR_INVALID_ARG   Parameter error
  */
 esp_err_t bsp_leds_init(void);
 

--- a/esp32_s3_usb_otg/CMakeLists.txt
+++ b/esp32_s3_usb_otg/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES fatfs esp_lcd esp_timer usb esp_adc
+    PRIV_REQUIRES fatfs esp_lcd usb esp_adc
 )

--- a/esp32_s3_usb_otg/esp32_s3_usb_otg.c
+++ b/esp32_s3_usb_otg/esp32_s3_usb_otg.c
@@ -5,15 +5,12 @@
  */
 
 #include <stdio.h>
-#include "bsp/esp32_s3_usb_otg.h"
 #include "esp_vfs_fat.h"
-#include "esp_timer.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_log.h"
-#include "esp_lvgl_port.h"
-#include "bsp_err_check.h"
+#include "esp_check.h"
 
 #include "esp_adc/adc_oneshot.h"
 #include "esp_adc/adc_cali.h"
@@ -26,6 +23,11 @@
 #include "driver/ledc.h"
 
 #include "usb/usb_host.h"
+
+#include "bsp/esp32_s3_usb_otg.h"
+#include "bsp/display.h"
+#include "esp_lvgl_port.h"
+#include "bsp_err_check.h"
 
 static const char *TAG = "USB-OTG";
 
@@ -164,8 +166,12 @@ esp_err_t bsp_display_backlight_on(void)
     return bsp_display_brightness_set(100);
 }
 
-static lv_disp_t *bsp_display_lcd_init(void)
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
         .sclk_io_num = BSP_LCD_SPI_CLK,
@@ -175,10 +181,9 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .quadhd_io_num = GPIO_NUM_NC,
         .max_transfer_sz = BSP_LCD_BUFF_SIZE * sizeof(lv_color_t),
     };
-    BSP_ERROR_CHECK_RETURN_NULL(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO));
+    ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
     ESP_LOGD(TAG, "Install panel IO");
-    esp_lcd_panel_io_handle_t io_handle = NULL;
     const esp_lcd_panel_io_spi_config_t io_config = {
         .dc_gpio_num = BSP_LCD_DC,
         .cs_gpio_num = BSP_LCD_SPI_CS,
@@ -188,21 +193,38 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .spi_mode = 0,
         .trans_queue_depth = 10,
     };
-    // Attach the LCD to the SPI bus
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, &io_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, ret_io), err, TAG, "New panel IO failed");
 
     ESP_LOGD(TAG, "Install LCD driver");
-    esp_lcd_panel_handle_t panel_handle = NULL;
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
         .color_space = ESP_LCD_COLOR_SPACE_RGB,
         .bits_per_pixel = 16,
     };
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
-    esp_lcd_panel_reset(panel_handle);
-    esp_lcd_panel_init(panel_handle);
-    esp_lcd_panel_invert_color(panel_handle, true);
+    esp_lcd_panel_reset(*ret_panel);
+    esp_lcd_panel_init(*ret_panel);
+    esp_lcd_panel_invert_color(*ret_panel, true);
+    return ret;
+
+err:
+    if (*ret_panel) {
+        esp_lcd_panel_del(*ret_panel);
+    }
+    if (*ret_io) {
+        esp_lcd_panel_io_del(*ret_io);
+    }
+    spi_bus_free(BSP_LCD_SPI_NUM);
+    return ret;
+}
+
+static lv_disp_t *bsp_display_lcd_init(void)
+{
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&panel_handle, &io_handle));
+
     esp_lcd_panel_disp_on_off(panel_handle, true);
 
     /* Add LCD screen */
@@ -232,7 +254,6 @@ static lv_disp_t *bsp_display_lcd_init(void)
 lv_disp_t *bsp_display_start(void)
 {
     lv_disp_t *disp = NULL;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
     const lvgl_port_cfg_t lvgl_cfg = ESP_LVGL_PORT_INIT_CONFIG();
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&lvgl_cfg));
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);

--- a/esp32_s3_usb_otg/idf_component.yml
+++ b/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.2"
+version: "1.4.0"
 description: Board Support Package for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_usb_otg
 

--- a/esp32_s3_usb_otg/include/bsp/display.h
+++ b/esp32_s3_usb_otg/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp_wrover_kit/CMakeLists.txt
+++ b/esp_wrover_kit/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(SRCS "esp_wrover_kit.c"
                     INCLUDE_DIRS "include"
                     PRIV_INCLUDE_DIRS "priv_include"
                     REQUIRES driver
-                    PRIV_REQUIRES fatfs esp_lcd esp_timer)
+                    PRIV_REQUIRES fatfs esp_lcd)
 

--- a/esp_wrover_kit/esp_wrover_kit.c
+++ b/esp_wrover_kit/esp_wrover_kit.c
@@ -1,22 +1,25 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
 
 #include <stdio.h>
-#include "bsp/esp_wrover_kit.h"
 #include "esp_vfs_fat.h"
-#include "esp_timer.h"
+#include "esp_log.h"
+#include "esp_check.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "driver/spi_master.h"
 #include "driver/ledc.h"
-#include "esp_lvgl_port.h"
-#include "bsp_err_check.h"
 
-#define TAG "Wrover"
+#include "bsp/esp_wrover_kit.h"
+#include "bsp/display.h"
+#include "bsp_err_check.h"
+#include "esp_lvgl_port.h"
+
+static const char *TAG = "Wrover";
 
 sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 
@@ -138,8 +141,12 @@ esp_err_t bsp_display_backlight_on(void)
     return bsp_display_brightness_set(100);
 }
 
-static lv_disp_t *bsp_display_lcd_init(void)
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
         .sclk_io_num = BSP_LCD_SPI_CLK,
@@ -147,12 +154,11 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .miso_io_num = BSP_LCD_SPI_MISO,
         .quadwp_io_num = -1,
         .quadhd_io_num = -1,
-        .max_transfer_sz = BSP_LCD_H_RES * 80 * sizeof(uint16_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUF_SIZE * sizeof(uint16_t),
     };
-    BSP_ERROR_CHECK_RETURN_NULL(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO));
+    ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
     ESP_LOGD(TAG, "Install panel IO");
-    esp_lcd_panel_io_handle_t io_handle = NULL;
     const esp_lcd_panel_io_spi_config_t io_config = {
         .dc_gpio_num = BSP_LCD_DC,
         .cs_gpio_num = BSP_LCD_SPI_CS,
@@ -162,11 +168,9 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .spi_mode = 0,
         .trans_queue_depth = 10,
     };
-    // Attach the LCD to the SPI bus
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, &io_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, ret_io), err, TAG, "New panel IO failed");
 
     ESP_LOGD(TAG, "Install LCD driver");
-    esp_lcd_panel_handle_t panel_handle = NULL;
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
 #ifdef CONFIG_BSP_LCD_ILI9341
@@ -176,22 +180,45 @@ static lv_disp_t *bsp_display_lcd_init(void)
 #endif
         .bits_per_pixel = 16,
     };
-    BSP_ERROR_CHECK_RETURN_NULL(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
-    esp_lcd_panel_reset(panel_handle);
-    esp_lcd_panel_init(panel_handle);
+    esp_lcd_panel_reset(*ret_panel);
+    esp_lcd_panel_init(*ret_panel);
 #ifdef CONFIG_BSP_LCD_ILI9341
-    esp_lcd_panel_mirror(panel_handle, true, false);
+    esp_lcd_panel_mirror(*ret_panel, true, false);
 #endif
+    return ret;
+
+err:
+    if (*ret_panel) {
+        esp_lcd_panel_del(*ret_panel);
+    }
+    if (*ret_io) {
+        esp_lcd_panel_io_del(*ret_io);
+    }
+    spi_bus_free(BSP_LCD_SPI_NUM);
+    return ret;
+}
+
+static lv_disp_t *bsp_display_lcd_init(void)
+{
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&panel_handle, &io_handle));
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
     esp_lcd_panel_disp_off(panel_handle, false);
+#else
+    esp_lcd_panel_disp_on_off(panel_handle, true);
+#endif
 
     /* Add LCD screen */
     ESP_LOGD(TAG, "Add LCD screen");
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_H_RES * 20,
-        .double_buffer = true,
+        .buffer_size = BSP_LCD_DRAW_BUF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,
@@ -216,7 +243,6 @@ static lv_disp_t *bsp_display_lcd_init(void)
 lv_disp_t *bsp_display_start(void)
 {
     lv_disp_t *disp = NULL;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
     const lvgl_port_cfg_t lvgl_cfg = ESP_LVGL_PORT_INIT_CONFIG();
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&lvgl_cfg));
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);

--- a/esp_wrover_kit/idf_component.yml
+++ b/esp_wrover_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.3"
+version: "1.4.0"
 description: Board Support Package for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/esp_wrover_kit
 

--- a/esp_wrover_kit/include/bsp/display.h
+++ b/esp_wrover_kit/include/bsp/display.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  esp_lcd failure
+ */
+esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);

--- a/esp_wrover_kit/include/bsp/esp_wrover_kit.h
+++ b/esp_wrover_kit/include/bsp/esp_wrover_kit.h
@@ -157,7 +157,7 @@ bool bsp_button_get(const bsp_button_t btn);
  * If your colours on the display are distorted, try changing the display type in menuconfig.
  *
  * LVGL is used as graphics library. LVGL is NOT thread safe, therefore the user must take LVGL mutex
- * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
+ * by calling bsp_display_lock() before calling any LVGL API (lv_...) and then give the mutex with
  * bsp_display_unlock().
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
@@ -166,6 +166,8 @@ bool bsp_button_get(const bsp_button_t btn);
 #define BSP_LCD_V_RES               (320)
 #define BSP_LCD_PIXEL_CLOCK_HZ      (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM             (SPI2_HOST)
+#define BSP_LCD_DRAW_BUF_SIZE       (BSP_LCD_H_RES * 30)
+#define BSP_LCD_DRAW_BUF_DOUBLE     (1)
 
 /**
  * @brief Initialize display


### PR DESCRIPTION
This PR allows LCD initialization without LVGL. The API is in a separate file `bsp/lcd.h` to indicate that it is not needed in usual usacases.

I'd like to discuss few issues before I implement it for all BSPs:
1. Is it OK (at least for now) to omit the deinit functions? _EDIT:_  Seems to be OK for now
2. ~Should we extend the backlight_init function with variable LEDC channels and timers? (the user can, after all, implement his own backlight control)~ 

Any ideas welcome!

Related #121 
