### PR TITLE
bsp: Fix display headers for use in C++ and update BSP constants

### DIFF
--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -201,7 +201,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num = GPIO_NUM_NC,
         .quadwp_io_num = GPIO_NUM_NC,
         .quadhd_io_num = GPIO_NUM_NC,
-        .max_transfer_sz = BSP_LCD_H_RES * 80 * sizeof(uint16_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -220,8 +220,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST, // Shared with Touch reset
-        .color_space = ESP_LCD_COLOR_SPACE_BGR,
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -254,8 +254,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_H_RES * BSP_LCD_DRAW_BUF_HEIGHT,
-        .double_buffer = BSP_LCD_DRAW_BUF_DOUBLE,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.3.1"
+version: "2.3.2"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 

--- a/esp-box/include/bsp/display.h
+++ b/esp-box/include/bsp/display.h
@@ -17,6 +17,23 @@
 #pragma once
 #include "esp_lcd_types.h"
 
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new display panel
  *
@@ -40,3 +57,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp-box/include/bsp/esp-box.h
+++ b/esp-box/include/bsp/esp-box.h
@@ -274,8 +274,8 @@ esp_err_t bsp_spiffs_unmount(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
-#define BSP_LCD_DRAW_BUF_HEIGHT     (10)
-#define BSP_LCD_DRAW_BUF_DOUBLE     (0)
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 10)
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
 
 /**
  * @brief Initialize display

--- a/esp-box/include/bsp/touch.h
+++ b/esp-box/include/bsp/touch.h
@@ -17,6 +17,10 @@
 #pragma once
 #include "esp_lcd_touch.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new touchscreen
  *
@@ -32,3 +36,7 @@
  *      - Else                  esp_lcd_touch failure
  */
 esp_err_t bsp_touch_new(esp_lcd_touch_handle_t *ret_touch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -217,7 +217,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num     = GPIO_NUM_NC,
         .quadwp_io_num   = GPIO_NUM_NC,
         .quadhd_io_num   = GPIO_NUM_NC,
-        .max_transfer_sz = BSP_LCD_H_RES * BSP_LCD_V_RES * sizeof(lv_color_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(lv_color_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -236,8 +236,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -272,8 +272,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_H_RES * BSP_LCD_V_RES,
-        .double_buffer = false,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.0"
+version: "2.2.1"
 description: Board Support Package for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
 

--- a/esp32_s2_kaluga_kit/include/bsp/display.h
+++ b/esp32_s2_kaluga_kit/include/bsp/display.h
@@ -17,6 +17,23 @@
 #pragma once
 #include "esp_lcd_types.h"
 
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new display panel
  *
@@ -40,3 +57,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
+++ b/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
@@ -259,6 +259,9 @@ esp_err_t bsp_i2c_deinit(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * BSP_LCD_V_RES)
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
+
 /**
  * @brief Initialize display and graphics library
  *

--- a/esp32_s3_eye/esp32_s3_eye.c
+++ b/esp32_s3_eye/esp32_s3_eye.c
@@ -124,7 +124,6 @@ esp_err_t bsp_sdcard_unmount(void)
 #define LCD_PARAM_BITS       (8)
 #define LCD_LEDC_CH          (CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH)
 #define LVGL_TICK_PERIOD_MS  (CONFIG_BSP_DISPLAY_LVGL_TICK)
-#define LVGL_BUFF_SIZE_PIX   (BSP_LCD_H_RES * BSP_LCD_V_RES)
 
 static esp_err_t bsp_display_brightness_init(void)
 {
@@ -193,7 +192,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num = GPIO_NUM_NC,
         .quadwp_io_num = GPIO_NUM_NC,
         .quadhd_io_num = GPIO_NUM_NC,
-        .max_transfer_sz = LVGL_BUFF_SIZE_PIX * sizeof(lv_color_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(lv_color_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -212,8 +211,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -251,8 +250,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = LVGL_BUFF_SIZE_PIX,
-        .double_buffer = false,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp32_s3_eye/idf_component.yml
+++ b/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "2.1.1"
 description: Board Support Package for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_eye
 

--- a/esp32_s3_eye/include/bsp/display.h
+++ b/esp32_s3_eye/include/bsp/display.h
@@ -17,6 +17,23 @@
 #pragma once
 #include "esp_lcd_types.h"
 
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new display panel
  *
@@ -40,3 +57,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -228,6 +228,9 @@ esp_err_t bsp_sdcard_unmount(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * BSP_LCD_V_RES)
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
+
 /**
  * @brief Initialize display
  *

--- a/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -213,7 +213,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num = GPIO_NUM_NC,
         .quadwp_io_num = GPIO_NUM_NC,
         .quadhd_io_num = GPIO_NUM_NC,
-        .max_transfer_sz = BSP_LCD_H_RES * 80 * sizeof(uint16_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -232,8 +232,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST, // Shared with Touch reset
-        .color_space = ESP_LCD_COLOR_SPACE_BGR,
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_ili9341(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -280,8 +280,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_H_RES * 50,
-        .double_buffer = true,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp32_s3_korvo_2/idf_component.yml
+++ b/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: Board Support Package for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_korvo_2
 

--- a/esp32_s3_korvo_2/include/bsp/display.h
+++ b/esp32_s3_korvo_2/include/bsp/display.h
@@ -17,6 +17,23 @@
 #pragma once
 #include "esp_lcd_types.h"
 
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new display panel
  *
@@ -40,3 +57,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -385,6 +385,9 @@ esp_err_t bsp_sdcard_unmount(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50)
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (1)
+
 /**
  * @brief Initialize display
  *

--- a/esp32_s3_korvo_2/include/bsp/touch.h
+++ b/esp32_s3_korvo_2/include/bsp/touch.h
@@ -17,6 +17,10 @@
 #pragma once
 #include "esp_lcd_touch.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new touchscreen
  *
@@ -32,3 +36,7 @@
  *      - Else                  esp_lcd_touch failure
  */
 esp_err_t bsp_touch_new(esp_lcd_touch_handle_t *ret_touch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s3_usb_otg/esp32_s3_usb_otg.c
+++ b/esp32_s3_usb_otg/esp32_s3_usb_otg.c
@@ -179,7 +179,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num = GPIO_NUM_NC,
         .quadwp_io_num = GPIO_NUM_NC,
         .quadhd_io_num = GPIO_NUM_NC,
-        .max_transfer_sz = BSP_LCD_BUFF_SIZE * sizeof(lv_color_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(lv_color_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -198,8 +198,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -232,8 +232,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_BUFF_SIZE,
-        .double_buffer = true,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp32_s3_usb_otg/idf_component.yml
+++ b/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.0"
+version: "1.4.1"
 description: Board Support Package for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_usb_otg
 

--- a/esp32_s3_usb_otg/include/bsp/display.h
+++ b/esp32_s3_usb_otg/include/bsp/display.h
@@ -17,6 +17,23 @@
 #pragma once
 #include "esp_lcd_types.h"
 
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Create new display panel
  *
@@ -40,3 +57,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
+++ b/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
@@ -126,7 +126,9 @@ esp_err_t bsp_sdcard_unmount(void);
 #define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
-#define BSP_LCD_BUFF_SIZE          (BSP_LCD_H_RES * 30) // Frame buffer size in pixels
+
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 30) // Frame buffer size in pixels
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (1)
 
 /**
  * @brief Initialize display

--- a/esp_wrover_kit/esp_wrover_kit.c
+++ b/esp_wrover_kit/esp_wrover_kit.c
@@ -154,7 +154,7 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
         .miso_io_num = BSP_LCD_SPI_MISO,
         .quadwp_io_num = -1,
         .quadhd_io_num = -1,
-        .max_transfer_sz = BSP_LCD_DRAW_BUF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
     };
     ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
 
@@ -173,12 +173,8 @@ esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_ha
     ESP_LOGD(TAG, "Install LCD driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = BSP_LCD_RST,
-#ifdef CONFIG_BSP_LCD_ILI9341
-        .color_space = ESP_LCD_COLOR_SPACE_BGR,
-#else
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-#endif
-        .bits_per_pixel = 16,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
     };
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
 
@@ -217,8 +213,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_DRAW_BUF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUF_DOUBLE,
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp_wrover_kit/idf_component.yml
+++ b/esp_wrover_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.0"
+version: "1.4.1"
 description: Board Support Package for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/esp_wrover_kit
 

--- a/esp_wrover_kit/include/bsp/display.h
+++ b/esp_wrover_kit/include/bsp/display.h
@@ -16,6 +16,28 @@
 
 #pragma once
 #include "esp_lcd_types.h"
+#include "sdkconfig.h"
+
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#ifdef CONFIG_BSP_LCD_ILI9341
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+#else
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Create new display panel
@@ -40,3 +62,7 @@
  *      - Else                  esp_lcd failure
  */
 esp_err_t bsp_display_new(esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_wrover_kit/include/bsp/esp_wrover_kit.h
+++ b/esp_wrover_kit/include/bsp/esp_wrover_kit.h
@@ -166,8 +166,9 @@ bool bsp_button_get(const bsp_button_t btn);
 #define BSP_LCD_V_RES               (320)
 #define BSP_LCD_PIXEL_CLOCK_HZ      (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM             (SPI2_HOST)
-#define BSP_LCD_DRAW_BUF_SIZE       (BSP_LCD_H_RES * 30)
-#define BSP_LCD_DRAW_BUF_DOUBLE     (1)
+
+#define BSP_LCD_DRAW_BUFF_SIZE      (BSP_LCD_H_RES * 30)
+#define BSP_LCD_DRAW_BUFF_DOUBLE    (1)
 
 /**
  * @brief Initialize display


### PR DESCRIPTION
Fixed display and touch headers for using with C++ and updated BSP header with LCD constants.

Closes #143, #144, #145