### PR TITLE
lcd_touch: Add interrupt callback into esp_lcd_touch

### DIFF
--- a/components/lcd_touch/esp_lcd_touch/README.md
+++ b/components/lcd_touch/esp_lcd_touch/README.md
@@ -10,6 +10,6 @@ This componnent is main esp_lcd_touch component which defines main functions and
 - [x] Swap XY
 - [x] Mirror X
 - [x] Mirror Y
+- [x] Interrupt callback
 - [ ] Calibration
-- [ ] Interrupt PIN
 

--- a/components/lcd_touch/esp_lcd_touch/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: ESP LCD Touch - main component for using touch screen controllers
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
+++ b/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
@@ -31,6 +31,12 @@ typedef struct esp_lcd_touch_s esp_lcd_touch_t;
 typedef esp_lcd_touch_t *esp_lcd_touch_handle_t;
 
 /**
+ * @brief Touch controller interrupt callback type
+ *
+ */
+typedef void (*esp_lcd_touch_interrupt_callback_t)(esp_lcd_touch_handle_t tp);
+
+/**
  * @brief Touch Configuration Type
  *
  */
@@ -52,8 +58,10 @@ typedef struct {
         unsigned int mirror_y: 1; /*!< Mirror Y after read coordinates */
     } flags;
 
-    /* User callback called after get coordinates from touch controller for apply user adjusting */
+    /*!< User callback called after get coordinates from touch controller for apply user adjusting */
     void (*process_coordinates)(esp_lcd_touch_handle_t tp, uint16_t *x, uint16_t *y, uint16_t *strength, uint8_t *point_num, uint8_t max_point_num);
+    /*!< User callback called after the touch interrupt occured */
+    esp_lcd_touch_interrupt_callback_t interrupt_callback;
 } esp_lcd_touch_config_t;
 
 typedef struct {
@@ -343,7 +351,16 @@ esp_err_t esp_lcd_touch_get_mirror_y(esp_lcd_touch_handle_t tp, bool *mirror);
  */
 esp_err_t esp_lcd_touch_del(esp_lcd_touch_handle_t tp);
 
-
+/**
+ * @brief Register user callback called after the touch interrupt occured
+ *
+ * @param tp: Touch handler
+ * @param callback: Interrupt callback
+ *
+ * @return
+ *      - ESP_OK on success
+ */
+esp_err_t esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_handle_t tp, esp_lcd_touch_interrupt_callback_t callback);
 
 #ifdef __cplusplus
 }

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -68,9 +68,15 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     if (cst816s->config.rst_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t rst_gpio_config = {
             .mode = GPIO_MODE_OUTPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(cst816s->config.rst_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");
+
+        /* Register interrupt callback */
+        if (cst816s->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(cst816s, cst816s->config.interrupt_callback);
+        }
     }
     /* Reset controller */
     ESP_GOTO_ON_ERROR(reset(cst816s), err, TAG, "Reset failed");

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -132,10 +132,16 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
     if (esp_lcd_touch_ft5x06->config.rst_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t rst_gpio_config = {
             .mode = GPIO_MODE_OUTPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.rst_gpio_num)
         };
         ret = gpio_config(&rst_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
+
+        /* Register interrupt callback */
+        if (esp_lcd_touch_ft5x06->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_ft5x06, esp_lcd_touch_ft5x06->config.interrupt_callback);
+        }
     }
 
     /* Init controller */

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
@@ -65,9 +65,15 @@ esp_err_t esp_lcd_touch_new_i2c_gt1151(const esp_lcd_panel_io_handle_t io, const
     if (gt1151->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(gt1151->config.int_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");
+
+        /* Register interrupt callback */
+        if (gt1151->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(gt1151, gt1151->config.interrupt_callback);
+        }
     }
     /* Prepare pin for touch controller reset */
     if (gt1151->config.rst_gpio_num != GPIO_NUM_NC) {

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: ESP LCD Touch GT1151 - touch controller GT1151
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -74,10 +74,16 @@ esp_err_t esp_lcd_touch_new_i2c_gt911(const esp_lcd_panel_io_handle_t io, const 
     if (esp_lcd_touch_gt911->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_gt911->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
+
+        /* Register interrupt callback */
+        if (esp_lcd_touch_gt911->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_gt911, esp_lcd_touch_gt911->config.interrupt_callback);
+        }
     }
 
     /* Prepare pin for touch controller reset */

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6"
+version: "1.0.7"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
@@ -123,10 +123,16 @@ esp_err_t esp_lcd_touch_new_spi_stmpe610(const esp_lcd_panel_io_handle_t io, con
     if (esp_lcd_touch_stmpe610->config.rst_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t rst_gpio_config = {
             .mode = GPIO_MODE_OUTPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_stmpe610->config.rst_gpio_num)
         };
         ret = gpio_config(&rst_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
+
+        /* Register interrupt callback */
+        if (esp_lcd_touch_stmpe610->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_stmpe610, esp_lcd_touch_stmpe610->config.interrupt_callback);
+        }
     }
 
     /* Reset and init controller */

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: ESP LCD Touch STMPE610 - touch controller STMPE610
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lcd_touch_stmpe610
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
@@ -72,10 +72,16 @@ esp_err_t esp_lcd_touch_new_i2c_tt21100(const esp_lcd_panel_io_handle_t io, cons
     if (esp_lcd_touch_tt21100->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_tt21100->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
+
+        /* Register interrupt callback */
+        if (esp_lcd_touch_tt21100->config.interrupt_callback) {
+            esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_tt21100, esp_lcd_touch_tt21100->config.interrupt_callback);
+        }
     }
 
     /* Prepare pin for touch controller reset */

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6"
+version: "1.0.7"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:


### PR DESCRIPTION
Improved esp_lcd_touch: Added support for interrupt callback. It can be registered when initializing or later (later is for LVGL port for future use).
This feature was requested by Qt developers (BSP-284).
