### PR TITLE
fix: Leftover from https://github.com/espressif/esp-bsp/pull/153

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ Best way to start with ESP-BSP is trying one of the [examples](examples) on your
 |---|---|
 | [audio](examples/audio) | ESP32-S3-Korvo-2 |
 | [display](examples/display) | WROVER-KIT |
-| [display_audio](examples/display_audio) | Kaluga-kit |
 | [display_camera](examples/display_camera) | Kaluga-kit |
 | [display_audio_photo](examples/display_audio_photo) | ESP-BOX |
 | [display_rotation](examples/display_rotation) | ESP-BOX |
 | [display_lvgl_demos](examples/display_lvgl_demos) | ESP32-S3-LCD-EV-BOARD |
-| [touchscreen_colorwheel](examples/touchscreen_colorwheel) | ESP-BOX |
 | [mqtt_example](examples/mqtt_example) | Azure-IoT-kit |
 | [sensors_example](examples/sensors_example) | Azure-IoT-kit |
 

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -21,4 +21,3 @@ dependencies:
 examples:
   - path: ../examples/display_audio_photo
   - path: ../examples/display_rotation
-  - path: ../examples/touchscreen_colorwheel

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -28,5 +28,4 @@ dependencies:
     public: true
 
 examples:
-  - path: ../examples/display_audio
   - path: ../examples/display_camera


### PR DESCRIPTION
The removed examples from https://github.com/espressif/esp-bsp/pull/153 were not removed from readmes and idf_component.yml files.

Let's wait until https://github.com/espressif/upload-components-ci-action/issues/10 is resolved before merging this
