### PR TITLE
ds18b20: device driver, work with onewire_bus library (BSP-319)

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           directories: >
             esp32_azure_iot_kit;esp32_s2_kaluga_kit;esp_wrover_kit;esp-box;esp32_s3_usb_otg;esp32_s3_eye;esp32_s3_lcd_ev_board;esp32_s3_korvo_2;esp-box-lite;
-            components/bh1750;components/es8311;components/es7210;components/fbm320;components/hts221;components/mag3110;components/mpu6050;components/ssd1306;components/esp_lvgl_port;
+            components/bh1750;components/ds18b20;components/es8311;components/es7210;components/fbm320;components/hts221;components/mag3110;components/mpu6050;components/ssd1306;components/esp_lvgl_port;
             components/lcd_touch/esp_lcd_touch;components/lcd_touch/esp_lcd_touch_ft5x06;components/lcd_touch/esp_lcd_touch_gt911;components/lcd_touch/esp_lcd_touch_tt21100;components/lcd_touch/esp_lcd_touch_gt1151;components/lcd_touch/esp_lcd_touch_cst816s;
             components/lcd/esp_lcd_gc9a01;components/lcd/esp_lcd_ili9341;components/lcd/esp_lcd_ra8875;components/lcd_touch/esp_lcd_touch_stmpe610;components/lcd/esp_lcd_sh1107;components/lcd/esp_lcd_st7796;
             components/io_expander/esp_io_expander;components/io_expander/esp_io_expander_tca9554;

--- a/components/ds18b20/CHANGELOG.md
+++ b/components/ds18b20/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial driver version, based on the [onewire_bus](https://components.espressif.com/components/espressif/onewire_bus) library.

--- a/components/ds18b20/CMakeLists.txt
+++ b/components/ds18b20/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "src/ds18b20.c"
+                       INCLUDE_DIRS "include")

--- a/components/ds18b20/LICENSE
+++ b/components/ds18b20/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/components/ds18b20/README.md
+++ b/components/ds18b20/README.md
@@ -1,0 +1,63 @@
+# DS18B20 Device Driver
+
+[![Component Registry](https://components.espressif.com/components/espressif/ds18b20/badge.svg)](https://components.espressif.com/components/espressif/ds18b20)
+
+DS18B20 temperature sensor only uses a single wire to write and read data, the interface is also called the `1-Wire` bus. This component only contains the sensor driver. For 1-Wire bus setup, you need to use the [onewire_bus](https://components.espressif.com/components/espressif/onewire_bus) library to initialize and enumerate the devices.
+
+## How to enumerate DS18B20 devices on the 1-Wire bus
+
+```c
+    #define EXAMPLE_ONEWIRE_BUS_GPIO    0
+    #define EXAMPLE_ONEWIRE_MAX_DS18B20 2
+
+    // install 1-wire bus
+    onewire_bus_handle_t bus = NULL;
+    onewire_bus_config_t bus_config = {
+        .bus_gpio_num = EXAMPLE_ONEWIRE_BUS_GPIO,
+    };
+    onewire_bus_rmt_config_t rmt_config = {
+        .max_rx_bytes = 10, // 1byte ROM command + 8byte ROM number + 1byte device command
+    };
+    ESP_ERROR_CHECK(onewire_new_bus_rmt(&bus_config, &rmt_config, &bus));
+
+    int ds18b20_device_num = 0;
+    ds18b20_device_handle_t ds18b20s[EXAMPLE_ONEWIRE_MAX_DS18B20];
+    onewire_device_iter_handle_t iter = NULL;
+    onewire_device_t next_onewire_device;
+    esp_err_t search_result = ESP_OK;
+
+    // create 1-wire device iterator, which is used for device search
+    ESP_ERROR_CHECK(onewire_new_device_iter(bus, &iter));
+    ESP_LOGI(TAG, "Device iterator created, start searching...");
+    do {
+        search_result = onewire_device_iter_get_next(iter, &next_onewire_device);
+        if (search_result == ESP_OK) { // found a new device, let's check if we can upgrade it to a DS18B20
+            ds18b20_config_t ds_cfg = {};
+            // check if the device is a DS18B20, if so, return the ds18b20 handle
+            if (ds18b20_new_device(&next_onewire_device, &ds_cfg, &ds18b20s[ds18b20_device_num]) == ESP_OK) {
+                ESP_LOGI(TAG, "Found a DS18B20[%d], address: %016llX", ds18b20_device_num, next_onewire_device.address);
+                ds18b20_device_num++;
+            } else {
+                ESP_LOGI(TAG, "Found an unknown device, address: %016llX", next_onewire_device.address);
+            }
+        }
+    } while (search_result != ESP_ERR_NOT_FOUND);
+    ESP_ERROR_CHECK(onewire_del_device_iter(iter));
+    ESP_LOGI(TAG, "Searching done, %d DS18B20 device(s) found", ds18b20_device_num);
+
+    // Now you have the DS18B20 sensor handle, you can use it to read the temperature
+```
+
+## Trigger a temperature conversion and then read the data
+
+```c
+for (int i = 0; i < ds18b20_device_num; i ++) {
+    ESP_ERROR_CHECK(ds18b20_trigger_temperature_conversion(ds18b20s[i]));
+    ESP_ERROR_CHECK(ds18b20_get_temperature(ds18b20s[i], &temperature));
+    ESP_LOGI(TAG, "temperature read from DS18B20[%d]: %.2fC", i, temperature);
+}
+```
+
+## Reference
+
+* See [DS18B20 datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ds18b20.pdf)

--- a/components/ds18b20/idf_component.yml
+++ b/components/ds18b20/idf_component.yml
@@ -1,0 +1,5 @@
+version: "0.1.0"
+description: DS18B20 device driver
+url: https://github.com/espressif/esp-bsp/tree/master/components/ds18b20
+dependencies:
+  onewire_bus: "^1.0.0"

--- a/components/ds18b20/include/ds18b20.h
+++ b/components/ds18b20/include/ds18b20.h
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "onewire_device.h"
+#include "ds18b20_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of DS18B20 device handle
+ */
+typedef struct ds18b20_device_t *ds18b20_device_handle_t;
+
+/**
+ * @brief DS18B20 configuration
+ */
+typedef struct {
+} ds18b20_config_t;
+
+/**
+ * @brief Create a new DS18B20 device based on the general 1-Wire device
+ *
+ * @note The general 1-Wire device can be enumerated during the 1-Wire bus device search process,
+ *       this function is going to check and upgrade that into a DS18B20 device.
+ *
+ * @param[in] device 1-Wire device basic information, including bus handle and device ROM ID
+ * @param[in] config DS18B20 configuration
+ * @param[out] ret_ds18b20 Returned DS18B20 device handle
+ * @return
+ *      - ESP_OK: Create DS18B20 device successfully
+ *      - ESP_ERR_INVALID_ARG: Create DS18B20 device failed due to invalid argument
+ *      - ESP_ERR_NO_MEM: Create DS18B20 device failed due to out of memory
+ *      - ESP_ERR_NOT_SUPPORTED: Create DS18B20 device failed because the device is unknown (e.g. a wrong family ID code)
+ *      - ESP_FAIL: Create DS18B20 device failed due to other reasons
+ */
+esp_err_t ds18b20_new_device(onewire_device_t *device, const ds18b20_config_t *config, ds18b20_device_handle_t *ret_ds18b20);
+
+/**
+ * @brief Delete DS18B20 device
+ *
+ * @param ds18b20 DS18B20 device handle returned by `ds18b20_new_device`
+ * @return
+ *      - ESP_OK: Delete DS18B20 device successfully
+ *      - ESP_ERR_INVALID_ARG: Delete DS18B20 device failed due to invalid argument
+ *      - ESP_FAIL: Delete DS18B20 device failed due to other reasons
+ */
+esp_err_t ds18b20_del_device(ds18b20_device_handle_t ds18b20);
+
+/**
+ * @brief Set DS18B20's temperature conversion resolution
+ *
+ * @param[in] ds18b20 DS18B20 device handle returned by `ds18b20_new_device`
+ * @param[in] resolution resolution of DS18B20's temperature conversion
+ * @return
+ *      - ESP_OK: Set resolution successfully
+ *      - ESP_ERR_INVALID_ARG: Set resolution failed due to invalid argument
+ *      - ESP_FAIL: Set resolution failed due to other reasons
+ */
+esp_err_t ds18b20_set_resolution(ds18b20_device_handle_t ds18b20, ds18b20_resolution_t resolution);
+
+/**
+ * @brief Trigger temperature conversion of DS18B20
+ *
+ * @note After send the trigger command, the DS18B20 will start temperature conversion.
+ *       This function will delay for some while, to ensure the temperature conversion won't be interrupted.
+ *
+ * @param[in] ds18b20 DS18B20 device handle returned by `ds18b20_new_device`
+ * @return
+ *      - ESP_OK: Trigger temperature conversion successfully
+ *      - ESP_ERR_INVALID_ARG: Trigger temperature conversion failed due to invalid argument
+ *      - ESP_FAIL: Trigger temperature conversion failed due to other reasons
+ */
+esp_err_t ds18b20_trigger_temperature_conversion(ds18b20_device_handle_t ds18b20);
+
+/**
+ * @brief Get temperature from DS18B20
+ *
+ * @param[in] ds18b20 DS18B20 device handle returned by `ds18b20_new_device`
+ * @param[out] temperature conversion result from DS18B20
+ * @return
+ *      - ESP_OK: Get temperature successfully
+ *      - ESP_ERR_INVALID_ARG: Get temperature failed due to invalid argument
+ *      - ESP_ERR_INVALID_CRC: Get temperature failed due to CRC check error
+ *      - ESP_FAIL: Get temperature failed due to other reasons
+ */
+esp_err_t ds18b20_get_temperature(ds18b20_device_handle_t ds18b20, float *temperature);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/ds18b20/include/ds18b20_types.h
+++ b/components/ds18b20/include/ds18b20_types.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DS18B20 supported resolutions
+ */
+typedef enum {
+    DS18B20_RESOLUTION_9B,  /*!<  9bit, needs ~93.75ms convert time */
+    DS18B20_RESOLUTION_10B, /*!< 10bit, needs ~187.5ms convert time */
+    DS18B20_RESOLUTION_11B, /*!< 11bit, needs ~375ms convert time */
+    DS18B20_RESOLUTION_12B, /*!< 12bit, needs ~750ms convert time */
+} ds18b20_resolution_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/ds18b20/src/ds18b20.c
+++ b/components/ds18b20/src/ds18b20.c
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_check.h"
+#include "onewire_bus.h"
+#include "onewire_cmd.h"
+#include "onewire_crc.h"
+#include "ds18b20.h"
+
+static const char *TAG = "ds18b20";
+
+#define DS18B20_CMD_CONVERT_TEMP      0x44
+#define DS18B20_CMD_WRITE_SCRATCHPAD  0x4E
+#define DS18B20_CMD_READ_SCRATCHPAD   0xBE
+
+/**
+ * @brief Structure of DS18B20's scratchpad
+ */
+typedef struct  {
+    uint8_t temp_lsb;      /*!< lsb of temperature */
+    uint8_t temp_msb;      /*!< msb of temperature */
+    uint8_t th_user1;      /*!< th register or user byte 1 */
+    uint8_t tl_user2;      /*!< tl register or user byte 2 */
+    uint8_t configuration; /*!< resolution configuration register */
+    uint8_t _reserved1;
+    uint8_t _reserved2;
+    uint8_t _reserved3;
+    uint8_t crc_value;     /*!< crc value of scratchpad data */
+} __attribute__((packed)) ds18b20_scratchpad_t;
+
+typedef struct ds18b20_device_t {
+    onewire_bus_handle_t bus;
+    onewire_device_address_t addr;
+    uint8_t th_user1;
+    uint8_t tl_user2;
+    ds18b20_resolution_t resolution;
+} ds18b20_device_t;
+
+esp_err_t ds18b20_new_device(onewire_device_t *device, const ds18b20_config_t *config, ds18b20_device_handle_t *ret_ds18b20)
+{
+    ds18b20_device_t *ds18b20 = NULL;
+    ESP_RETURN_ON_FALSE(device && config && ret_ds18b20, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    // check ROM ID, the family code of DS18B20 is 0x28
+    if ((device->address & 0xFF) != 0x28) {
+        ESP_LOGD(TAG, "%016llX is not a DS18B20 device", device->address);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    ds18b20 = calloc(1, sizeof(ds18b20_device_t));
+    ESP_RETURN_ON_FALSE(ds18b20, ESP_ERR_NO_MEM, TAG, "no mem for ds18b20");
+    ds18b20->bus = device->bus;
+    ds18b20->addr = device->address;
+    ds18b20->resolution = DS18B20_RESOLUTION_12B; // DS18B20 default resolution is 12 bits
+
+    *ret_ds18b20 = ds18b20;
+    return ESP_OK;
+}
+
+esp_err_t ds18b20_del_device(ds18b20_device_handle_t ds18b20)
+{
+    ESP_RETURN_ON_FALSE(ds18b20, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    free(ds18b20);
+    return ESP_OK;
+}
+
+static esp_err_t ds18b20_send_command(ds18b20_device_handle_t ds18b20, uint8_t cmd)
+{
+    // send command
+    uint8_t tx_buffer[10] = {0};
+    tx_buffer[0] = ONEWIRE_CMD_MATCH_ROM;
+    memcpy(&tx_buffer[1], &ds18b20->addr, sizeof(ds18b20->addr));
+    tx_buffer[sizeof(ds18b20->addr) + 1] = cmd;
+
+    return onewire_bus_write_bytes(ds18b20->bus, tx_buffer, sizeof(tx_buffer));
+}
+
+esp_err_t ds18b20_set_resolution(ds18b20_device_handle_t ds18b20, ds18b20_resolution_t resolution)
+{
+    ESP_RETURN_ON_FALSE(ds18b20, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    // reset bus and check if the ds18b20 is present
+    ESP_RETURN_ON_ERROR(onewire_bus_reset(ds18b20->bus), TAG, "reset bus error");
+
+    // send command: DS18B20_CMD_WRITE_SCRATCHPAD
+    ESP_RETURN_ON_ERROR(ds18b20_send_command(ds18b20, DS18B20_CMD_WRITE_SCRATCHPAD), TAG, "send DS18B20_CMD_WRITE_SCRATCHPAD failed");
+
+    // write new resolution to scratchpad
+    const uint8_t resolution_data[] = {0x1F, 0x3F, 0x5F, 0x7F};
+    uint8_t tx_buffer[3] = {0};
+    tx_buffer[0] = ds18b20->th_user1;
+    tx_buffer[1] = ds18b20->tl_user2;
+    tx_buffer[2] = resolution_data[resolution];
+    ESP_RETURN_ON_ERROR(onewire_bus_write_bytes(ds18b20->bus, tx_buffer, sizeof(tx_buffer)), TAG, "send new resolution failed");
+
+    ds18b20->resolution = resolution;
+    return ESP_OK;
+}
+
+esp_err_t ds18b20_trigger_temperature_conversion(ds18b20_device_handle_t ds18b20)
+{
+    ESP_RETURN_ON_FALSE(ds18b20, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    // reset bus and check if the ds18b20 is present
+    ESP_RETURN_ON_ERROR(onewire_bus_reset(ds18b20->bus), TAG, "reset bus error");
+
+    // send command: DS18B20_CMD_CONVERT_TEMP
+    ESP_RETURN_ON_ERROR(ds18b20_send_command(ds18b20, DS18B20_CMD_CONVERT_TEMP), TAG, "send DS18B20_CMD_CONVERT_TEMP failed");
+
+    // delay proper time for temperature conversion
+    const uint32_t delays_ms[] = {100, 200, 400, 800};
+    vTaskDelay(pdMS_TO_TICKS(delays_ms[ds18b20->resolution]));
+
+    return ESP_OK;
+}
+
+esp_err_t ds18b20_get_temperature(ds18b20_device_handle_t ds18b20, float *ret_temperature)
+{
+    ESP_RETURN_ON_FALSE(ds18b20 && ret_temperature, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    // reset bus and check if the ds18b20 is present
+    ESP_RETURN_ON_ERROR(onewire_bus_reset(ds18b20->bus), TAG, "reset bus error");
+
+    // send command: DS18B20_CMD_READ_SCRATCHPAD
+    ESP_RETURN_ON_ERROR(ds18b20_send_command(ds18b20, DS18B20_CMD_READ_SCRATCHPAD), TAG, "send DS18B20_CMD_READ_SCRATCHPAD failed");
+
+    // read scratchpad data
+    ds18b20_scratchpad_t scratchpad;
+    ESP_RETURN_ON_ERROR(onewire_bus_read_bytes(ds18b20->bus, (uint8_t *)&scratchpad, sizeof(scratchpad)),
+                        TAG, "error while reading scratchpad data");
+    // check crc
+    ESP_RETURN_ON_FALSE(onewire_crc8(0, (uint8_t *)&scratchpad, 8) == scratchpad.crc_value, ESP_ERR_INVALID_CRC, TAG, "scratchpad crc error");
+
+    const uint8_t lsb_mask[4] = {0x07, 0x03, 0x01, 0x00}; // mask bits not used in low resolution
+    uint8_t lsb_masked = scratchpad.temp_lsb & (~lsb_mask[scratchpad.configuration >> 5]);
+    *ret_temperature = (((int16_t)scratchpad.temp_msb << 8) | lsb_masked)  / 16.0f;
+
+    return ESP_OK;
+}

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -13,9 +13,9 @@ if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "4.4")
     list(APPEND EXTRA_COMPONENT_DIRS "../components/io_expander")
 endif()
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "4.4")
-    set(EXCLUDE_COMPONENTS "es8311" "es7210" "esp_lvgl_port")
+    set(EXCLUDE_COMPONENTS "es8311" "es7210" "esp_lvgl_port" "ds18b20")
 elseif("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "5.0")
-    set(EXCLUDE_COMPONENTS "esp_lcd_touch_stmpe610")
+    set(EXCLUDE_COMPONENTS "esp_lcd_touch_stmpe610" "ds18b20")
 endif()
 
 


### PR DESCRIPTION
Added the driver for the DS18B20 temperature sensor.

This is a 1-Wire sensor, so it depends on the [onewire_bus](https://components.espressif.com/components/espressif/onewire_bus) component.