### PR TITLE
bsp: Fixed LCD SPI maximum transfer size.

### DIFF
--- a/esp-box-lite/esp-box-lite.c
+++ b/esp-box-lite/esp-box-lite.c
@@ -23,6 +23,8 @@
 
 static const char *TAG = "ESP-BOX-LITE";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 static lv_indev_t *disp_indev = NULL;   /* Input device (buttons) */
 static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface */
 static i2s_chan_handle_t i2s_tx_chan = NULL;
@@ -313,7 +315,7 @@ esp_err_t bsp_display_backlight_on(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
 
@@ -371,7 +373,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp-box-lite/idf_component.yml
+++ b/esp-box-lite/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: Board Support Package for ESP32-S3-BOX-Lite
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box-lite
 

--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -25,6 +25,8 @@
 
 static const char *TAG = "ESP-BOX";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 /** @cond */
 _Static_assert(CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS > 0, "Touch buttons must be supported for this BSP");
 /** @endcond */
@@ -306,7 +308,7 @@ esp_err_t bsp_display_backlight_on(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
 
@@ -362,7 +364,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.4.0"
+version: "2.4.1"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 

--- a/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -19,6 +19,8 @@
 
 static const char *TAG = "Kaluga";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 static const touch_pad_t bsp_touch_button[TOUCH_BUTTON_NUM] = {
     TOUCH_BUTTON_PHOTO,      /*!< 'PHOTO' button */
     TOUCH_BUTTON_PLAY,       /*!< 'PLAY/PAUSE' button */
@@ -210,7 +212,7 @@ esp_err_t bsp_touchpad_calibrate(bsp_touchpad_button_t tch_pad, float tch_thresh
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
@@ -266,7 +268,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp32_s2_kaluga_kit/idf_component.yml
+++ b/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.3"
+version: "2.2.4"
 description: Board Support Package for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s2_kaluga_kit
 

--- a/esp32_s3_eye/esp32_s3_eye.c
+++ b/esp32_s3_eye/esp32_s3_eye.c
@@ -26,6 +26,8 @@
 
 static const char *TAG = "S3-EYE";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 
 const button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
@@ -182,7 +184,7 @@ esp_err_t bsp_display_backlight_on(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
 
@@ -239,7 +241,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp32_s3_eye/idf_component.yml
+++ b/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.3"
+version: "2.1.4"
 description: Board Support Package for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_eye
 

--- a/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -33,6 +33,8 @@
 
 static const char *TAG = "S3-KORVO-2";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 static esp_io_expander_handle_t io_expander = NULL; // IO expander tca9554 handle
 //static adc_oneshot_unit_handle_t adc1_handle; // ADC1 handle; for USB voltage measurement
 //static adc_cali_handle_t adc1_cali_handle; // ADC1 calibration handle
@@ -207,7 +209,7 @@ esp_io_expander_handle_t bsp_io_expander_init(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_LOGD(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = {
@@ -275,7 +277,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp32_s3_korvo_2/idf_component.yml
+++ b/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.4"
+version: "1.1.5"
 description: Board Support Package for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_korvo_2
 

--- a/esp32_s3_usb_otg/esp32_s3_usb_otg.c
+++ b/esp32_s3_usb_otg/esp32_s3_usb_otg.c
@@ -31,6 +31,8 @@
 
 static const char *TAG = "USB-OTG";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 static TaskHandle_t usb_host_task;  // USB Host Library task
 static adc_oneshot_unit_handle_t adc1_handle; // ADC1 handle; for USB voltage measurement
 static adc_cali_handle_t adc1_cali_handle; // ADC1 calibration handle
@@ -169,7 +171,7 @@ esp_err_t bsp_display_backlight_on(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
 
@@ -225,7 +227,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp32_s3_usb_otg/idf_component.yml
+++ b/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.3"
+version: "1.4.4"
 description: Board Support Package for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/esp32_s3_usb_otg
 

--- a/esp_wrover_kit/esp_wrover_kit.c
+++ b/esp_wrover_kit/esp_wrover_kit.c
@@ -21,6 +21,8 @@
 
 static const char *TAG = "Wrover";
 
+#define LCD_SPI_MAX_DATA_SIZE (32768)
+
 sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 
 esp_err_t bsp_leds_init(void)
@@ -144,7 +146,7 @@ esp_err_t bsp_display_backlight_on(void)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
-    assert(config != NULL && config->max_transfer_sz > 0);
+    assert(config != NULL && config->max_transfer_sz > 0 && config->max_transfer_sz <= LCD_SPI_MAX_DATA_SIZE);
 
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
 
@@ -202,7 +204,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = 10 * BSP_LCD_H_RES,
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 

--- a/esp_wrover_kit/idf_component.yml
+++ b/esp_wrover_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.3"
+version: "1.4.4"
 description: Board Support Package for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/esp_wrover_kit
 


### PR DESCRIPTION
After changes in `esp_lcd`, there is no check on maximum transfer size in SPI. It must be changed in BSP. Here is a fix.