### PR TITLE
fixed initialization of reset and interrupt pins (BSP-321)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -120,7 +120,7 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
 
     /* Prepare pin for touch interrupt */
     if (esp_lcd_touch_ft5x06->config.int_gpio_num != GPIO_NUM_NC) {
-        const gpio_config_t rst_gpio_config = {
+        const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
             .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.int_gpio_num)

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -125,7 +125,7 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
             .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.int_gpio_num)
         };
-        ret = gpio_config(&rst_gpio_config);
+        ret = gpio_config(&int_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
 
         /* Register interrupt callback */
@@ -140,7 +140,7 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
             .mode = GPIO_MODE_OUTPUT,
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.rst_gpio_num)
         };
-        ret = gpio_config(&int_gpio_config);
+        ret = gpio_config(&rst_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
     }
 

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -136,7 +136,7 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
 
     /* Prepare pin for touch controller reset */
     if (esp_lcd_touch_ft5x06->config.rst_gpio_num != GPIO_NUM_NC) {
-        const gpio_config_t int_gpio_config = {
+        const gpio_config_t rst_gpio_config = {
             .mode = GPIO_MODE_OUTPUT,
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.rst_gpio_num)
         };

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -120,20 +120,10 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
 
     /* Prepare pin for touch interrupt */
     if (esp_lcd_touch_ft5x06->config.int_gpio_num != GPIO_NUM_NC) {
-        const gpio_config_t int_gpio_config = {
-            .mode = GPIO_MODE_INPUT,
-            .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.int_gpio_num)
-        };
-        ret = gpio_config(&int_gpio_config);
-        ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
-    }
-
-    /* Prepare pin for touch controller reset */
-    if (esp_lcd_touch_ft5x06->config.rst_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t rst_gpio_config = {
-            .mode = GPIO_MODE_OUTPUT,
+            .mode = GPIO_MODE_INPUT,
             .intr_type = GPIO_INTR_NEGEDGE,
-            .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.rst_gpio_num)
+            .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.int_gpio_num)
         };
         ret = gpio_config(&rst_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
@@ -142,6 +132,16 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
         if (esp_lcd_touch_ft5x06->config.interrupt_callback) {
             esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_ft5x06, esp_lcd_touch_ft5x06->config.interrupt_callback);
         }
+    }
+
+    /* Prepare pin for touch controller reset */
+    if (esp_lcd_touch_ft5x06->config.rst_gpio_num != GPIO_NUM_NC) {
+        const gpio_config_t int_gpio_config = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.rst_gpio_num)
+        };
+        ret = gpio_config(&int_gpio_config);
+        ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
     }
 
     /* Init controller */


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [master] Version of modified component bumped

# Change description
There is an error in initializing the reset and interrupt pins for the FT5X06 touch driver, where part of the pins' functionalities were changed.
