### PR TITLE
Fix touch interrupt callbacks (BSP-322)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -60,6 +60,7 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     if (cst816s->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(cst816s->config.int_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");
@@ -68,7 +69,6 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     if (cst816s->config.rst_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t rst_gpio_config = {
             .mode = GPIO_MODE_OUTPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(cst816s->config.rst_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -4,5 +4,5 @@ url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_l
 dependencies:
   idf: ">=4.4.2"
   esp_lcd_touch:
-    version: "^1.0.4"
+    version: "^1.0.5"
     public: true


### PR DESCRIPTION
.intr_type was being set on the RST pin not the IRQ pin.

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Interrupts were being enabled on the RST pin not the IRQ pin, therefore config.interrupt_callback was never being called.
