### PR TITLE
TCA95xx_16bit (BSP-326)

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -19,6 +19,6 @@ jobs:
             components/bh1750;components/ds18b20;components/es8311;components/es7210;components/fbm320;components/hts221;components/mag3110;components/mpu6050;components/ssd1306;components/esp_lvgl_port;
             components/lcd_touch/esp_lcd_touch;components/lcd_touch/esp_lcd_touch_ft5x06;components/lcd_touch/esp_lcd_touch_gt911;components/lcd_touch/esp_lcd_touch_tt21100;components/lcd_touch/esp_lcd_touch_gt1151;components/lcd_touch/esp_lcd_touch_cst816s;
             components/lcd/esp_lcd_gc9a01;components/lcd/esp_lcd_ili9341;components/lcd/esp_lcd_ra8875;components/lcd_touch/esp_lcd_touch_stmpe610;components/lcd/esp_lcd_sh1107;components/lcd/esp_lcd_st7796;
-            components/io_expander/esp_io_expander;components/io_expander/esp_io_expander_tca9554;
+            components/io_expander/esp_io_expander;components/io_expander/esp_io_expander_tca9554;components/io_expander/esp_io_expander_tca95xx_16bit;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/CMakeLists.txt
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "esp_io_expander_tca95xx_16bit.c" INCLUDE_DIRS "include" REQUIRES "driver" "esp_io_expander")

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/CMakeLists.txt
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "esp_io_expander_tca95xx_16bit.c" INCLUDE_DIRS "include" REQUIRES "driver" "esp_io_expander")
+idf_component_register(SRCS "esp_io_expander_tca95xx_16bit.c" INCLUDE_DIRS "include" REQUIRES "driver")

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/README.md
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/README.md
@@ -1,0 +1,40 @@
+# ESP IO Expander Chip TCA9539 and TCA9555
+
+Implementation of the TCA9539 and TCA9555 io expander chip with esp_io_expander component.
+
+| Chip             | Communication interface | Component name                | Link to datasheet |
+| :--------------: | :---------------------: | :---------------------------: | :---------------: |
+| TCA9539          | I2C                     | esp_io_expander_tca95xx_16bit | [datasheet](https://www.ti.com/lit/gpn/tca9539) |
+| TCA9555          | I2C                     | esp_io_expander_tca95xx_16bit | [datasheet](https://www.ti.com/lit/gpn/tca9555) |
+
+## Add to project
+
+Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
+You can add them to your project via `idf.py add-dependency`, e.g.
+```
+    idf.py add-dependency esp_io_expander_tca95xx_16bit==1.0.0
+```
+
+Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
+
+## Example use
+
+Creation of the component.
+
+```
+    esp_io_expander_handle_t io_expander = NULL;
+    esp_io_expander_new_i2c_tca95xx_16bit(1, ESP_IO_EXPANDER_I2C_TCA9539_ADDRESS_00, &io_expander);
+```
+
+Set pin 0 and pin 1 with output dircetion and low level:
+
+```
+    esp_io_expander_set_dir(io_expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1, IO_EXPANDER_OUTPUT);
+    esp_io_expander_set_level(io_expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1, 0);
+```
+
+Print all pins's status to the log:
+
+```
+    esp_io_expander_print_state(io_expander);
+```

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/README.md
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/README.md
@@ -1,5 +1,7 @@
 # ESP IO Expander Chip TCA9539 and TCA9555
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_io_expander_tca95xx_16bit/badge.svg)](https://components.espressif.com/components/espressif/esp_io_expander_tca95xx_16bit)
+
 Implementation of the TCA9539 and TCA9555 io expander chip with esp_io_expander component.
 
 | Chip             | Communication interface | Component name                | Link to datasheet |

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/esp_io_expander_tca95xx_16bit.c
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/esp_io_expander_tca95xx_16bit.c
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "driver/i2c.h"
+#include "esp_bit_defs.h"
+#include "esp_check.h"
+#include "esp_log.h"
+
+#include "esp_io_expander.h"
+#include "esp_io_expander_tca95xx_16bit.h"
+
+/* Timeout of each I2C communication */
+#define I2C_TIMEOUT_MS          (10)
+
+#define IO_COUNT                (16)
+
+/* Register address */
+#define INPUT_REG_ADDR          (0x00)
+#define OUTPUT_REG_ADDR         (0x02)
+#define DIRECTION_REG_ADDR      (0x06)
+
+/* Default register value on power-up */
+#define DIR_REG_DEFAULT_VAL     (0xffff)
+#define OUT_REG_DEFAULT_VAL     (0xffff)
+
+/**
+ * @brief Device Structure Type
+ *
+ */
+typedef struct {
+    esp_io_expander_t base;
+    i2c_port_t i2c_num;
+    uint32_t i2c_address;
+    struct {
+        uint8_t direction;
+        uint8_t output;
+    } regs;
+} esp_io_expander_tca95xx_16bit_t;
+
+static char *TAG = "tca95xx_16";
+
+static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value);
+static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value);
+static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t reset(esp_io_expander_t *handle);
+static esp_err_t del(esp_io_expander_t *handle);
+
+esp_err_t esp_io_expander_new_i2c_tca95xx_16bit(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle)
+{
+    ESP_RETURN_ON_FALSE(i2c_num < I2C_NUM_MAX, ESP_ERR_INVALID_ARG, TAG, "Invalid i2c num");
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)calloc(1, sizeof(esp_io_expander_tca95xx_16bit_t));
+    ESP_RETURN_ON_FALSE(tca, ESP_ERR_NO_MEM, TAG, "Malloc failed");
+
+    tca->base.config.io_count = IO_COUNT;
+    tca->base.config.flags.dir_out_bit_zero = 1;
+    tca->i2c_num = i2c_num;
+    tca->i2c_address = i2c_address;
+    tca->base.read_input_reg = read_input_reg;
+    tca->base.write_output_reg = write_output_reg;
+    tca->base.read_output_reg = read_output_reg;
+    tca->base.write_direction_reg = write_direction_reg;
+    tca->base.read_direction_reg = read_direction_reg;
+    tca->base.del = del;
+    tca->base.reset = reset;
+
+    esp_err_t ret = ESP_OK;
+    /* Reset configuration and register status */
+    ESP_GOTO_ON_ERROR(reset(&tca->base), err, TAG, "Reset failed");
+
+    *handle = &tca->base;
+    return ESP_OK;
+err:
+    free(tca);
+    return ret;
+}
+
+static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+
+    uint8_t temp[2] = {0, 0};
+    // *INDENT-OFF*
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_read_device(tca->i2c_num, tca->i2c_address, (uint8_t[]){INPUT_REG_ADDR}, 1, (uint8_t*)&temp, 2, pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Read input reg failed");
+    // *INDENT-ON*
+    *value = (((uint32_t)temp[0]) << 8) | (temp[1]);
+    return ESP_OK;
+}
+
+static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+    value &= 0xffff;
+
+    uint8_t data[] = {OUTPUT_REG_ADDR, value >> 8, value & 0xff};
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_to_device(tca->i2c_num, tca->i2c_address, data, sizeof(data), pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Write output reg failed");
+    tca->regs.output = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+
+    *value = tca->regs.output;
+    return ESP_OK;
+}
+
+static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+    value &= 0xffff;
+
+    uint8_t data[] = {DIRECTION_REG_ADDR, value >> 8, value & 0xff};
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_to_device(tca->i2c_num, tca->i2c_address, data, sizeof(data), pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Write direction reg failed");
+    tca->regs.direction = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+
+    *value = tca->regs.direction;
+    return ESP_OK;
+}
+
+static esp_err_t reset(esp_io_expander_t *handle)
+{
+    ESP_RETURN_ON_ERROR(write_direction_reg(handle, DIR_REG_DEFAULT_VAL), TAG, "Write dir reg failed");
+    ESP_RETURN_ON_ERROR(write_output_reg(handle, OUT_REG_DEFAULT_VAL), TAG, "Write output reg failed");
+    return ESP_OK;
+}
+
+static esp_err_t del(esp_io_expander_t *handle)
+{
+    esp_io_expander_tca95xx_16bit_t *tca = (esp_io_expander_tca95xx_16bit_t *)__containerof(handle, esp_io_expander_tca95xx_16bit_t, base);
+
+    free(tca);
+    return ESP_OK;
+}

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/idf_component.yml
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/idf_component.yml
@@ -1,0 +1,7 @@
+dependencies:
+  esp_io_expander:
+    version: ^1.0.1
+  idf: '>=4.4.2'
+description: ESP IO Expander - tca9539 and tca9555
+url: https://github.com/espressif/esp-bsp/tree/master/components/io_expander/esp_io_expander_tca95xx_16bit
+version: 1.0.0

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/include/esp_io_expander_tca95xx_16bit.h
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/include/esp_io_expander_tca95xx_16bit.h
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "driver/i2c.h"
+#include "esp_err.h"
+
+#include "esp_io_expander.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create a new TCA95xx_16bit IO expander driver
+ *
+ * @note The I2C communication should be initialized before use this function
+ *
+ * @param i2c_num: I2C port num
+ * @param i2c_address: I2C address of chip (\see esp_io_expander_tca_95xx_16bit_address)
+ * @param handle: IO expander handle
+ *
+ * @return
+ *      - ESP_OK: Success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_io_expander_new_i2c_tca95xx_16bit(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle);
+
+/**
+ * @brief I2C address of the TCA9539 or TCA9555
+ *
+ * The 8-bit address format for the TCA9539 is as follows:
+ *
+ *                (Slave Address)
+ *     ┌─────────────────┷─────────────────┐
+ *  ┌─────┐─────┐─────┐─────┐─────┐─────┐─────┐─────┐
+ *  |  1  |  1  |  1  |  0  |  1  | A1  | A0  | R/W |
+ *  └─────┘─────┘─────┘─────┘─────┘─────┘─────┘─────┘
+ *     └────────┯──────────────┘     └──┯──┘
+ *           (Fixed)        (Hareware Selectable)
+ *
+ * The 8-bit address format for the TCA9555 is as follows:
+ *
+ *                (Slave Address)
+ *     ┌─────────────────┷─────────────────┐
+ *  ┌─────┐─────┐─────┐─────┐─────┐─────┐─────┐─────┐
+ *  |  0  |  1  |  0  |  0  | A2  | A1  | A0  | R/W |
+ *  └─────┘─────┘─────┘─────┘─────┘─────┘─────┘─────┘
+ *     └────────┯────────┘     └─────┯──────┘
+ *           (Fixed)        (Hareware Selectable)
+ *
+ * And the 7-bit slave address is the most important data for users.
+ * For example, if a TCA9555 chip's A0,A1,A2 are connected to GND, it's 7-bit slave address is 0b0100000.
+ * Then users can use `ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_000` to init it.
+ */
+enum esp_io_expander_tca_95xx_16bit_address {
+    ESP_IO_EXPANDER_I2C_TCA9539_ADDRESS_00 = 0b1110100,
+    ESP_IO_EXPANDER_I2C_TCA9539_ADDRESS_01 = 0b1110101,
+    ESP_IO_EXPANDER_I2C_TCA9539_ADDRESS_10 = 0b1110110,
+    ESP_IO_EXPANDER_I2C_TCA9539_ADDRESS_11 = 0b1110111,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_000 = 0b0100000,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_001 = 0b0100001,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_010 = 0b0100010,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_011 = 0b0100011,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_100 = 0b0100000,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_101 = 0b0100101,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_110 = 0b0100110,
+    ESP_IO_EXPANDER_I2C_TCA9555_ADDRESS_111 = 0b0100111,
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/io_expander/esp_io_expander_tca95xx_16bit/license.txt
+++ b/components/io_expander/esp_io_expander_tca95xx_16bit/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
closes #137

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [x] Version of modified component bumped
- [ ] CI passing

# Change description

Added TCA9539 and TCA9555 16bit port expanders.
