### PR TITLE
CST816: Extend the reset time and fix the interruption

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/README.md
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/README.md
@@ -8,6 +8,13 @@ Implementation of the CST816S touch controller with esp_lcd_touch component.
 | :--------------: | :---------------------: | :-------------------: | :------------------------------------------------------------------------: |
 |     CST816S      |           I2C           | esp_lcd_touch_cst816s | [datasheet](https://www.buydisplay.com/download/ic/DS-CST816S_DS_V1.3.pdf) |
 
+**Note, there are two things about the driver are noteworthy (from [document](https://doc.riot-os.org/group__drivers__cst816s.html)):**
+
+* It only responds to I2C commands after an event, such as a touch detection. Do not expect it to respond on init. Instead after a touch event, it will assert the IRQ and respond to I2C reads for a short time.
+* While it should be able to detect multiple finger events, this version of the chip always returns only a single finger event and a gesture.
+
+Reading the display data multiple times during a single event will return the last sampled finger position.
+
 ## Add to project
 
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
@@ -20,6 +27,28 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ## Example use
 
+Define a mutex for the touch and create it before initialize the touch:
+
+```
+static SemaphoreHandle_t touch_mux;
+
+touch_mux = xSemaphoreCreateBinary();
+```
+
+Define a callback function used by ISR:
+
+```
+static void touch_callback(esp_lcd_touch_handle_t tp)
+{
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xSemaphoreGiveFromISR(touch_mux, &xHigherPriorityTaskWoken);
+
+    if (xHigherPriorityTaskWoken) {
+        portYIELD_FROM_ISR();
+    }
+}
+```
+
 Initialization of the touch component.
 
 ```
@@ -28,8 +57,8 @@ Initialization of the touch component.
     esp_lcd_touch_config_t tp_cfg = {
         .x_max = CONFIG_LCD_HRES,
         .y_max = CONFIG_LCD_VRES,
-        .rst_gpio_num = -1,
-        .int_gpio_num = -1,
+        .rst_gpio_num = CONFIG_LCD_TOUCH_RST,
+        .int_gpio_num = CONFIG_LCD_TOUCH_INT,
         .levels = {
             .reset = 0,
             .interrupt = 0,
@@ -39,6 +68,7 @@ Initialization of the touch component.
             .mirror_x = 0,
             .mirror_y = 0,
         },
+        .interrupt_callback = touch_callback,
     };
 
     esp_lcd_touch_handle_t tp;
@@ -48,7 +78,9 @@ Initialization of the touch component.
 Read data from the touch controller and store it in RAM memory. It should be called regularly in poll.
 
 ```
-    esp_lcd_touch_read_data(tp);
+    if (xSemaphoreTake(touch_mux, 0) == pdTRUE) {
+        esp_lcd_touch_read_data(tp); // read only when ISR was triggled
+    }
 ```
 
 Get one X and Y coordinates with strength of touch.

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -60,23 +60,23 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     if (cst816s->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(cst816s->config.int_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");
-    }
-    /* Prepare pin for touch controller reset */
-    if (cst816s->config.rst_gpio_num != GPIO_NUM_NC) {
-        const gpio_config_t rst_gpio_config = {
-            .mode = GPIO_MODE_OUTPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
-            .pin_bit_mask = BIT64(cst816s->config.rst_gpio_num)
-        };
-        ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");
 
         /* Register interrupt callback */
         if (cst816s->config.interrupt_callback) {
             esp_lcd_touch_register_interrupt_callback(cst816s, cst816s->config.interrupt_callback);
         }
+    }
+    /* Prepare pin for touch controller reset */
+    if (cst816s->config.rst_gpio_num != GPIO_NUM_NC) {
+        const gpio_config_t rst_gpio_config = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = BIT64(cst816s->config.rst_gpio_num)
+        };
+        ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");
     }
     /* Reset controller */
     ESP_GOTO_ON_ERROR(reset(cst816s), err, TAG, "Reset failed");
@@ -160,9 +160,9 @@ static esp_err_t reset(esp_lcd_touch_handle_t tp)
 {
     if (tp->config.rst_gpio_num != GPIO_NUM_NC) {
         ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, tp->config.levels.reset), TAG, "GPIO set level failed");
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(200));
         ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, !tp->config.levels.reset), TAG, "GPIO set level failed");
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(200));
     }
 
     return ESP_OK;

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2~1"
+version: "1.0.3"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
@@ -113,26 +113,26 @@ esp_err_t esp_lcd_touch_new_spi_stmpe610(const esp_lcd_panel_io_handle_t io, con
     if (esp_lcd_touch_stmpe610->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
+            .intr_type = GPIO_INTR_NEGEDGE,
             .pin_bit_mask = BIT64(esp_lcd_touch_stmpe610->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);
-        ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
-    }
-
-    /* Prepare pin for touch controller reset */
-    if (esp_lcd_touch_stmpe610->config.rst_gpio_num != GPIO_NUM_NC) {
-        const gpio_config_t rst_gpio_config = {
-            .mode = GPIO_MODE_OUTPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
-            .pin_bit_mask = BIT64(esp_lcd_touch_stmpe610->config.rst_gpio_num)
-        };
-        ret = gpio_config(&rst_gpio_config);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
 
         /* Register interrupt callback */
         if (esp_lcd_touch_stmpe610->config.interrupt_callback) {
             esp_lcd_touch_register_interrupt_callback(esp_lcd_touch_stmpe610, esp_lcd_touch_stmpe610->config.interrupt_callback);
         }
+    }
+
+    /* Prepare pin for touch controller reset */
+    if (esp_lcd_touch_stmpe610->config.rst_gpio_num != GPIO_NUM_NC) {
+        const gpio_config_t rst_gpio_config = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = BIT64(esp_lcd_touch_stmpe610->config.rst_gpio_num)
+        };
+        ret = gpio_config(&rst_gpio_config);
+        ESP_GOTO_ON_ERROR(ret, err, TAG, "GPIO config failed");
     }
 
     /* Reset and init controller */

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5~1"
+version: "1.0.6"
 description: ESP LCD Touch STMPE610 - touch controller STMPE610
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lcd_touch_stmpe610
 dependencies:


### PR DESCRIPTION
Closes https://github.com/espressif/esp-bsp/issues/178

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Fix bugs of `esp_lcd_touch_cst816s`
