### PR TITLE
framebuffer: esp-box/esp-box-lite use framebuf height form Kconfig (BSP-331)

### DIFF
--- a/esp-box-lite/Kconfig
+++ b/esp-box-lite/Kconfig
@@ -69,9 +69,8 @@ menu "Board Support Package"
             Framebuf is used for lvgl rendering output.
 
         config BSP_LCD_DRAW_BUF_DOUBLE
-        int "LCD framebuf number"
-        default 0
-        range 0 1
+        bool "LCD double framebuf"
+        default n
         help
             Whether to enable double framebuf.
     endmenu

--- a/esp-box-lite/Kconfig
+++ b/esp-box-lite/Kconfig
@@ -60,6 +60,20 @@ menu "Board Support Package"
         help
             LEDC channel is used to generate PWM signal that controls display brightness.
             Set LEDC index that should be used.
+
+        config BSP_LCD_DRAW_BUF_HEIGHT
+        int "LCD framebuf height"
+        default 100
+        range 10 240
+        help
+            Framebuf is used for lvgl rendering output.
+
+        config BSP_LCD_DRAW_BUF_DOUBLE
+        int "LCD framebuf number"
+        default 0
+        range 0 1
+        help
+            Whether to enable double framebuf.
     endmenu
 
     config BSP_I2S_NUM

--- a/esp-box-lite/esp-box-lite.c
+++ b/esp-box-lite/esp-box-lite.c
@@ -383,7 +383,11 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .io_handle = io_handle,
         .panel_handle = panel_handle,
         .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
-        .double_buffer = CONFIG_BSP_LCD_DRAW_BUF_DOUBLE,
+#if CONFIG_BSP_LCD_DRAW_BUF_DOUBLE
+        .double_buffer = 1,
+#else
+        .double_buffer = 0,
+#endif
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp-box-lite/esp-box-lite.c
+++ b/esp-box-lite/esp-box-lite.c
@@ -371,7 +371,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = (BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT) * sizeof(uint16_t),
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 
@@ -382,8 +382,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
+        .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
+        .double_buffer = CONFIG_BSP_LCD_DRAW_BUF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp-box-lite/idf_component.yml
+++ b/esp-box-lite/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Board Support Package for ESP32-S3-BOX-Lite
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box-lite
 

--- a/esp-box-lite/include/bsp/esp-box-lite.h
+++ b/esp-box-lite/include/bsp/esp-box-lite.h
@@ -299,11 +299,6 @@ esp_err_t bsp_spiffs_unmount(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
-#ifndef BSP_LCD_DRAW_BUFF_SIZE
-#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 100)
-#endif
-#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
-
 /**
  * @brief Initialize display
  *

--- a/esp-box/Kconfig
+++ b/esp-box/Kconfig
@@ -60,6 +60,20 @@ menu "Board Support Package"
         help
             LEDC channel is used to generate PWM signal that controls display brightness.
             Set LEDC index that should be used.
+
+        config BSP_LCD_DRAW_BUF_HEIGHT
+        int "LCD framebuf height"
+        default 100
+        range 10 240
+        help
+            Framebuf is used for lvgl rendering output.
+
+        config BSP_LCD_DRAW_BUF_DOUBLE
+        int "LCD framebuf number"
+        default 0
+        range 0 1
+        help
+            Whether to enable double framebuf.
     endmenu
     
     config BSP_I2S_NUM

--- a/esp-box/Kconfig
+++ b/esp-box/Kconfig
@@ -69,9 +69,8 @@ menu "Board Support Package"
             Framebuf is used for lvgl rendering output.
 
         config BSP_LCD_DRAW_BUF_DOUBLE
-        int "LCD framebuf number"
-        default 0
-        range 0 1
+        bool "LCD double framebuf"
+        default n
         help
             Whether to enable double framebuf.
     endmenu

--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -362,7 +362,7 @@ static lv_disp_t *bsp_display_lcd_init(void)
     esp_lcd_panel_io_handle_t io_handle = NULL;
     esp_lcd_panel_handle_t panel_handle = NULL;
     const bsp_display_config_t bsp_disp_cfg = {
-        .max_transfer_sz = BSP_LCD_DRAW_BUFF_SIZE * sizeof(uint16_t),
+        .max_transfer_sz = (BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT) * sizeof(uint16_t),
     };
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
 
@@ -373,8 +373,8 @@ static lv_disp_t *bsp_display_lcd_init(void)
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
+        .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
+        .double_buffer = CONFIG_BSP_LCD_DRAW_BUF_DOUBLE,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -374,7 +374,11 @@ static lv_disp_t *bsp_display_lcd_init(void)
         .io_handle = io_handle,
         .panel_handle = panel_handle,
         .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
-        .double_buffer = CONFIG_BSP_LCD_DRAW_BUF_DOUBLE,
+#if CONFIG_BSP_LCD_DRAW_BUF_DOUBLE
+        .double_buffer = 1,
+#else
+        .double_buffer = 0,
+#endif
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
         .monochrome = false,

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.4.1"
+version: "2.4.2"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 

--- a/esp-box/include/bsp/esp-box.h
+++ b/esp-box/include/bsp/esp-box.h
@@ -283,9 +283,6 @@ esp_err_t bsp_spiffs_unmount(void);
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
-#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 10)
-#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
-
 /**
  * @brief Initialize display
  *


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
In some scenarios, the remaining SRAM is insufficient, make the num of framebuf height to configurable.
