### PR TITLE
fix(ci): Ignore pkg_resources warning

### DIFF
--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -2,6 +2,7 @@ target = "all"
 paths = "examples"
 recursive = true
 check_warnings = true
+ignore_warning_file = ".ignore_build_warnings.txt"
 config = "sdkconfig.bsp.*"
 
 # build related options

--- a/.ignore_build_warnings.txt
+++ b/.ignore_build_warnings.txt
@@ -1,0 +1,1 @@
+DeprecationWarning: pkg_resources is deprecated as an API


### PR DESCRIPTION
Ignore pkg_resources warning coming from updated `pip`