### PR TITLE
add lvgl task size and task priority config for lvgl task (BSP-334)

### DIFF
--- a/components/esp_lvgl_port/Kconfig
+++ b/components/esp_lvgl_port/Kconfig
@@ -1,0 +1,14 @@
+menu "ESP Lvgl Port"
+
+    config LVGL_PORT_TASK_STACK_SIZE
+        int "Lvgl task stack size"
+        default 4096
+        help
+            Set the default lvgl port task stack size.
+
+    config LVGL_PORT_TASK_PRIORITY
+        int "LVGL task priority"
+        default 4
+        help
+            Set the default lvgl port task priority.
+endmenu

--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -109,13 +109,13 @@ typedef struct {
  * @brief LVGL port configuration structure
  *
  */
-#define ESP_LVGL_PORT_INIT_CONFIG() \
-    {                               \
-        .task_priority = 4,       \
-        .task_stack = 4096,       \
-        .task_affinity = -1,      \
-        .task_max_sleep_ms = 500, \
-        .timer_period_ms = 5,     \
+#define ESP_LVGL_PORT_INIT_CONFIG()                     \
+    {                                                   \
+        .task_priority = CONFIG_LVGL_PORT_TASK_PRIORITY,\
+        .task_stack = CONFIG_LVGL_PORT_TASK_STACK_SIZE, \
+        .task_affinity = -1,                            \
+        .task_max_sleep_ms = 500,                       \
+        .timer_period_ms = 5,                           \
     }
 
 /**


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

In some application, the default 4096 lvgl task stack size is not enough, so we need config this task stack size

# Change
Add a menuconfig entry to config the lvgl task stack size and priority
