### PR TITLE
bsp: Added support for IDF v4.4 into ESP-BOX

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -1,0 +1,4 @@
+examples:
+  disable:
+    - if: IDF_VERSION_MAJOR < 5 and CONFIG_NAME not in ["esp-box"]
+      reason: Example depends on BSP, which is supported only for IDF >= 5.0

--- a/.github/PULL_REQUEST_TEMPLATE/pr_template_bsp.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template_bsp.md
@@ -7,6 +7,8 @@
 - [ ] Component was added to CI [upload job](https://github.com/espressif/esp-bsp/blob/master/.github/workflows/upload_component.yml#L17)
 - [ ] New files were added to CI build job
 - [ ] New BSP definitions added to [bsp_ext.py](../examples/bsp_ext.py)
+- [ ] BSP was [added to SquareLine](https://github.com/espressif/esp-bsp/tree/master/SquareLine/common)
+- [ ] New BSP supports IDF v4.4.x and later releases
 - [ ] _Optional:_ Component contains unit tests
 - [ ] CI passing
 

--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -8,8 +8,25 @@ jobs:
   build:
     strategy:
       matrix:
-        idf_ver: ["latest"]
-        parallel_index: [1,2,3,4,5] # This must be from 1 to 'parallel_count' defined in .idf_build_apps.toml
+        include:
+          - idf_ver: "latest"
+            parallel_count: 5
+            parallel_index: 1
+          - idf_ver: "latest"
+            parallel_count: 5
+            parallel_index: 2
+          - idf_ver: "latest"
+            parallel_count: 5
+            parallel_index: 3
+          - idf_ver: "latest"
+            parallel_count: 5
+            parallel_index: 4
+          - idf_ver: "latest"
+            parallel_count: 5
+            parallel_index: 5
+          - idf_ver: "release-v4.4"
+            parallel_count: 1
+            parallel_index: 1
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -23,4 +40,4 @@ jobs:
           . ${IDF_PATH}/export.sh
           pip install idf-component-manager ruamel.yaml idf-build-apps --upgrade
           idf-build-apps find
-          idf-build-apps build --parallel-index ${{ matrix.parallel_index }}
+          idf-build-apps build --parallel-count ${{ matrix.parallel_count }} --parallel-index ${{ matrix.parallel_index }}

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -1,10 +1,10 @@
 target = "all"
 paths = "examples"
 recursive = true
+manifest_file = ".build-test-rules.yml"
 check_warnings = true
 ignore_warning_file = ".ignore_build_warnings.txt"
 config = "sdkconfig.bsp.*"
 
 # build related options
 build_dir = "build_@w"
-parallel_count = 5

--- a/esp-box/CMakeLists.txt
+++ b/esp-box/CMakeLists.txt
@@ -1,5 +1,12 @@
+#IDF version is less than IDF5.0
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "5.0")
+    set(SRC_VER "esp-box_idf4.c")
+else()
+    set(SRC_VER "esp-box_idf5.c")
+endif()
+
 idf_component_register(
-    SRCS "esp-box.c"
+    SRCS "esp-box.c" ${SRC_VER}
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver spiffs

--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -400,12 +400,22 @@ static lv_indev_t *bsp_display_indev_init(lv_disp_t *disp)
 
 lv_disp_t *bsp_display_start(void)
 {
-    const lvgl_port_cfg_t lvgl_cfg = ESP_LVGL_PORT_INIT_CONFIG();
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&lvgl_cfg));
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG()
+    };
+    return bsp_display_start_with_config(&cfg);
+}
+
+lv_disp_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+{
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
 
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
-    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
+    BSP_NULL_CHECK(bsp_display_indev_init(disp), NULL);
 
     return disp;
 }

--- a/esp-box/esp-box_idf4.c
+++ b/esp-box/esp-box_idf4.c
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_err.h"
+#include "bsp/esp-box.h"
+#include "bsp_err_check.h"
+#include "esp_codec_dev_defaults.h"
+
+static const char *TAG = "ESP-BOX";
+
+/* This configuration is used by default in bsp_audio_init() */
+#define BSP_I2S_DUPLEX_MONO_CFG(_sample_rate)                      \
+    {                                                                 \
+        .mode = I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_RX,          \
+        .sample_rate = _sample_rate,                                  \
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,                 \
+        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,                  \
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,            \
+        .dma_buf_count = 3,                                           \
+        .dma_buf_len = 1024,                                          \
+        .use_apll = true,                                             \
+        .tx_desc_auto_clear = true,                                   \
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2 | ESP_INTR_FLAG_IRAM \
+    }
+
+static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface */
+
+esp_err_t bsp_audio_init(const i2s_config_t *i2s_config)
+{
+    esp_err_t ret = ESP_FAIL;
+
+    if (i2s_data_if != NULL) {
+        /* Audio was initialized before */
+        return ESP_OK;
+    }
+
+    /* Setup I2S peripheral */
+    const i2s_pin_config_t i2s_pin_config = {
+        .mck_io_num = BSP_I2S_MCLK,
+        .bck_io_num = BSP_I2S_SCLK,
+        .ws_io_num = BSP_I2S_LCLK,
+        .data_out_num = BSP_I2S_DOUT,
+        .data_in_num = BSP_I2S_DSIN
+    };
+
+    /* Setup I2S channels */
+    const i2s_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
+    const i2s_config_t *p_i2s_cfg = &std_cfg_default;
+    if (i2s_config != NULL) {
+        p_i2s_cfg = i2s_config;
+    }
+
+    ESP_ERROR_CHECK(i2s_driver_install(CONFIG_BSP_I2S_NUM, p_i2s_cfg, 0, NULL));
+    ESP_GOTO_ON_ERROR(i2s_set_pin(CONFIG_BSP_I2S_NUM, &i2s_pin_config), err, TAG, "I2S set pin failed");
+
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = CONFIG_BSP_I2S_NUM,
+    };
+    i2s_data_if = audio_codec_new_i2s_data(&i2s_cfg);
+    BSP_NULL_CHECK_GOTO(i2s_data_if, err);
+
+    return ESP_OK;
+
+err:
+    i2s_driver_uninstall(CONFIG_BSP_I2S_NUM);
+    return ret;
+}
+
+const audio_codec_data_if_t *bsp_audio_get_codec_itf(void)
+{
+    return i2s_data_if;
+}

--- a/esp-box/esp-box_idf5.c
+++ b/esp-box/esp-box_idf5.c
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_err.h"
+#include "bsp/esp-box.h"
+#include "bsp_err_check.h"
+#include "esp_codec_dev_defaults.h"
+
+static const char *TAG = "ESP-BOX";
+
+static i2s_chan_handle_t i2s_tx_chan = NULL;
+static i2s_chan_handle_t i2s_rx_chan = NULL;
+static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface */
+
+
+/* Can be used for i2s_std_gpio_config_t and/or i2s_std_config_t initialization */
+#define BSP_I2S_GPIO_CFG       \
+    {                          \
+        .mclk = BSP_I2S_MCLK,  \
+        .bclk = BSP_I2S_SCLK,  \
+        .ws = BSP_I2S_LCLK,    \
+        .dout = BSP_I2S_DOUT,  \
+        .din = BSP_I2S_DSIN,   \
+        .invert_flags = {      \
+            .mclk_inv = false, \
+            .bclk_inv = false, \
+            .ws_inv = false,   \
+        },                     \
+    }
+
+/* This configuration is used by default in bsp_audio_init() */
+#define BSP_I2S_DUPLEX_MONO_CFG(_sample_rate)                                                         \
+    {                                                                                                 \
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sample_rate),                                          \
+        .slot_cfg = I2S_STD_PHILIP_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO), \
+        .gpio_cfg = BSP_I2S_GPIO_CFG,                                                                 \
+    }
+
+esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config)
+{
+    esp_err_t ret = ESP_FAIL;
+    if (i2s_tx_chan && i2s_rx_chan) {
+        /* Audio was initialized before */
+        return ESP_OK;
+    }
+
+    /* Setup I2S peripheral */
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(CONFIG_BSP_I2S_NUM, I2S_ROLE_MASTER);
+    chan_cfg.auto_clear = true; // Auto clear the legacy data in the DMA buffer
+    BSP_ERROR_CHECK_RETURN_ERR(i2s_new_channel(&chan_cfg, &i2s_tx_chan, &i2s_rx_chan));
+
+    /* Setup I2S channels */
+    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
+    const i2s_std_config_t *p_i2s_cfg = &std_cfg_default;
+    if (i2s_config != NULL) {
+        p_i2s_cfg = i2s_config;
+    }
+
+    if (i2s_tx_chan != NULL) {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_tx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
+        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_tx_chan), err, TAG, "I2S enabling failed");
+    }
+    if (i2s_rx_chan != NULL) {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_rx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
+        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "I2S enabling failed");
+    }
+
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = CONFIG_BSP_I2S_NUM,
+        .rx_handle = i2s_rx_chan,
+        .tx_handle = i2s_tx_chan,
+    };
+    i2s_data_if = audio_codec_new_i2s_data(&i2s_cfg);
+    BSP_NULL_CHECK_GOTO(i2s_data_if, err);
+
+    return ESP_OK;
+
+err:
+    if (i2s_tx_chan) {
+        i2s_del_channel(i2s_tx_chan);
+    }
+    if (i2s_rx_chan) {
+        i2s_del_channel(i2s_rx_chan);
+    }
+
+    return ret;
+}
+
+const audio_codec_data_if_t *bsp_audio_get_codec_itf(void)
+{
+    return i2s_data_if;
+}

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.4.2"
+version: "3.0.0"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 
@@ -7,7 +7,7 @@ targets:
   - esp32s3
 
 dependencies:
-  idf: ">=5.0"
+  idf: ">=4.4.5"
   esp_lcd_touch_tt21100: "^1"
 
   esp_lvgl_port:
@@ -16,6 +16,10 @@ dependencies:
 
   esp_codec_dev:
     version: "^1"
+    public: true
+
+  button:
+    version: "^2.5"
     public: true
 
 examples:

--- a/esp-box/include/bsp/esp-box.h
+++ b/esp-box/include/bsp/esp-box.h
@@ -16,6 +16,7 @@
 #include "driver/i2c.h"
 #include "soc/usb_pins.h"
 #include "lvgl.h"
+#include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
 
@@ -105,6 +106,14 @@ typedef enum {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief BSP display configuration structure
+ *
+ */
+typedef struct {
+    lvgl_port_cfg_t lvgl_port_cfg;
+} bsp_display_cfg_t;
 
 /**************************************************************************************************
  *
@@ -272,6 +281,18 @@ esp_err_t bsp_spiffs_unmount(void);
  * @return Pointer to LVGL display or NULL when error occured
  */
 lv_disp_t *bsp_display_start(void);
+
+/**
+ * @brief Initialize display
+ *
+ * This function initializes SPI, display controller and starts LVGL handling task.
+ * LCD backlight must be enabled separately by calling bsp_display_brightness_set()
+ *
+ * @param cfg display configuration
+ *
+ * @return Pointer to LVGL display or NULL when error occured
+ */
+lv_disp_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
 
 /**
  * @brief Get pointer to input device (touch, buttons, ...)

--- a/examples/bsp_ext.py
+++ b/examples/bsp_ext.py
@@ -13,8 +13,8 @@ def action_extensions(base_actions, project_path=os.getcwd()):
     try:
         from idf_py_actions.tools import PropertyDict, red_print
     except ImportError:
-        print('Unsupported IDF version!')
-        return {}
+        PropertyDict = dict
+        red_print = print
     try:
         import ruamel.yaml
     except ImportError:

--- a/examples/display/main/idf_component.yml
+++ b/examples/display/main/idf_component.yml
@@ -1,7 +1,6 @@
 description: BSP Display example
 
 dependencies:
-  idf: ">=4.4"
   esp_wrover_kit:
     version: "^1.0.0"
     override_path: "../../../esp_wrover_kit"

--- a/examples/display_audio_photo/main/app_disp_fs.c
+++ b/examples/display_audio_photo/main/app_disp_fs.c
@@ -35,7 +35,7 @@
    With sampling frequency 22050 Hz and 16bit mono resolution it equals to ~3.715 seconds */
 #define RECORDING_LENGTH (160)
 
-#define REC_FILENAME    "/root/recording.wav"
+#define REC_FILENAME    FS_MNT_PATH"/recording.wav"
 
 static const char *TAG = "DISP";
 
@@ -787,7 +787,7 @@ static void rec_file(void *arg)
     ESP_LOGI(TAG, "Recording start");
 
     esp_codec_dev_sample_info_t fs = {
-        .sample_rate = SAMPLE_RATE / 2,
+        .sample_rate = SAMPLE_RATE,
         .channel = 1,
         .bits_per_sample = 16,
     };

--- a/examples/display_audio_photo/main/idf_component.yml
+++ b/examples/display_audio_photo/main/idf_component.yml
@@ -1,6 +1,5 @@
 description: BSP Display Audio Photo Example
 dependencies:
-  idf: ">=4.4"
   esp_jpeg: "*"
   esp-box:
     version: ">=3.0.0"

--- a/examples/display_audio_photo/main/idf_component.yml
+++ b/examples/display_audio_photo/main/idf_component.yml
@@ -1,7 +1,7 @@
 description: BSP Display Audio Photo Example
 dependencies:
-  idf: ">=5.0"
+  idf: ">=4.4"
   esp_jpeg: "*"
   esp-box:
-    version: "*"
+    version: ">=3.0.0"
     override_path: "../../../esp-box"

--- a/examples/display_camera/main/idf_component.yml
+++ b/examples/display_camera/main/idf_component.yml
@@ -1,7 +1,6 @@
 description: BSP Display and camera example
 
 dependencies:
-  idf: ">=4.4"
   esp32_s2_kaluga_kit:
     version: "*"
     override_path: "../../../esp32_s2_kaluga_kit"

--- a/examples/display_lvgl_demos/main/idf_component.yml
+++ b/examples/display_lvgl_demos/main/idf_component.yml
@@ -1,6 +1,5 @@
 description: BSP Display rotation example
 dependencies:
-  idf: ">=5"
   esp32_s3_lcd_ev_board:
     version: "*"
     override_path: "../../../esp32_s3_lcd_ev_board"

--- a/examples/display_rotation/main/idf_component.yml
+++ b/examples/display_rotation/main/idf_component.yml
@@ -1,6 +1,5 @@
 description: BSP Display rotation example
 dependencies:
-  idf: ">=4.4"
   esp-box:
     version: "*"
     override_path: "../../../esp-box"


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Added support for IDF v4.4 into ESP-BOX
- Fixed display_audio_photo example (recording)
- Updated Pull Request template for new BSPs
- Used new API for button handling
- New API for display init with configuration
- Removed minimal IDF version from examples

Closes https://github.com/espressif/esp-bsp/issues/151