### PR TITLE
lcd_touch_ft5x06: Fixed missing reset.

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -146,6 +146,9 @@ static esp_err_t del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
     if (tp->config.rst_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.rst_gpio_num);

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -60,7 +60,7 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     if (cst816s->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (cst816s->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(cst816s->config.int_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -242,6 +242,9 @@ static esp_err_t esp_lcd_touch_ft5x06_del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
 
     /* Reset GPIO pin settings */

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -124,7 +124,7 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
     if (esp_lcd_touch_ft5x06->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (esp_lcd_touch_ft5x06->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(esp_lcd_touch_ft5x06->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5~1"
+version: "1.0.6"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
@@ -178,6 +178,9 @@ static esp_err_t del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
     if (tp->config.rst_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.rst_gpio_num);

--- a/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
@@ -65,7 +65,7 @@ esp_err_t esp_lcd_touch_new_i2c_gt1151(const esp_lcd_panel_io_handle_t io, const
     if (gt1151->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (gt1151->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(gt1151->config.int_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&int_gpio_config), err, TAG, "GPIO intr config failed");

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -205,6 +205,9 @@ static esp_err_t esp_lcd_touch_gt911_del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
 
     /* Reset GPIO pin settings */

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -74,7 +74,7 @@ esp_err_t esp_lcd_touch_new_i2c_gt911(const esp_lcd_panel_io_handle_t io, const 
     if (esp_lcd_touch_gt911->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (esp_lcd_touch_gt911->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(esp_lcd_touch_gt911->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
@@ -113,7 +113,7 @@ esp_err_t esp_lcd_touch_new_spi_stmpe610(const esp_lcd_panel_io_handle_t io, con
     if (esp_lcd_touch_stmpe610->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (esp_lcd_touch_stmpe610->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(esp_lcd_touch_stmpe610->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
@@ -246,6 +246,9 @@ static esp_err_t esp_lcd_touch_stmpe610_del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
 
     /* Reset GPIO pin settings */

--- a/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
@@ -79,7 +79,7 @@ esp_err_t esp_lcd_touch_new_i2c_tt21100(const esp_lcd_panel_io_handle_t io, cons
     if (esp_lcd_touch_tt21100->config.int_gpio_num != GPIO_NUM_NC) {
         const gpio_config_t int_gpio_config = {
             .mode = GPIO_MODE_INPUT,
-            .intr_type = GPIO_INTR_NEGEDGE,
+            .intr_type = (esp_lcd_touch_tt21100->config.levels.interrupt ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE),
             .pin_bit_mask = BIT64(esp_lcd_touch_tt21100->config.int_gpio_num)
         };
         ret = gpio_config(&int_gpio_config);

--- a/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
@@ -307,6 +307,9 @@ static esp_err_t esp_lcd_touch_tt21100_del(esp_lcd_touch_handle_t tp)
     /* Reset GPIO pin settings */
     if (tp->config.int_gpio_num != GPIO_NUM_NC) {
         gpio_reset_pin(tp->config.int_gpio_num);
+        if (tp->config.interrupt_callback) {
+            gpio_isr_handler_remove(tp->config.int_gpio_num);
+        }
     }
 
     /* Reset GPIO pin settings */


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
Fixed missing reset call in `esp_lcd_touch_ft5x06`. 
Fixed interrupt level in all touch drivers.
Closes #211
