### PR TITLE
esp-box: Prevent I2C bus form getting stuck. (BSP-377)

### DIFF
--- a/esp-box/esp-box.c
+++ b/esp-box/esp-box.c
@@ -495,7 +495,6 @@ bool bsp_button_get(const bsp_button_t btn)
 static uint8_t bsp_get_main_button(void *param)
 {
     assert(tp);
-    ESP_ERROR_CHECK(esp_lcd_touch_read_data(tp));
 #if (CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS > 0)
     uint8_t home_btn_val = 0x00;
     esp_lcd_touch_get_button_state(tp, 0, &home_btn_val);

--- a/esp-box/idf_component.yml
+++ b/esp-box/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "3.0.0"
+version: "3.0.1"
 description: Board Support Package for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [x] Version of modified component bumped
- [x] CI passing

# Change description
Iot button call `bsp_get_main_button` too busy, it'll block I2C bus.
