### PR TITLE
esp-box-lite: Add initialization and definition of IO button (BSP-376)

### DIFF
--- a/esp-box-lite/Kconfig
+++ b/esp-box-lite/Kconfig
@@ -1,4 +1,4 @@
-menu "Board Support Package"
+menu "Board Support Package(ESP-BOX-Lite)"
 
     config BSP_ERROR_CHECK
         bool "Enable error check in BSP"

--- a/esp-box-lite/idf_component.yml
+++ b/esp-box-lite/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: Board Support Package for ESP32-S3-BOX-Lite
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box-lite
 

--- a/esp-box-lite/include/bsp/esp-box-lite.h
+++ b/esp-box-lite/include/bsp/esp-box-lite.h
@@ -53,6 +53,9 @@
 #define BSP_USB_POS           USBPHY_DP_NUM
 #define BSP_USB_NEG           USBPHY_DM_NUM
 
+/* Buttons */
+#define BSP_BUTTON_CONFIG_IO  (GPIO_NUM_0)
+
 /* PMOD */
 /*
  * PMOD interface (peripheral module interface) is an open standard defined by Digilent Inc.
@@ -98,9 +101,7 @@ extern "C" {
 
 /* Buttons */
 typedef enum {
-    BSP_BUTTON_PREV,
-    BSP_BUTTON_ENTER,
-    BSP_BUTTON_NEXT,
+    BSP_BUTTON_CONFIG,
     BSP_BUTTON_NUM
 } bsp_button_t;
 
@@ -393,6 +394,24 @@ esp_err_t bsp_adc_initialize(void);
  */
 adc_oneshot_unit_handle_t bsp_adc_get_handle(void);
 #endif
+
+/**
+ * @brief Initialize all buttons
+ *
+ * Returned button handlers must be used with espressif/button component API
+ *
+ * @note ADC buttons BSP_BUTTON_PREV, BSP_BUTTON_ENTER, BSP_BUTTON_NEXT won't be created by this API,
+ *       they will be maintained by esp_lvgl_port.
+ *
+ * @param[out] btn_array      Output button array
+ * @param[out] btn_cnt        Number of button handlers saved to btn_array, can be NULL
+ * @param[in]  btn_array_size Size of output button array. Must be at least BSP_BUTTON_NUM
+ * @return
+ *     - ESP_OK               All buttons initialized
+ *     - ESP_ERR_INVALID_ARG  btn_array is too small or NULL
+ *     - ESP_FAIL             Underlaying iot_button_create failed
+ */
+esp_err_t bsp_iot_button_create(button_handle_t btn_array[], int *btn_cnt, int btn_array_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [x] Version of modified component bumped
- [x] CI passing

# Change description
Add initialization and definition of IO button in BSP.

I want to provide the same interface as esp-box here.