### PR TITLE
ci: Add example building workflow for launchpad (BSP-378)

### DIFF
--- a/.github/workflows/build-examples-gh-pages-on-push.yml
+++ b/.github/workflows/build-examples-gh-pages-on-push.yml
@@ -1,0 +1,59 @@
+name: "ESP-IDF build examples to github pages (push)"
+
+on:
+    push:
+        branches:
+        - master
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        idf_ver: ["v5.1.1"]
+    runs-on: ubuntu-latest
+    container: espressif/idf:${{ matrix.idf_ver }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Action for building binaries and config.toml
+        uses: espressif/idf-examples-launchpad-ci-action@v1.0
+        with: 
+          idf_version: ${{ matrix.idf_ver }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: built_files
+          path: binaries/
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write      
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built files
+        uses: actions/download-artifact@v3
+        with:
+          name: built_files
+          path: binaries/
+
+      - name: Upload built files to gh pages
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: binaries/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

# Change description
This PR adds a workflow for integration with Launchpad. It builds examples according to `.idf_build_apps.toml` and uploads merged binaries and `config.toml` to github-pages

Detailed description of the action can be found [here](https://github.com/espressif/idf-examples-launchpad-ci-action)

If you want to build examples with specific versions, please provide me with the list and I will adjust the workflow accordingly

Follow up PR will feature a button in the README files (after examples are built with the action)