### PR TITLE
esp-box-3: add new LCD support (BSP-379)

### DIFF
--- a/esp-box-3/idf_component.yml
+++ b/esp-box-3/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0"
+version: "1.1.0"
 description: Board Support Package for ESP32-S3-BOX-3
 url: https://github.com/espressif/esp-bsp/tree/master/esp-box-3
 
@@ -9,6 +9,8 @@ targets:
 dependencies:
   idf: ">=4.4.5"
   esp_lcd_touch_tt21100: "^1"
+  esp_lcd_touch_gt911: "^1"
+  esp_lcd_ili9341: "^1"
 
   esp_lvgl_port:
     version: "^1"


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [x] Version of modified component bumped
- [x] CI passing

# Change description
Add new LCD support, use I2C probe to select LCD.
