### PR TITLE
docs: Include Launchpad URLs in Examples README (BSP-386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Moreover, LVGL port includes recommendations and tips for increasing graphical p
 
 Best way to start with ESP-BSP is trying one of the [examples](examples) on your board. Every example contains `README.md` with a list of supported boards. Here is the summary of the available examples:
 
-| Example | Supported boards |
-|---|---|
-| [audio](examples/audio) | ESP32-S3-Korvo-2 |
-| [display](examples/display) | WROVER-KIT |
-| [display_camera](examples/display_camera) | Kaluga-kit |
-| [display_audio_photo](examples/display_audio_photo) | ESP-BOX |
-| [display_rotation](examples/display_rotation) | ESP-BOX |
-| [display_lvgl_demos](examples/display_lvgl_demos) | ESP32-S3-LCD-EV-Board |
-| [display_sensors](examples/display_sensors) | Azure-IoT-kit |
-| [mqtt_example](examples/mqtt_example) | Azure-IoT-kit |
+| Example | Supported boards | Try with ESP Launchpad |
+|---|---|---|
+| [audio](examples/audio) | ESP32-S3-Korvo-2 | [Flash audio](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=audio) |
+| [display](examples/display) | WROVER-KIT | [Flash display](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display) |
+| [display_camera](examples/display_camera) | Kaluga-kit | [Flash display_camera](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_camera) |
+| [display_audio_photo](examples/display_audio_photo) | ESP-BOX | [Flash display_audio_photo](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_audio_photo) |
+| [display_rotation](examples/display_rotation) | ESP-BOX | [Flash display_rotation](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_rotation) |
+| [display_lvgl_demos](examples/display_lvgl_demos) | ESP32-S3-LCD-EV-Board | [Flash display_lvgl_demos](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_lvgl_demos) |
+| [display_sensors](examples/display_sensors) | Azure-IoT-kit | [Flash display_sensors](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_sensors) |
+| [mqtt_example](examples/mqtt_example) | Azure-IoT-kit | - |
 
 ### BSP headers
 Each BSP provides its header file in 'bsp' subfolder, so it can be included as follows: `#include "bsp/name-of-the-bsp.h"`.

--- a/examples/audio/README.md
+++ b/examples/audio/README.md
@@ -23,3 +23,7 @@ Playing check box on display will be checked for the playing time.
 ### Buttons VOL+/-
 Increases/decreases playback volume by 5/100.
 Current playback volume is depicted on display.
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=audio">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display/README.md
+++ b/examples/display/README.md
@@ -2,3 +2,7 @@
 
 This is a minimalistic display + LVGL graphics library example.
 In few function calls it sets up the display and shows Espressif's logo and label.
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display_audio_photo/README.md
+++ b/examples/display_audio_photo/README.md
@@ -53,3 +53,6 @@ I (191135) DISP: Bits per sample: 16
 I (191135) DISP: Sample rate: 22050
 I (191135) DISP: Data size: 1763806
 ```
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_audio_photo">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display_camera/README.md
+++ b/examples/display_camera/README.md
@@ -13,3 +13,7 @@ This very simple example continuously fetches image frames from camera and displ
 ### Hardware Required
 
 Kaluga kit with its camera module.
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_camera">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display_lvgl_demos/README.md
+++ b/examples/display_lvgl_demos/README.md
@@ -28,3 +28,7 @@ To improve display performance (FPS), please set the following configurations:
 ### Hardware Required
 
 ESP32-S3-LCD-EV-Board or ESP32-S3-LCD-EV-Board-2
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_lvgl_demos">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display_rotation/README.md
+++ b/examples/display_rotation/README.md
@@ -36,3 +36,7 @@ I (455) ESP-BOX: Setting LCD backlight: 100%
 I (455) ESP-BOX: Starting LVGL task
 I (495) ESP-BOX: Example initialization done.
 ```
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_rotation">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>

--- a/examples/display_sensors/README.md
+++ b/examples/display_sensors/README.md
@@ -15,3 +15,7 @@ On every press of KEY_IO0 button, the buzzer beeps and AZURE LED blinks.
 
 ## uSD card
 If a uSD card is successfully mounted a hello.txt file is created and WIFI LED is turned on.
+
+<a href="https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_sensors">
+    <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="250" height="70">
+</a>


### PR DESCRIPTION
# Description

This MR adds Launchpad URLs in Examples README

As discussed before, the only ommited example is MQTT as it requires Kconfig setup of SSID and Password and it does not make sense to have it flashable by Launchpad