### PR TITLE
change(ci): update astyle_py to 1.0.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/igrr/astyle_py.git
-    rev: master
+    rev: v1.0.5
     hooks:
     -   id: astyle_py
         args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper']


### PR DESCRIPTION
Fixes pre-commit failing with Python 3.12, among other things.
