### PR TITLE
bsp: Add display and touch support to gerenic BSP.

### DIFF
--- a/bsp/esp_bsp_generic/Kconfig
+++ b/bsp/esp_bsp_generic/Kconfig
@@ -1,4 +1,4 @@
-menu "Board Support Package"
+menu "Board Support Package (generic)"
 
     config BSP_ERROR_CHECK
         bool "Enable error check in BSP"
@@ -339,6 +339,8 @@ menu "Board Support Package"
                 Select a LED type GPIO or Adressable RGB 
             config BSP_LED_TYPE_GPIO
                 bool "GPIO LED"
+            config BSP_LED_TYPE_RGB_CLASSIC
+                bool "Classic RGB LED"
             config BSP_LED_TYPE_RGB
                 bool "Adressable RGB LED"
         endchoice
@@ -351,6 +353,42 @@ menu "Board Support Package"
             range -1 ENV_GPIO_OUT_RANGE_MAX
             help
                 The GPIO pin for adressable LEDs.
+                    
+        config BSP_LED_RGB_CLASSIC_LEVEL
+            depends on BSP_LED_TYPE_RGB_CLASSIC
+            int
+            prompt "Classic RGB LED Active Level"
+            default 0
+            range 0 1
+            help
+                The active level for classic RGB LED. 
+            
+        config BSP_LED_RGB_RED_GPIO
+            depends on BSP_LED_TYPE_RGB_CLASSIC
+            int 
+            prompt "Classic RGB LED red GPIO"
+            default -1
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            help
+                The GPIO pin for red color RGB LED.
+            
+        config BSP_LED_RGB_GREEN_GPIO
+            depends on BSP_LED_TYPE_RGB_CLASSIC
+            int 
+            prompt "Classic RGB LED green GPIO"
+            default -1
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            help
+                The GPIO pin for green color RGB LED.
+            
+        config BSP_LED_RGB_BLUE_GPIO
+            depends on BSP_LED_TYPE_RGB_CLASSIC
+            int 
+            prompt "Classic RGB LED blue GPIO"
+            default -1
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            help
+                The GPIO pin for blue color RGB LED.
 
         config BSP_ESP_IDF_VERSION
             string 
@@ -376,7 +414,6 @@ menu "Board Support Package"
             depends on BSP_LEDS_NUM > 0 && BSP_LED_TYPE_GPIO
             
             config BSP_LED_1_GPIO
-                depends on BSP_LED_1_TYPE_GPIO
                 int 
                 prompt "LED 1 GPIO"
                 default 0
@@ -385,7 +422,6 @@ menu "Board Support Package"
                     The GPIO pin for LED 1.
                     
             config BSP_LED_1_LEVEL
-                depends on BSP_LED_1_TYPE_GPIO
                 int
                 prompt "LED 1 Active Level"
                 default 1
@@ -398,7 +434,6 @@ menu "Board Support Package"
             depends on BSP_LEDS_NUM > 1 && BSP_LED_TYPE_GPIO
             
             config BSP_LED_2_GPIO
-                depends on BSP_LED_2_TYPE_GPIO
                 int 
                 prompt "LED 2 GPIO"
                 default 0
@@ -406,7 +441,6 @@ menu "Board Support Package"
                 help
                     The GPIO pin for LED 2.
             config BSP_LED_2_LEVEL
-                depends on BSP_LED_2_TYPE_GPIO
                 int
                 prompt "LED 2 Active Level"
                 default 1
@@ -419,7 +453,6 @@ menu "Board Support Package"
             depends on BSP_LEDS_NUM > 2 && BSP_LED_TYPE_GPIO
             
             config BSP_LED_3_GPIO
-                depends on BSP_LED_3_TYPE_GPIO
                 int 
                 prompt "LED 3 GPIO"
                 default 0
@@ -427,7 +460,6 @@ menu "Board Support Package"
                 help
                     The GPIO pin for LED 3.
             config BSP_LED_3_LEVEL
-                depends on BSP_LED_3_TYPE_GPIO
                 int
                 prompt "LED 3 Active Level"
                 default 1
@@ -440,7 +472,6 @@ menu "Board Support Package"
             depends on BSP_LEDS_NUM > 3 && BSP_LED_TYPE_GPIO
             
             config BSP_LED_4_GPIO
-                depends on BSP_LED_4_TYPE_GPIO
                 int 
                 prompt "LED 4 GPIO"
                 default 0
@@ -448,7 +479,6 @@ menu "Board Support Package"
                 help
                     The GPIO pin for LED 4.
             config BSP_LED_4_LEVEL
-                depends on BSP_LED_4_TYPE_GPIO
                 int
                 prompt "LED 4 Active Level"
                 default 1
@@ -461,7 +491,6 @@ menu "Board Support Package"
             depends on BSP_LEDS_NUM > 4 && BSP_LED_TYPE_GPIO
             
             config BSP_LED_5_GPIO
-                depends on BSP_LED_5_TYPE_GPIO
                 int 
                 prompt "LED 5 GPIO"
                 default 0
@@ -469,7 +498,6 @@ menu "Board Support Package"
                 help
                     The GPIO pin for LED 5.
             config BSP_LED_5_LEVEL
-                depends on BSP_LED_5_TYPE_GPIO
                 int
                 prompt "LED 5 Active Level"
                 default 1

--- a/bsp/esp_bsp_generic/Kconfig
+++ b/bsp/esp_bsp_generic/Kconfig
@@ -326,12 +326,6 @@ menu "Board Support Package (generic)"
     
 
     menu "LEDs"
-        config BSP_LEDS_NUM
-            int
-            prompt "Number of LEDs in BSP"
-            default 1
-            range 0 5
-            
         choice  
             prompt "LED type"
             default BSP_LED_TYPE_GPIO
@@ -344,9 +338,26 @@ menu "Board Support Package (generic)"
             config BSP_LED_TYPE_RGB
                 bool "Adressable RGB LED"
         endchoice
+        
+        if BSP_LED_TYPE_GPIO
+            config ENV_MAX_LEDS
+                int
+                default 5
+        endif
+        if BSP_LED_TYPE_RGB_CLASSIC || BSP_LED_TYPE_RGB
+            config ENV_MAX_LEDS
+                int
+                default 1
+        endif
+        
+        config BSP_LEDS_NUM
+            int
+            prompt "Number of LEDs in BSP"
+            default 1
+            range 0 ENV_MAX_LEDS
             
         config BSP_LED_RGB_GPIO
-            depends on BSP_LED_TYPE_RGB
+            depends on BSP_LED_TYPE_RGB && BSP_LEDS_NUM > 0
             int 
             prompt "Adressable RGB LED GPIO"
             default 48
@@ -355,7 +366,7 @@ menu "Board Support Package (generic)"
                 The GPIO pin for adressable LEDs.
                     
         config BSP_LED_RGB_CLASSIC_LEVEL
-            depends on BSP_LED_TYPE_RGB_CLASSIC
+            depends on BSP_LED_TYPE_RGB_CLASSIC && BSP_LEDS_NUM > 0
             int
             prompt "Classic RGB LED Active Level"
             default 0
@@ -364,7 +375,7 @@ menu "Board Support Package (generic)"
                 The active level for classic RGB LED. 
             
         config BSP_LED_RGB_RED_GPIO
-            depends on BSP_LED_TYPE_RGB_CLASSIC
+            depends on BSP_LED_TYPE_RGB_CLASSIC && BSP_LEDS_NUM > 0
             int 
             prompt "Classic RGB LED red GPIO"
             default -1
@@ -373,7 +384,7 @@ menu "Board Support Package (generic)"
                 The GPIO pin for red color RGB LED.
             
         config BSP_LED_RGB_GREEN_GPIO
-            depends on BSP_LED_TYPE_RGB_CLASSIC
+            depends on BSP_LED_TYPE_RGB_CLASSIC && BSP_LEDS_NUM > 0
             int 
             prompt "Classic RGB LED green GPIO"
             default -1
@@ -382,7 +393,7 @@ menu "Board Support Package (generic)"
                 The GPIO pin for green color RGB LED.
             
         config BSP_LED_RGB_BLUE_GPIO
-            depends on BSP_LED_TYPE_RGB_CLASSIC
+            depends on BSP_LED_TYPE_RGB_CLASSIC && BSP_LEDS_NUM > 0
             int 
             prompt "Classic RGB LED blue GPIO"
             default -1
@@ -395,7 +406,7 @@ menu "Board Support Package (generic)"
             default "$ESP_IDF_VERSION"
 
         choice BSP_LED_RGB_BACKEND
-            depends on BSP_LED_TYPE_RGB
+            depends on BSP_LED_TYPE_RGB && BSP_LEDS_NUM > 0
             prompt "Adressable RGB LED backend peripheral"
             default BSP_LED_RGB_BACKEND_RMT
             default BSP_LED_RGB_BACKEND_SPI
@@ -507,7 +518,295 @@ menu "Board Support Package (generic)"
         endmenu
             
     endmenu
+    
+
+    menu "Display"
+
+        config BSP_DISPLAY_ENABLED
+            bool "Enable display"
+            default n
+            help
+                Enable using display in BSP
+        
+        menu "Connection"
+            depends on BSP_DISPLAY_ENABLED
+            choice  
+                prompt "Communication interface"
+                help
+                    Select a communication interface
+                config BSP_DISPLAY_INTERFACE_SPI
+                    bool "SPI"
+            endchoice
             
+            config BSP_DISPLAY_SCLK_GPIO
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                int 
+                prompt "Display SPI SCLK GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The SCLK pin for SPI display.
+            
+            config BSP_DISPLAY_MOSI_GPIO
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                int 
+                prompt "Display SPI MOSI GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The MOSI pin for SPI display.
+            
+            config BSP_DISPLAY_MISO_GPIO
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                int 
+                prompt "Display SPI MISO GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The MISO pin for SPI display.
+            
+            config BSP_DISPLAY_CS_GPIO
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                int 
+                prompt "Display SPI CS GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The CS pin for SPI display.
+            
+            config BSP_DISPLAY_DC_GPIO
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                int 
+                prompt "Display SPI DC GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The DC pin for SPI display.
+            
+            config BSP_DISPLAY_RST_GPIO
+                int 
+                prompt "Display reset GPIO"
+                default 0
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The reset pin for display.
+            
+            config BSP_DISPLAY_BACKLIGHT_GPIO
+                int 
+                prompt "Display backlight GPIO"
+                default -1
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The backlight pin for display.
+            
+        endmenu
+            
+        choice  
+            prompt "Display driver"
+            depends on BSP_DISPLAY_ENABLED
+            help
+                Select a display driver 
+            config BSP_DISPLAY_DRIVER_ST7789
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                bool "ST7789"
+            config BSP_DISPLAY_DRIVER_ILI9341
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                bool "ILI9341"
+            config BSP_DISPLAY_DRIVER_GC9A01
+                depends on BSP_DISPLAY_INTERFACE_SPI
+                bool "GC9A01"
+        endchoice
+        
+        menu "Rotation"
+            depends on BSP_DISPLAY_ENABLED
+
+            config BSP_DISPLAY_ROTATION_SWAP_XY
+                bool "Swap XY"
+                default n
+                help
+                    Swap X and Y axis on the screen.
+
+            config BSP_DISPLAY_ROTATION_MIRROR_X
+                bool "Mirror X"
+                default n
+                help
+                    Mirror X axis on the screen.
+
+            config BSP_DISPLAY_ROTATION_MIRROR_Y
+                bool "Mirror Y"
+                default n
+                help
+                    Mirror Y axis on the screen.
+        endmenu
+            
+        choice  
+            prompt "Color space"
+            depends on BSP_DISPLAY_ENABLED
+            help
+                Select a display color space 
+            config BSP_DISPLAY_COLOR_SPACE_RGB
+                bool "RGB"
+            config BSP_DISPLAY_COLOR_SPACE_BGR
+                bool "BGR"
+        endchoice
+
+        config BSP_DISPLAY_INVERT_COLOR
+            bool "Invert colors"
+            default n
+            help
+                Invert colors of the screen.
+
+        config BSP_DISPLAY_BRIGHTNESS_INVERT
+            bool "Invert brightness level"
+            default n
+            help
+                Invert brightness level of the screen.
+
+        config BSP_DISPLAY_CMD_BITS
+            depends on BSP_DISPLAY_ENABLED
+            int
+            default 8
+            help
+                The command bits of the display.
+
+        config BSP_DISPLAY_PARAM_BITS
+            depends on BSP_DISPLAY_ENABLED
+            int
+            default 8
+            help
+                The param bits of the display.
+            
+        config BSP_DISPLAY_PIXEL_CLOCK
+            depends on BSP_DISPLAY_ENABLED
+            int 
+            prompt "Display pixel clock (MHz)"
+            default 20
+            range 1 40
+            help
+                The pixel clock of the display in MHz.
+            
+        config BSP_DISPLAY_WIDTH
+            depends on BSP_DISPLAY_ENABLED
+            int 
+            prompt "Display width"
+            default 320
+            help
+                The width in pixels of the display.
+            
+        config BSP_DISPLAY_HEIGHT
+            depends on BSP_DISPLAY_ENABLED
+            int 
+            prompt "Display height"
+            default 240
+            help
+                The height in pixels of the display.
+                
+        config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+            depends on BSP_DISPLAY_ENABLED && BSP_DISPLAY_BACKLIGHT_GPIO != -1
+            int "LEDC channel index for brightness control"
+            default 1
+            range 0 7
+            help
+                LEDC channel is used to generate PWM signal that controls display brightness.
+                Set LEDC index that should be used.
+
+        config BSP_LCD_DRAW_BUF_HEIGHT
+            depends on BSP_DISPLAY_ENABLED
+            int "LCD framebuf height"
+            default 100
+            range 10 240
+            help
+                Framebuf is used for lvgl rendering output (rows).
+
+        config BSP_LCD_DRAW_BUF_DOUBLE
+            depends on BSP_DISPLAY_ENABLED
+            bool "LCD double framebuf"
+            default n
+            help
+                Whether to enable double framebuf.
+        
+    endmenu
+    
+    menu "Display Touch"
+
+        config BSP_TOUCH_ENABLED
+            bool "Enable display touch"
+            default n
+            help
+                Enable using display touch in BSP
+        
+        menu "Connection"
+            depends on BSP_TOUCH_ENABLED
+            choice  
+                prompt "Communication interface"
+                help
+                    Select a communication interface
+                config BSP_TOUCH_INTERFACE_I2C
+                    bool "I2C"
+            endchoice
+            
+            config BSP_TOUCH_RST_GPIO
+                int 
+                prompt "Display touch reset GPIO"
+                default -1
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The reset pin for display touch.
+            
+            config BSP_TOUCH_INT_GPIO
+                int 
+                prompt "Display touch interrupt GPIO"
+                default -1
+                range -1 ENV_GPIO_OUT_RANGE_MAX
+                help
+                    The interrupt pin for display touch.
+            
+        endmenu
+            
+        choice  
+            prompt "Display touch driver"
+            depends on BSP_TOUCH_ENABLED
+            help
+                Select a display touch driver 
+            config BSP_TOUCH_DRIVER_TT21100
+                depends on BSP_TOUCH_INTERFACE_I2C
+                bool "TT21100"
+            config BSP_TOUCH_DRIVER_GT1151
+                depends on BSP_TOUCH_INTERFACE_I2C
+                bool "GT1151"
+            config BSP_TOUCH_DRIVER_GT911
+                depends on BSP_TOUCH_INTERFACE_I2C
+                bool "GT911"
+            config BSP_TOUCH_DRIVER_CST816S
+                depends on BSP_TOUCH_INTERFACE_I2C
+                bool "CST816S"
+            config BSP_TOUCH_DRIVER_FT5X06
+                depends on BSP_TOUCH_INTERFACE_I2C
+                bool "FT5X06"
+        endchoice
+        
+        menu "Rotation"
+            depends on BSP_TOUCH_ENABLED
+
+            config BSP_TOUCH_ROTATION_SWAP_XY
+                bool "Swap XY"
+                default n
+                help
+                    Swap X and Y axis on the touch.
+
+            config BSP_TOUCH_ROTATION_MIRROR_X
+                bool "Mirror X"
+                default n
+                help
+                    Mirror X axis on the touch.
+
+            config BSP_TOUCH_ROTATION_MIRROR_Y
+                bool "Mirror Y"
+                default n
+                help
+                    Mirror Y axis on the touch.
+        endmenu
+    endmenu
 
     menu "uSD card - Virtual File System"
         menu "Pins"

--- a/bsp/esp_bsp_generic/README.md
+++ b/bsp/esp_bsp_generic/README.md
@@ -113,7 +113,7 @@ For button handling is used component [iot_button](https://components.espressif.
     - `BSP_LEDS_NUM` (max 5)
 
 2. Set type for all LEDs in `menuconfig`
-    - `BSP_LED_TYPE` (GPIO / Adressable LED)
+    - `BSP_LED_TYPE` (GPIO / Adressable RGB LED / Classic RGB)
 
 3. For GPIO LEDs set pin and level for each LED in `menuconfig`
     - `BSP_LED_x_GPIO`
@@ -122,6 +122,12 @@ For button handling is used component [iot_button](https://components.espressif.
 3. For addressable RBG LEDs set pin and peripheral in `menuconfig`
     - `BSP_LED_RGB_GPIO`
     - `BSP_LED_RGB_BACKEND`
+
+3. For classic RBG LEDs set pins for all colors and level in `menuconfig`
+    - `BSP_LED_RGB_RED_GPIO`
+    - `BSP_LED_RGB_GREEN_GPIO`
+    - `BSP_LED_RGB_BLUE_GPIO`
+    - `BSP_LED_RGB_CLASSIC_LEVEL`
 
 Example code:
 ```
@@ -137,5 +143,76 @@ Example code:
 ```
 For LEDs handling is used component [led_indicator](https://components.espressif.com/components/espressif/led_indicator) with [led_strip](https://components.espressif.com/components/espressif/led_strip) component. For more information, please look into guides for these components.
 
+## LCD Display
 
+1. Enable display in `menuconfig`
+    - `BSP_DISPLAY_ENABLED`
 
+2. Select communication interface in `menuconfig`
+    - `BSP_DISPLAY_INTERFACE_` (only SPI is supported)
+
+3. Set communication pins in `menuconfig`
+    - `BSP_DISPLAY_SCLK_GPIO`
+    - `BSP_DISPLAY_MOSI_GPIO`
+    - `BSP_DISPLAY_MISO_GPIO`
+    - `BSP_DISPLAY_CS_GPIO`
+    - `BSP_DISPLAY_DC_GPIO`
+    - `BSP_DISPLAY_RST_GPIO`
+    - `BSP_DISPLAY_BACKLIGHT_GPIO`
+
+4. Select display driver in `menuconfig` (one of these)
+    - `BSP_DISPLAY_DRIVER_ST7789`
+    - `BSP_DISPLAY_DRIVER_ILI9341`
+    - `BSP_DISPLAY_DRIVER_GC9A01`
+
+5. Set right rotation of the screen in `menuconfig`
+    - `BSP_DISPLAY_ROTATION_SWAP_XY`
+    - `BSP_DISPLAY_ROTATION_MIRROR_X`
+    - `BSP_DISPLAY_ROTATION_MIRROR_Y`
+
+6. Set other display params in `menuconfig`
+    - `BSP_DISPLAY_CMD_BITS`
+    - `BSP_DISPLAY_PARAM_BITS`
+    - `BSP_DISPLAY_PIXEL_CLOCK`
+    - `BSP_DISPLAY_WIDTH`
+    - `BSP_DISPLAY_HEIGHT`
+    - `BSP_DISPLAY_BRIGHTNESS_LEDC_CH`
+    - `BSP_LCD_DRAW_BUF_HEIGHT`
+    - `BSP_LCD_DRAW_BUF_DOUBLE`
+
+## LCD Touch
+
+1. Enable display touch in `menuconfig`
+    - `BSP_TOUCH_ENABLED`
+
+2. Select communication interface in `menuconfig`
+    - `BSP_TOUCH_INTERFACE_` (only I2C is supported)
+
+3. Set communication pins in `menuconfig`
+    - `BSP_TOUCH_RST_GPIO`
+    - `BSP_TOUCH_INT_GPIO`
+
+4. Select display driver in `menuconfig` (one of these)
+    - `BSP_TOUCH_DRIVER_TT21100`
+    - `BSP_TOUCH_DRIVER_GT1151`
+    - `BSP_TOUCH_DRIVER_GT911`
+    - `BSP_TOUCH_DRIVER_CST816S`
+    - `BSP_TOUCH_DRIVER_FT5X06`
+
+5. Set right rotation of the screen in `menuconfig`
+    - `BSP_TOUCH_ROTATION_SWAP_XY`
+    - `BSP_TOUCH_ROTATION_MIRROR_X`
+    - `BSP_TOUCH_ROTATION_MIRROR_Y`
+
+Example code:
+```
+    /* Initialize display, touch and LVGL */
+    bsp_display_start();
+
+    /* Set display brightness to 100% */
+    bsp_display_backlight_on();
+
+    bsp_display_lock(0);
+    /* === Your LVGL code here === */
+    bsp_display_unlock();
+```

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -11,7 +11,8 @@ dependencies:
     public: true
 
   led_indicator:
-    version: ">=0.7,<=0.8"
+    version: "^0.9"
+    public: true
     public: true
 
 examples:

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,10 +1,18 @@
 
-version: "1.0.0~1"
+version: "1.1.0"
 description: Generig Board Support Package
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
 
 dependencies:
   idf: ">=4.4.2"
+  esp_lcd_touch_tt21100:  "^1"
+  esp_lcd_touch_gt1151:   "^1"
+  esp_lcd_touch_gt911:    "^1"
+  esp_lcd_touch_cst816s:  "^1"
+  esp_lcd_touch_ft5x06:   "^1"
+
+  esp_lcd_ili9341:  "^1"
+  esp_lcd_gc9a01:   "^1"
 
   button:
     version: ">=2.5,<4.0"
@@ -13,6 +21,9 @@ dependencies:
   led_indicator:
     version: "^0.9"
     public: true
+
+  esp_lvgl_port:
+    version: "^1"
     public: true
 
 examples:

--- a/bsp/esp_bsp_generic/include/bsp/display.h
+++ b/bsp/esp_bsp_generic/include/bsp/display.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief BSP LCD
+ *
+ * This file offers API for basic LCD control.
+ * It is useful for users who want to use the LCD without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization with LVGL graphical library, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "sdkconfig.h"
+#include "esp_lcd_types.h"
+
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (1)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#if defined(CONFIG_BSP_DISPLAY_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#elif defined(CONFIG_BSP_DISPLAY_COLOR_SPACE_BGR)
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief BSP display configuration structure
+ *
+ */
+typedef struct {
+    int max_transfer_sz;    /*!< Maximum transfer size, in bytes. */
+} bsp_display_config_t;
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[in]  config    display configuration
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd failure
+ */
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp_bsp_generic/include/bsp/touch.h
+++ b/bsp/esp_bsp_generic/include/bsp/touch.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief BSP Touchscreen
+ *
+ * This file offers API for basic touchscreen initialization.
+ * It is useful for users who want to use the touchscreen without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization with LVGL graphical library, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+#include "esp_lcd_touch.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief BSP touch configuration structure
+ *
+ */
+typedef struct {
+    void *dummy;    /*!< Prepared for future use. */
+} bsp_touch_config_t;
+
+/**
+ * @brief Create new touchscreen
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd_touch API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_touch_del(tp);
+ * \endcode
+ *
+ * @param[in]  config    touch configuration
+ * @param[out] ret_touch esp_lcd_touch touchscreen handle
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd_touch failure
+ */
+esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp_bsp_generic/src/esp_bsp_generic.c
+++ b/bsp/esp_bsp_generic/src/esp_bsp_generic.c
@@ -14,7 +14,46 @@
 #include "bsp/esp_bsp_generic.h"
 #include "bsp_err_check.h"
 
+#if CONFIG_BSP_DISPLAY_ENABLED
+#include "driver/spi_master.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_panel_ops.h"
+#include "bsp/display.h"
+
+#if CONFIG_BSP_DISPLAY_DRIVER_ILI9341
+#include "esp_lcd_ili9341.h"
+#elif CONFIG_BSP_DISPLAY_DRIVER_GC9A01
+#include "esp_lcd_gc9a01.h"
+#endif
+
+#endif
+
+#if CONFIG_BSP_TOUCH_ENABLED
+#include "bsp/touch.h"
+#if CONFIG_BSP_TOUCH_DRIVER_TT21100
+#include "esp_lcd_touch_tt21100.h"
+#elif CONFIG_BSP_TOUCH_DRIVER_GT1151
+#include "esp_lcd_touch_gt1151.h"
+#elif CONFIG_BSP_TOUCH_DRIVER_GT911
+#include "esp_lcd_touch_gt911.h"
+#elif CONFIG_BSP_TOUCH_DRIVER_CST816S
+#include "esp_lcd_touch_cst816s.h"
+#elif CONFIG_BSP_TOUCH_DRIVER_FT5X06
+#include "esp_lcd_touch_ft5x06.h"
+#endif
+#endif
+
 static const char *TAG = "BSP-Gen";
+
+#if CONFIG_BSP_DISPLAY_ENABLED
+static lv_disp_t *disp;
+static lv_indev_t *disp_indev = NULL;
+#endif
+
+#if CONFIG_BSP_TOUCH_ENABLED
+static esp_lcd_touch_handle_t tp;   // LCD touch handle
+#endif
 
 sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 static bool i2c_initialized = false;
@@ -35,7 +74,7 @@ static const button_config_t bsp_button_config[] = {
         .adc_button_config.button_index = BSP_BUTTON_1,
         .adc_button_config.min = (CONFIG_BSP_BUTTON_1_ADC_VALUE - 100),
         .adc_button_config.max = (CONFIG_BSP_BUTTON_1_ADC_VALUE + 100)
-    }
+    },
 #endif // CONFIG_BSP_BUTTON_1_TYPE_x
 #endif // CONFIG_BSP_BUTTONS_NUM >= 0
 
@@ -54,7 +93,7 @@ static const button_config_t bsp_button_config[] = {
         .adc_button_config.button_index = BSP_BUTTON_2,
         .adc_button_config.min = (CONFIG_BSP_BUTTON_2_ADC_VALUE - 100),
         .adc_button_config.max = (CONFIG_BSP_BUTTON_2_ADC_VALUE + 100)
-    }
+    },
 #endif // CONFIG_BSP_BUTTON_2_TYPE_x
 #endif // CONFIG_BSP_BUTTONS_NUM >= 1
 
@@ -73,7 +112,7 @@ static const button_config_t bsp_button_config[] = {
         .adc_button_config.button_index = BSP_BUTTON_3,
         .adc_button_config.min = (CONFIG_BSP_BUTTON_3_ADC_VALUE - 100),
         .adc_button_config.max = (CONFIG_BSP_BUTTON_3_ADC_VALUE + 100)
-    }
+    },
 #endif // CONFIG_BSP_BUTTON_3_TYPE_x
 #endif // CONFIG_BSP_BUTTONS_NUM >= 2
 
@@ -92,7 +131,7 @@ static const button_config_t bsp_button_config[] = {
         .adc_button_config.button_index = BSP_BUTTON_4,
         .adc_button_config.min = (CONFIG_BSP_BUTTON_4_ADC_VALUE - 100),
         .adc_button_config.max = (CONFIG_BSP_BUTTON_4_ADC_VALUE + 100)
-    }
+    },
 #endif // CONFIG_BSP_BUTTON_4_TYPE_x
 #endif // CONFIG_BSP_BUTTONS_NUM >= 3
 
@@ -376,6 +415,313 @@ esp_err_t bsp_sdcard_unmount(void)
     return ESP_OK;
 #endif // SOC_SDMMC_HOST_SUPPORTED
 }
+
+#if CONFIG_BSP_DISPLAY_ENABLED
+// Bit number used to represent command and parameter
+#define LCD_CMD_BITS           CONFIG_BSP_DISPLAY_CMD_BITS
+#define LCD_PARAM_BITS         CONFIG_BSP_DISPLAY_PARAM_BITS
+
+static esp_err_t bsp_display_brightness_init(void)
+{
+#if CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+    // Setup LEDC peripheral for PWM backlight control
+    const ledc_channel_config_t LCD_backlight_channel = {
+        .gpio_num = BSP_LCD_BACKLIGHT,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = 1,
+        .duty = 0,
+        .hpoint = 0
+    };
+    const ledc_timer_config_t LCD_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_10_BIT,
+        .timer_num = 1,
+        .freq_hz = 5000,
+        .clk_cfg = LEDC_AUTO_CLK
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&LCD_backlight_channel));
+#endif
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_brightness_set(int brightness_percent)
+{
+#if CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+    if (brightness_percent > 100) {
+        brightness_percent = 100;
+    }
+    if (brightness_percent < 0) {
+        brightness_percent = 0;
+    }
+
+#if CONFIG_BSP_DISPLAY_BRIGHTNESS_INVERT
+    brightness_percent = (100 - brightness_percent);
+#endif
+
+    ESP_LOGI(TAG, "Setting LCD backlight: %d%%", brightness_percent);
+    uint32_t duty_cycle = (1023 * brightness_percent) / 100; // LEDC resolution set to 10bits, thus: 100% = 1023
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH, duty_cycle));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH));
+#endif
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_backlight_off(void)
+{
+    return bsp_display_brightness_set(0);
+}
+
+esp_err_t bsp_display_backlight_on(void)
+{
+    return bsp_display_brightness_set(100);
+}
+
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
+{
+    esp_err_t ret = ESP_OK;
+    assert(config != NULL && config->max_transfer_sz > 0);
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+
+    ESP_LOGD(TAG, "Initialize SPI bus");
+    const spi_bus_config_t buscfg = {
+        .sclk_io_num = BSP_LCD_PCLK,
+        .mosi_io_num = BSP_LCD_DATA0,
+        .miso_io_num = GPIO_NUM_NC,
+        .quadwp_io_num = GPIO_NUM_NC,
+        .quadhd_io_num = GPIO_NUM_NC,
+        .max_transfer_sz = config->max_transfer_sz,
+    };
+    ESP_RETURN_ON_ERROR(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO), TAG, "SPI init failed");
+
+    ESP_LOGD(TAG, "Install panel IO");
+    const esp_lcd_panel_io_spi_config_t io_config = {
+        .dc_gpio_num = BSP_LCD_DC,
+        .cs_gpio_num = BSP_LCD_CS,
+        .pclk_hz = BSP_LCD_PIXEL_CLOCK_HZ,
+        .lcd_cmd_bits = LCD_CMD_BITS,
+        .lcd_param_bits = LCD_PARAM_BITS,
+        .spi_mode = 0,
+        .trans_queue_depth = 10,
+    };
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)BSP_LCD_SPI_NUM, &io_config, ret_io), err, TAG, "New panel IO failed");
+
+    ESP_LOGD(TAG, "Install LCD driver");
+    const esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = BSP_LCD_RST,
+        .color_space = BSP_LCD_COLOR_SPACE,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+    };
+#if CONFIG_BSP_DISPLAY_DRIVER_ST7789
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_st7789(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
+    ESP_LOGI(TAG, "Initialize LCD: ST7789");
+#elif CONFIG_BSP_DISPLAY_DRIVER_ILI9341
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_ili9341(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
+    ESP_LOGI(TAG, "Initialize LCD: ILI9341");
+#elif CONFIG_BSP_DISPLAY_DRIVER_GC9A01
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_gc9a01(*ret_io, &panel_config, ret_panel), err, TAG, "New panel failed");
+    ESP_LOGI(TAG, "Initialize LCD: GC9A01");
+#endif
+    esp_lcd_panel_reset(*ret_panel);
+    esp_lcd_panel_init(*ret_panel);
+
+    bool disp_swap_xy = false;
+    bool disp_mirror_x = false;
+    bool disp_mirror_y = false;
+    bool disp_invert_color = false;
+#if CONFIG_BSP_DISPLAY_ROTATION_SWAP_XY
+    disp_swap_xy = true;
+#endif
+#if CONFIG_BSP_DISPLAY_ROTATION_MIRROR_X
+    disp_mirror_x = true;
+#endif
+#if CONFIG_BSP_DISPLAY_ROTATION_MIRROR_Y
+    disp_mirror_y = true;
+#endif
+#if CONFIG_BSP_DISPLAY_INVERT_COLOR
+    disp_invert_color = true;
+#endif
+
+    esp_lcd_panel_mirror(*ret_panel, disp_mirror_x, disp_mirror_y);
+    esp_lcd_panel_swap_xy(*ret_panel, disp_swap_xy);
+    esp_lcd_panel_invert_color(*ret_panel, disp_invert_color);
+    return ret;
+
+err:
+    if (*ret_panel) {
+        esp_lcd_panel_del(*ret_panel);
+    }
+    if (*ret_io) {
+        esp_lcd_panel_io_del(*ret_io);
+    }
+    spi_bus_free(BSP_LCD_SPI_NUM);
+    return ret;
+}
+
+static lv_disp_t *bsp_display_lcd_init(void)
+{
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    const bsp_display_config_t bsp_disp_cfg = {
+        .max_transfer_sz = (BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT) * sizeof(uint16_t),
+    };
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&bsp_disp_cfg, &panel_handle, &io_handle));
+
+    esp_lcd_panel_disp_on_off(panel_handle, true);
+
+    /* Add LCD screen */
+    ESP_LOGD(TAG, "Add LCD screen");
+    const lvgl_port_display_cfg_t disp_cfg = {
+        .io_handle = io_handle,
+        .panel_handle = panel_handle,
+        .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
+#if CONFIG_BSP_LCD_DRAW_BUF_DOUBLE
+        .double_buffer = 1,
+#else
+        .double_buffer = 0,
+#endif
+        .hres = BSP_LCD_H_RES,
+        .vres = BSP_LCD_V_RES,
+        .monochrome = false,
+        /* Rotation values must be same as used in esp_lcd for initial settings of the screen */
+        .rotation = {
+#if CONFIG_BSP_DISPLAY_ROTATION_SWAP_XY
+            .swap_xy = true,
+#endif
+#if CONFIG_BSP_DISPLAY_ROTATION_MIRROR_X
+            .mirror_x = true,
+#endif
+#if CONFIG_BSP_DISPLAY_ROTATION_MIRROR_Y
+            .mirror_y = true,
+#endif
+        },
+        .flags = {
+            .buff_dma = true,
+        }
+    };
+
+    return lvgl_port_add_disp(&disp_cfg);
+}
+
+#if CONFIG_BSP_TOUCH_ENABLED
+esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch)
+{
+    /* Initilize I2C */
+    BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
+
+    /* Initialize touch */
+    const esp_lcd_touch_config_t tp_cfg = {
+        .x_max = BSP_LCD_H_RES,
+        .y_max = BSP_LCD_V_RES,
+        .rst_gpio_num = BSP_LCD_TOUCH_RST,
+        .int_gpio_num = BSP_LCD_TOUCH_INT,
+        .levels = {
+            .reset = 0,
+            .interrupt = 0,
+        },
+        .flags = {
+#if CONFIG_BSP_TOUCH_ROTATION_SWAP_XY
+            .swap_xy = true,
+#endif
+#if CONFIG_BSP_TOUCH_ROTATION_MIRROR_X
+            .mirror_x = true,
+#endif
+#if CONFIG_BSP_TOUCH_ROTATION_MIRROR_Y
+            .mirror_y = true,
+#endif
+        },
+    };
+    esp_lcd_panel_io_handle_t tp_io_handle = NULL;
+#if CONFIG_BSP_TOUCH_DRIVER_TT21100
+    ESP_LOGI(TAG, "Initialize LCD Touch: TT21100");
+    const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_TT21100_CONFIG();
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_tt21100(tp_io_handle, &tp_cfg, ret_touch);
+#elif CONFIG_BSP_TOUCH_DRIVER_GT1151
+    ESP_LOGI(TAG, "Initialize LCD Touch: GT1151");
+    const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_GT1151_CONFIG();
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_gt1151(tp_io_handle, &tp_cfg, ret_touch);
+#elif CONFIG_BSP_TOUCH_DRIVER_GT911
+    ESP_LOGI(TAG, "Initialize LCD Touch: GT911");
+    const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_gt911(tp_io_handle, &tp_cfg, ret_touch);
+#elif CONFIG_BSP_TOUCH_DRIVER_CST816S
+    ESP_LOGI(TAG, "Initialize LCD Touch: CST816S");
+    const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_CST816S_CONFIG();
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_cst816s(tp_io_handle, &tp_cfg, ret_touch);
+#elif CONFIG_BSP_TOUCH_DRIVER_FT5X06
+    ESP_LOGI(TAG, "Initialize LCD Touch: FT5X06");
+    const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_FT5X06_CONFIG();
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)BSP_I2C_NUM, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_ft5x06(tp_io_handle, &tp_cfg, ret_touch);
+#endif
+}
+
+static lv_indev_t *bsp_display_indev_init(lv_disp_t *disp)
+{
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(NULL, &tp));
+    assert(tp);
+
+    /* Add touch input (for selected screen) */
+    const lvgl_port_touch_cfg_t touch_cfg = {
+        .disp = disp,
+        .handle = tp,
+    };
+
+    return lvgl_port_add_touch(&touch_cfg);
+}
+#endif //CONFIG_BSP_TOUCH_ENABLED
+
+lv_disp_t *bsp_display_start(void)
+{
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG()
+    };
+    return bsp_display_start_with_config(&cfg);
+}
+
+lv_disp_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+{
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
+
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
+#if CONFIG_BSP_TOUCH_ENABLED
+    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
+#endif //CONFIG_BSP_TOUCH_ENABLED
+
+    return disp;
+}
+
+lv_indev_t *bsp_display_get_input_dev(void)
+{
+    return disp_indev;
+}
+
+void bsp_display_rotate(lv_disp_t *disp, lv_disp_rot_t rotation)
+{
+    lv_disp_set_rotation(disp, rotation);
+}
+
+bool bsp_display_lock(uint32_t timeout_ms)
+{
+    return lvgl_port_lock(timeout_ms);
+}
+
+void bsp_display_unlock(void)
+{
+    lvgl_port_unlock();
+}
+#endif //CONFIG_BSP_DISPLAY_ENABLED
 
 esp_err_t bsp_iot_button_create(button_handle_t btn_array[], int *btn_cnt, int btn_array_size)
 {

--- a/examples/generic_button_led/README.md
+++ b/examples/generic_button_led/README.md
@@ -7,7 +7,7 @@ Available LEDs and buttons are initialized with preconfigured settings. The firs
 
 # Build with predefined configuration
 
-Predefined configurations are saved in [generic_button_led](examples/generic_button_led) example.
+Predefined configurations are saved in [generic_button_led](https://github.com/espressif/esp-bsp/tree/master/examples/generic_button_led) example.
 
 ```
     idf.py -p COM4 -D "SDKCONFIG_DEFAULTS=sdkconfig.esp32_s3_devkitc_1" flash monitor

--- a/examples/generic_button_led/sdkconfig.esp32_c2_devkitm_1
+++ b/examples/generic_button_led/sdkconfig.esp32_c2_devkitm_1
@@ -1,0 +1,15 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32c2"
+
+# ESP8684-DevKitM-1 v1.1 Settings
+# Buttons
+CONFIG_BSP_BUTTONS_NUM=0
+# LEDs
+CONFIG_BSP_LEDS_NUM=1
+CONFIG_BSP_LED_TYPE_RGB_CLASSIC=y
+CONFIG_BSP_LED_RGB_CLASSIC_LEVEL=0
+CONFIG_BSP_LED_RGB_RED_GPIO=0
+CONFIG_BSP_LED_RGB_GREEN_GPIO=1
+CONFIG_BSP_LED_RGB_BLUE_GPIO=8


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Updated `led_indicator` and support classic RGB LED (e.g. ESP32C2)
- Added LCD and touch support to generig BSP. I selected only some drivers
- LCD is supported only via SPI
- Touch is supported only via I2C

# Issues
- When some part not used (e.g. buttons, leds, LCD, touch), the component is still downloaded
- Components for all touches and LCDs are downloaded
