### PR TITLE
doc: add ESP32-S3-USB-OTG instructions to power up USB Host (BSP-426)

### DIFF
--- a/examples/display_usb_hid/README.md
+++ b/examples/display_usb_hid/README.md
@@ -1,12 +1,14 @@
 # BSP: Display USB HID Example
 
-This example demonstrates usage of the USB HID (keyboard, mouse or GamePad) with Board Support Package. 
+This example demonstrates usage of the USB HID (keyboard, mouse or GamePad) with Board Support Package.
 
 ## How to use the example
 
 ### Hardware Required
 
-* Board ESP32-S3-USB-OTG
+* Board [ESP32-S3-USB-OTG](https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32s3/esp32-s3-usb-otg/user_guide.html)
+  - connect 5V USB power supply to the left "USB DEV" connector
+  - connect USB keyboard/mouse to the right "USB Host" connector
 
 ### Compile and flash
 


### PR DESCRIPTION
Documentation update.

Added instructions how to power up USB Host port on ESP32-S3-USB-OTG. Without described change the example does not read values from mouse or keyboard.
