### PR TITLE
lcd: remove unused structs

### DIFF
--- a/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
+++ b/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
@@ -171,12 +171,6 @@ static esp_err_t panel_ili9341_reset(esp_lcd_panel_t *panel)
     return ESP_OK;
 }
 
-typedef struct {
-    uint8_t cmd;
-    uint8_t data[16];
-    uint8_t data_bytes; // Length of data in above data array; 0xFF = end of cmds.
-} lcd_init_cmd_t;
-
 static const ili9341_lcd_init_cmd_t vendor_specific_init_default[] = {
 //  {cmd, { data }, data_size, delay_ms}
     /* Power contorl B, power control = 0, DC_ENA = 1 */

--- a/components/lcd/esp_lcd_st7796/esp_lcd_st7796.c
+++ b/components/lcd/esp_lcd_st7796/esp_lcd_st7796.c
@@ -175,12 +175,6 @@ static esp_err_t panel_st7796_reset(esp_lcd_panel_t *panel)
     return ESP_OK;
 }
 
-typedef struct {
-    uint8_t cmd;
-    uint8_t data[16];
-    uint8_t data_bytes; // Length of data in above data array; 0xFF = end of cmds.
-} lcd_init_cmd_t;
-
 static const st7796_lcd_init_cmd_t vendor_specific_init_default[] = {
 //  {cmd, { data }, data_size, delay_ms}
     {0xf0, (uint8_t []){0xc3}, 1, 0},

--- a/components/lcd/esp_lcd_st7796/test_apps/main/test_esp_lcd_st7796.c
+++ b/components/lcd/esp_lcd_st7796/test_apps/main/test_esp_lcd_st7796.c
@@ -10,6 +10,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include "driver/gpio.h"
+#include "soc/soc_caps.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_lcd_panel_ops.h"
@@ -32,7 +33,11 @@
 #define TEST_PIN_NUM_LCD_DATA2      (GPIO_NUM_11)
 #define TEST_PIN_NUM_LCD_DATA3      (GPIO_NUM_14)
 #define TEST_PIN_NUM_LCD_DATA4      (GPIO_NUM_13)
+#if CONFIG_IDF_TARGET_ESP32S2
+#define TEST_PIN_NUM_LCD_DATA5      (GPIO_NUM_8)
+#else
 #define TEST_PIN_NUM_LCD_DATA5      (GPIO_NUM_47)
+#endif
 #define TEST_PIN_NUM_LCD_DATA6      (GPIO_NUM_21)
 #define TEST_PIN_NUM_LCD_DATA7      (GPIO_NUM_45)
 #define TEST_PIN_NUM_LCD_DATA8      (-1)


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
* ili9341 & st7796: remove unused structs
* st7796: fix the building error of test_apps when using esp32s2
