### PR TITLE
Update build-examples-gh-pages-on-push.yml

### DIFF
--- a/.github/workflows/build-examples-gh-pages-on-push.yml
+++ b/.github/workflows/build-examples-gh-pages-on-push.yml
@@ -1,9 +1,9 @@
 name: "ESP-IDF build examples to github pages (push)"
 
 on:
-    push:
-        branches:
-        - master
+  push:
+      branches:
+      - master
 
 jobs:
 
@@ -18,6 +18,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+
+      - name: Upgrade component manager
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          pip install idf-component-manager --upgrade
 
       - name: Action for building binaries and config.toml
         uses: espressif/idf-examples-launchpad-ci-action@v1.0


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] CI passing

# Change description
With fixed IDF version that we use for publishing example binaries, we are also tight to fixed version of idf-component-manager. Some of our BSPs (esp32_s3_lcd_ev_board) need v1.4 of idf-component-manager here we update it explicitely
