### PR TITLE
esp_lvgl_port: Fix bad condition in port deinit (BSP-440)

### DIFF
--- a/components/esp_lvgl_port/esp_lvgl_port.c
+++ b/components/esp_lvgl_port/esp_lvgl_port.c
@@ -237,7 +237,7 @@ esp_err_t lvgl_port_deinit(void)
     }
 
     /* Stop running task */
-    if (!lvgl_port_ctx.running) {
+    if (lvgl_port_ctx.running) {
         lvgl_port_ctx.running = false;
     } else {
         lvgl_port_task_deinit();


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [x] CI passing

# Change description
The `lvgl_port_deinit()` method appears to have an incorrect if-condition when checking if the LVGL task is running. Currently the code essentially says `if (!running) running = false;`, but it should be `if (running) running = false;`. The incorrect condition causes the LVGL task to never be stopped.
