### PR TITLE
esp_lvgl_port: apply rotation from display configuration (BSP-443)

### DIFF
--- a/components/esp_lvgl_port/esp_lvgl_port.c
+++ b/components/esp_lvgl_port/esp_lvgl_port.c
@@ -330,6 +330,9 @@ err:
         if (disp_ctx) {
             free(disp_ctx);
         }
+    } else {
+        /* Apply rotation from initial display configuration */
+        lvgl_port_update_callback(&disp_ctx->disp_drv);
     }
 
     return disp;

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.0"
+version: "1.4.1"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:


### PR DESCRIPTION
Initial rotation set in lvgl_port_display_cfg_t was not applied properly after display initialization. This commit adds call to update callback that sets the swap and mirror properties on panel.

Sample code that shows the behavior:
```
esp_lcd_panel_handle_t lcdPanelHandle;
ESP_ERROR_CHECK(esp_lcd_new_panel_gc9a01(lcdPanelIOHandle, &lcdPanelConfig, &lcdPanelHandle));

ESP_ERROR_CHECK(esp_lcd_panel_reset(lcdPanelHandle));
ESP_ERROR_CHECK(esp_lcd_panel_init(lcdPanelHandle));
ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(lcdPanelHandle, 1));

const lvgl_port_display_cfg_t displayCfg = {
		.io_handle = lcdPanelIOHandle,
		.panel_handle = lcdPanelHandle,
		.buffer_size = 240 * 240,
		.double_buffer = 0,
		.hres = 240,
		.vres = 240,
		.monochrome = 0,
		.rotation = {
			.mirror_x = 0,
			.mirror_y = 1,
			.swap_xy = 0,
		},
		.flags.buff_dma = 0,
		.flags.buff_spiram = 0,
};
display = lvgl_port_add_disp(&displayCfg);

lv_obj_t* root = lv_disp_get_scr_act(display);
lv_obj_t* lHello = lv_label_create(root);
lv_label_set_text(lHello, "Hello world~!");
lv_obj_align(lHello, LV_ALIGN_CENTER, 0, 0);
```

After this, the rotation parameters are ignored and requires manual update of lvgl driver to reapply them. This PR makes the rotation being applied just after initialization, as expected.
Tested on: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28