### PR TITLE
fix(ds18b20): fix the wrong value of a sub-zero temperature (BSP-444)

### DIFF
--- a/components/ds18b20/CHANGELOG.md
+++ b/components/ds18b20/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fix the issue that sign-bit is not extended properly when doing temperature value conversion.
+
 ## 0.1.0
 
 - Initial driver version, based on the [onewire_bus](https://components.espressif.com/components/espressif/onewire_bus) library.

--- a/components/ds18b20/idf_component.yml
+++ b/components/ds18b20/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.1.1"
 description: DS18B20 device driver
 url: https://github.com/espressif/esp-bsp/tree/master/components/ds18b20
 dependencies:

--- a/components/ds18b20/src/ds18b20.c
+++ b/components/ds18b20/src/ds18b20.c
@@ -134,7 +134,10 @@ esp_err_t ds18b20_get_temperature(ds18b20_device_handle_t ds18b20, float *ret_te
 
     const uint8_t lsb_mask[4] = {0x07, 0x03, 0x01, 0x00}; // mask bits not used in low resolution
     uint8_t lsb_masked = scratchpad.temp_lsb & (~lsb_mask[scratchpad.configuration >> 5]);
-    *ret_temperature = (((int16_t)scratchpad.temp_msb << 8) | lsb_masked)  / 16.0f;
+    // Combine the MSB and masked LSB into a signed 16-bit integer
+    int16_t temperature_raw = (((int16_t)scratchpad.temp_msb << 8) | lsb_masked);
+    // Convert the raw temperature to a float,
+    *ret_temperature = temperature_raw / 16.0f;
 
     return ESP_OK;
 }


### PR DESCRIPTION
because of the drop in the sign when doing the temperature conversion

Closes https://github.com/espressif/esp-bsp/issues/258

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [x] Version of modified component bumped
- [x] CI passing

# Change description
_Please describe your change here_
