### PR TITLE
fix: Failing CI for Launchpad (BSP-449)

### DIFF
--- a/.github/workflows/build-examples-gh-pages-on-push.yml
+++ b/.github/workflows/build-examples-gh-pages-on-push.yml
@@ -26,7 +26,7 @@ jobs:
           pip install idf-component-manager --upgrade
 
       - name: Action for building binaries and config.toml
-        uses: espressif/idf-examples-launchpad-ci-action@v1.0
+        uses: espressif/idf-examples-launchpad-ci-action@v1.0.1
         with: 
           idf_version: ${{ matrix.idf_ver }}
 


### PR DESCRIPTION
# Change description
Bumped version of Github Action for building examples for ESP Launchpad - fixes the crash in CI.
