### PR TITLE
fix bsp/display.h

### DIFF
--- a/bsp/esp-box-3/include/bsp/display.h
+++ b/bsp/esp-box-3/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+/* LCD definition */
+#define BSP_LCD_H_RES              (320)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp-box-3/include/bsp/esp-box-3.h
+++ b/bsp/esp-box-3/include/bsp/esp-box-3.h
@@ -20,6 +20,7 @@
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -333,8 +334,6 @@ esp_err_t bsp_sdcard_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (320)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -383,40 +382,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Set display enter sleep mode

--- a/bsp/esp-box-lite/include/bsp/display.h
+++ b/bsp/esp-box-lite/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+/* LCD definition */
+#define BSP_LCD_H_RES              (320)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp-box-lite/include/bsp/esp-box-lite.h
+++ b/bsp/esp-box-lite/include/bsp/esp-box-lite.h
@@ -19,6 +19,7 @@
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -278,8 +279,6 @@ esp_err_t bsp_spiffs_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (320)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -328,40 +327,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controlling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp-box/include/bsp/display.h
+++ b/bsp/esp-box/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+/* LCD definition */
+#define BSP_LCD_H_RES              (320)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp-box/include/bsp/esp-box.h
+++ b/bsp/esp-box/include/bsp/esp-box.h
@@ -19,6 +19,7 @@
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -275,8 +276,6 @@ esp_err_t bsp_spiffs_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (320)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -325,40 +324,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_azure_iot_kit/include/bsp/display.h
+++ b/bsp/esp32_azure_iot_kit/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +30,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (1)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_MONOCHROME)
+/* LCD definition */
+#define BSP_LCD_H_RES              (128)
+#define BSP_LCD_V_RES              (64)
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,6 +71,11 @@ typedef struct {
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
 
+/* Backlight functions are not implemented - Azure kit doesn't provide backlight control
+   These functions are here to provide consistent API with other Board Support Packages */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+esp_err_t bsp_display_backlight_on(void);
+esp_err_t bsp_display_backlight_off(void);
 #ifdef __cplusplus
 }
 #endif

--- a/bsp/esp32_azure_iot_kit/include/bsp/esp32_azure_iot_kit.h
+++ b/bsp/esp32_azure_iot_kit/include/bsp/esp32_azure_iot_kit.h
@@ -17,6 +17,7 @@
 #include "sdkconfig.h"
 #include "iot_button.h"
 #include "esp_lvgl_port.h"
+#include "bsp/display.h"
 
 /**************************************************************************************************
  *  Pinout
@@ -186,8 +187,6 @@ esp_err_t bsp_sdcard_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (128)
-#define BSP_LCD_V_RES              (64)
 #define BSP_LCD_I2C_ADDR           (0x3C)
 
 #define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * BSP_LCD_V_RES)
@@ -238,40 +237,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_c3_lcdkit/include/bsp/display.h
+++ b/bsp/esp32_c3_lcdkit/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+/* LCD definition */
+#define BSP_LCD_H_RES              (240)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
+++ b/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
@@ -18,6 +18,7 @@
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
+#include "bsp/display.h"
 
 /**************************************************************************************************
  *  ESP32-C3-LCDkit pinout
@@ -67,8 +68,6 @@ extern "C" {
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (240)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI2_HOST)
 
@@ -106,40 +105,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/bsp/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -430,7 +430,6 @@ void bsp_display_unlock(void)
     lvgl_port_unlock();
 }
 
-
 /* Backlight functions are not implemented - Kaluga board doesn't provide backlight control
    These functions are here to provide consistent API with other Board Support Packages */
 esp_err_t bsp_display_backlight_off(void)
@@ -438,6 +437,10 @@ esp_err_t bsp_display_backlight_off(void)
     return ESP_OK;
 }
 esp_err_t bsp_display_backlight_on(void)
+{
+    return ESP_OK;
+}
+esp_err_t bsp_display_brightness_set(int brightness_percent)
 {
     return ESP_OK;
 }

--- a/bsp/esp32_s2_kaluga_kit/include/bsp/display.h
+++ b/bsp/esp32_s2_kaluga_kit/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+/* LCD definition */
+#define BSP_LCD_H_RES              (320)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,6 +70,11 @@ typedef struct {
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
 
+/* Backlight functions are not implemented - Kaluga board doesn't provide backlight control
+   These functions are here to provide consistent API with other Board Support Packages */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+esp_err_t bsp_display_backlight_on(void);
+esp_err_t bsp_display_backlight_off(void);
 #ifdef __cplusplus
 }
 #endif

--- a/bsp/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
+++ b/bsp/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
@@ -18,6 +18,7 @@
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -288,8 +289,6 @@ esp_err_t bsp_spiffs_unmount(void);
  *
  * @note Default SPI clock is set to 40MHz. On some displays shipped with Kaluga kit, 80MHz can be achieved
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (320)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -339,11 +338,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/* Backlight functions are not implemented - Kaluga board doesn't provide backlight control
-   These functions are here to provide consistent API with other Board Support Packages */
-esp_err_t bsp_display_backlight_on(void);
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_s3_eye/esp32_s3_eye.c
+++ b/bsp/esp32_s3_eye/esp32_s3_eye.c
@@ -74,6 +74,11 @@ static const button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
         .adc_button_config.button_index = BSP_BUTTON_UP,
         .adc_button_config.min = 280, // middle is 380mV
         .adc_button_config.max = 480
+    },
+    {
+        .type = BUTTON_TYPE_GPIO,
+        .gpio_button_config.active_level = 0,
+        .gpio_button_config.gpio_num = BSP_BUTTON_BOOT_IO
     }
 };
 

--- a/bsp/esp32_s3_eye/include/bsp/display.h
+++ b/bsp/esp32_s3_eye/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+/* LCD display definition */
+#define BSP_LCD_H_RES              (240)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -27,6 +27,19 @@
 #endif
 
 /**************************************************************************************************
+ *  BSP Capabilities
+ **************************************************************************************************/
+
+#define BSP_CAPS_DISPLAY        1
+#define BSP_CAPS_TOUCH          0
+#define BSP_CAPS_BUTTONS        1
+#define BSP_CAPS_AUDIO          1
+#define BSP_CAPS_AUDIO_SPEAKER  0
+#define BSP_CAPS_AUDIO_MIC      1
+#define BSP_CAPS_SDCARD         1
+#define BSP_CAPS_IMU            0 // There is an IMU, but not supported in this BSP
+
+/**************************************************************************************************
  * ESP32-S3-EYE pinout
  **************************************************************************************************/
 

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -79,7 +79,8 @@
 #define BSP_SD_CMD           (GPIO_NUM_38)
 #define BSP_SD_CLK           (GPIO_NUM_39)
 
-/* Others */
+/* Buttons */
+#define BSP_BUTTON_BOOT_IO   (GPIO_NUM_0)
 #define BSP_BUTTONS_IO       (GPIO_NUM_1) // All 4 buttons mapped to this GPIO
 typedef enum bsp_led_t {
     BSP_LED_GREEN = GPIO_NUM_3,
@@ -110,9 +111,10 @@ typedef struct {
  **************************************************************************************************/
 typedef enum {
     BSP_BUTTON_MENU = 0,
+    BSP_BUTTON_PLAY,
     BSP_BUTTON_DOWN,
     BSP_BUTTON_UP,
-    BSP_BUTTON_PLAY,
+    BSP_BUTTON_BOOT,
     BSP_BUTTON_NUM
 } bsp_button_t;
 

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -18,6 +18,7 @@
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -287,11 +288,8 @@ esp_err_t bsp_sdcard_unmount(void);
  * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
  * bsp_display_unlock().
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (240)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
-
 #define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * BSP_LCD_V_RES)
 #define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
 
@@ -339,41 +337,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controlling backlight.
- * Display must be already initialized by calling bsp_display_start()
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_s3_korvo_2/include/bsp/display.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
+/* LCD definition */
+#define BSP_LCD_H_RES              (320)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +69,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -16,6 +16,7 @@
 #include "esp_codec_dev.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
+#include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "driver/i2s.h"
@@ -422,8 +423,6 @@ esp_err_t bsp_sdcard_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (320)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -475,39 +474,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * @attention ESP32-S3 Korvo v2 board has backlight control connected through IO expander, so brightness control is not supported.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_ERR_NOT_SUPPORTED Always
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * @note I2C must be already initialized by bsp_i2c_init()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_STATE Could not init IO expander
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * @note I2C must be already initialized by bsp_i2c_init()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_STATE Could not init IO expander
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/display.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -68,10 +68,35 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
  * @param[in] callback The function to be registered. It should return true if need to yield, otherwise return false
  *
  * @return
- *      - ESP_OK               Succsee
+ *      - ESP_OK               Success
  *      - ESP_ERR_INVALID_ARG  Callback function should be placed in IRAM, use `IRAM_ATTR` to define it
  */
 esp_err_t bsp_display_register_trans_done_callback(bsp_display_trans_done_cb_t callback);
+
+/**
+ * @brief Set display's brightness (Useless, just for compatibility)
+ *
+ * @param[in] brightness_percent: Brightness in [%]
+ * @return
+ *      - ESP_ERR_NOT_SUPPORTED: Always
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight (Useless, just for compatibility)
+ *
+ * @return
+ *      - ESP_ERR_NOT_SUPPORTED: Always
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight (Useless, just for compatibility)
+ *
+ * @return
+ *      - ESP_ERR_NOT_SUPPORTED: Always
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
@@ -21,6 +21,7 @@
 #include "esp_lcd_gc9503.h"
 #include "iot_button.h"
 #include "lvgl.h"
+#include "bsp/display.h"
 
 #include "sdkconfig.h"
 
@@ -359,31 +360,6 @@ lv_disp_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
  * @return Pointer to LVGL input device or NULL when not initialized
  */
 lv_indev_t *bsp_display_get_input_dev(void);
-
-/**
- * @brief Set display's brightness (Useless, just for compatibility)
- *
- * @param[in] brightness_percent: Brightness in [%]
- * @return
- *      - ESP_ERR_NOT_SUPPORTED: Always
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight (Useless, just for compatibility)
- *
- * @return
- *      - ESP_ERR_NOT_SUPPORTED: Always
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight (Useless, just for compatibility)
- *
- * @return
- *      - ESP_ERR_NOT_SUPPORTED: Always
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Take LVGL mutex

--- a/bsp/esp32_s3_usb_otg/include/bsp/display.h
+++ b/bsp/esp32_s3_usb_otg/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,9 @@
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+/* LCD definition */
+#define BSP_LCD_H_RES              (240)
+#define BSP_LCD_V_RES              (240)
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,6 +70,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
+++ b/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
@@ -18,6 +18,7 @@
 #include "iot_button.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
+#include "bsp/display.h"
 
 /**************************************************************************************************
  *  BSP Capabilities
@@ -193,8 +194,6 @@ esp_err_t bsp_spiffs_unmount(void);
  * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
  * bsp_display_unlock().
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (240)
-#define BSP_LCD_V_RES              (240)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
@@ -245,41 +244,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controlling backlight.
- * Display must be already initialized by calling bsp_display_start()
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp_bsp_generic/include/bsp/display.h
+++ b/bsp/esp_bsp_generic/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,6 +34,9 @@
 #elif defined(CONFIG_BSP_DISPLAY_COLOR_SPACE_BGR)
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_BGR)
 #endif
+/* Display definition */
+#define BSP_LCD_H_RES              (CONFIG_BSP_DISPLAY_WIDTH)
+#define BSP_LCD_V_RES              (CONFIG_BSP_DISPLAY_HEIGHT)
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,6 +74,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp_bsp_generic/include/bsp/esp_bsp_generic.h
+++ b/bsp/esp_bsp_generic/include/bsp/esp_bsp_generic.h
@@ -19,6 +19,7 @@
 #include "led_indicator.h"
 
 #if CONFIG_BSP_DISPLAY_ENABLED
+#include "bsp/display.h"
 #include "esp_lvgl_port.h"
 #endif //CONFIG_BSP_DISPLAY_ENABLED
 /**************************************************************************************************
@@ -267,8 +268,6 @@ esp_err_t bsp_sdcard_unmount(void);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES              (CONFIG_BSP_DISPLAY_WIDTH)
-#define BSP_LCD_V_RES              (CONFIG_BSP_DISPLAY_HEIGHT)
 #define BSP_LCD_PIXEL_CLOCK_HZ     (CONFIG_BSP_DISPLAY_PIXEL_CLOCK * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI2_HOST)
 
@@ -317,40 +316,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen

--- a/bsp/esp_wrover_kit/include/bsp/display.h
+++ b/bsp/esp_wrover_kit/include/bsp/display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,6 +34,9 @@
 #else
 #define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
 #endif
+/* LCD definition */
+#define BSP_LCD_H_RES               (240)
+#define BSP_LCD_V_RES               (320)
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,6 +74,41 @@ typedef struct {
  *      - Else           esp_lcd failure
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Display must be already initialized by calling bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp_wrover_kit/include/bsp/esp_wrover_kit.h
+++ b/bsp/esp_wrover_kit/include/bsp/esp_wrover_kit.h
@@ -17,6 +17,7 @@
 #include "lvgl.h"
 #include "iot_button.h"
 #include "esp_lvgl_port.h"
+#include "bsp/display.h"
 
 /**************************************************************************************************
  * ESP-WROVER-KIT pinout
@@ -234,8 +235,6 @@ esp_err_t bsp_iot_button_create(button_handle_t btn_array[], int *btn_cnt, int b
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
-#define BSP_LCD_H_RES               (240)
-#define BSP_LCD_V_RES               (320)
 #define BSP_LCD_PIXEL_CLOCK_HZ      (40 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM             (SPI2_HOST)
 
@@ -286,40 +285,6 @@ bool bsp_display_lock(uint32_t timeout_ms);
  *
  */
 void bsp_display_unlock(void);
-
-/**
- * @brief Set display's brightness
- *
- * Brightness is controlled with PWM signal to a pin controling backlight.
- *
- * @param[in] brightness_percent Brightness in [%]
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-
-/**
- * @brief Turn on display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_on(void);
-
-/**
- * @brief Turn off display backlight
- *
- * Display must be already initialized by calling bsp_display_start()
- *
- * @return
- *      - ESP_OK                On success
- *      - ESP_ERR_INVALID_ARG   Parameter error
- */
-esp_err_t bsp_display_backlight_off(void);
 
 /**
  * @brief Rotate screen


### PR DESCRIPTION
* Added backlight functions to `bsp/display.h` so users can use them without including the main `bsp/esp-bsp.h`. This is important for future BSP version without LVGL
* Added capabilities of S3_eye board
* Add support for S3-EYE BOOT button

No need to release now