### PR TITLE
feat: No graphical library in BSPs

### DIFF
--- a/.github/ci/bsp_noglib.py
+++ b/.github/ci/bsp_noglib.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Remove esp_lvgl_port from BSP's dependencies
+"""
+
+import sys
+from pathlib import Path
+from idf_component_tools.manifest import ManifestManager
+
+DEFINE_NOGLIB_OFF = '#define BSP_CONFIG_NO_GRAPHIC_LIB (0)'
+DEFINE_NOGLIB_ON = '#define BSP_CONFIG_NO_GRAPHIC_LIB (1)'
+ESP_REGISTRY_URL = 'https://components.espressif.com/components/'
+README_NOGLIB_NOTICE = '> :warning: This is **No Graphical version** of {} BSP. If you want to use this BSP with LVGL use [{}]({}) component.\n'
+
+
+def select_bsp_config_no_graphic_lib(bsp_name):
+    config_path = Path('bsp') / bsp_name / 'include' / 'bsp' / 'config.h'
+    try:
+        with open(config_path, encoding='utf-8', mode='r') as header:
+            content = header.read()
+        content = content.replace(DEFINE_NOGLIB_OFF, DEFINE_NOGLIB_ON)
+        with open(config_path, encoding='utf-8', mode='w') as header:
+            header.write(content)
+        return 0
+    except FileNotFoundError:
+        print("{}: could not modify config.h".format(bsp_name))
+        return 1
+
+
+def remove_esp_lvgl_port(bsp_name):
+    bsp_path = Path('bsp') / bsp_name
+    manager = ManifestManager(bsp_path, 'bsp')
+    try:
+        del manager.manifest_tree["dependencies"]["espressif/esp_lvgl_port"]
+        manager.manifest_tree["description"] = manager.manifest_tree["description"] + ' with no graphical library'
+        manager.dump()
+        return 0
+    except KeyError:
+        print("{}: could not remove esp_lvgl_port".format(bsp_name))
+        return 1
+
+
+def add_notice_to_readme(bsp_name):
+    readme_path = Path('bsp') / bsp_name / 'README.md'
+    try:
+        with open(readme_path, encoding='utf-8', mode='r') as readme:
+            content = readme.readlines()
+
+        content.insert(0, README_NOGLIB_NOTICE.format(bsp_name, bsp_name, ESP_REGISTRY_URL + 'espressif/' + bsp_name))
+        with open(readme_path, encoding='utf-8', mode='w') as readme:
+            readme.writelines(content)
+        return 0
+    except FileNotFoundError:
+        print("{}: could not modify README.md".format(bsp_name))
+        return 1
+
+
+def bsp_no_glib_all():
+    # First version modifies only ESP32-S3-EYE BSP
+    # TODO: Add a loop that will process all BSPs
+    ret = select_bsp_config_no_graphic_lib("esp32_s3_eye")
+    ret += remove_esp_lvgl_port("esp32_s3_eye")
+    ret += add_notice_to_readme("esp32_s3_eye")
+    return ret
+
+
+if __name__ == '__main__':
+    sys.exit(bsp_no_glib_all())

--- a/.github/ci/update_readme_dependencies.py
+++ b/.github/ci/update_readme_dependencies.py
@@ -51,7 +51,7 @@ def check_bsp_readme(file: str) -> Any:
         try:
             start_idx = content.index(DEPENDENCIES_START)
             end_idx = content.index(DEPENDENCIES_END)
-            if set(table.splitlines()) <= set([line[:-1] for line in content]):
+            if set(table.splitlines()) == set([line[:-1] for line in content[start_idx + 1:end_idx]]):
                 # The table exists and is correct, we can return here
                 return 0
             else:

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -25,3 +25,19 @@ jobs:
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
           dry_run: ${{ github.ref_name != 'master' || github.repository_owner != 'espressif' }}
+      - name: Upload noglib version of BSPs
+        continue-on-error: true # update_readme_dependencies.py returns error if the readme file was modified
+        # TODO: Extend this part to all BSPs
+        run: |
+          pip install idf-component-manager py-markdown-table --upgrade
+          python .github/ci/bsp_noglib.py
+          python .github/ci/update_readme_dependencies.py bsp/esp32_s3_eye/idf_component.yml || true
+          mkdir -p bsp/esp32_s3_eye_noglib
+          mv bsp/esp32_s3_eye/* bsp/esp32_s3_eye_noglib
+      - uses: espressif/upload-components-ci-action@v1
+        with:
+          directories: >
+            bsp/esp32_s3_eye_noglib
+          namespace: "espressif"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+          dry_run: ${{ github.ref_name != 'master' || github.repository_owner != 'espressif' }}

--- a/BSP_development_guide.md
+++ b/BSP_development_guide.md
@@ -48,28 +48,35 @@ esp_err_t bsp_i2c_deinit(void);
 * See any BSP
 
 #### Display
-* BSPs with display are shipped with [LVGL](https://components.espressif.com/components/lvgl/lvgl) component
-* Display functions are divided into two parts. The first part is only HW initialization (include\bsp\display.h) and second part is initialization of the LVGL (BSP header).
-* Functions, which must be defined in BSP *.c file:
+* BSPs with display are shipped with [LVGL](https://components.espressif.com/components/lvgl/lvgl) component by default. For version without LVGL, you can use BSP version with `noglib` suffix (eg. `esp32_s3_eye_noglib`)
+* Display functions are divided into two parts. The first part is HW initialization only (include/bsp/display.h), second part is initialization of the display and LVGL (bsp/esp-bsp.h)
+* HW initialization functions, which must be defined in bsp/display.h file:
 ``` c
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+esp_err_t bsp_display_backlight_on(void);
+esp_err_t bsp_display_backlight_off(void);
+```
+* LVGL init function, which must be defined in bsp/esp-bsp.h file:
+``` c
 lv_disp_t *bsp_display_start(void);
 lv_disp_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
 bool bsp_display_lock(uint32_t timeout_ms);
 void bsp_display_unlock(void);
-esp_err_t bsp_display_brightness_set(int brightness_percent);
-esp_err_t bsp_display_backlight_on(void);
-esp_err_t bsp_display_backlight_off(void);
 void bsp_display_rotate(lv_disp_t *disp, lv_disp_rot_t rotation);
 ```
 * See esp_wrover_kit, esp32_s2_kaluga_kit ...
 
 #### LCD Touch
 * LCD touch drivers are build around base [esp_lcd_touch](https://components.espressif.com/components/espressif/esp_lcd_touch) component
-* LCD touch functions are divided into two parts. The first part is only HW initialization (include\bsp\touch.h) and second part is initialization of the LVGL (BSP header).
-* Functions, which must be defined in BSP *.c file:
+* BSPs with touch display are shipped with [LVGL](https://components.espressif.com/components/lvgl/lvgl) component by default. For version without LVGL, you can use BSP version with `noglib` suffix (eg. `esp32_s3_eye_noglib`)
+* If LVGL is used, the touch controller is initialized together with display. If LVGL is not used you can use HW initialization functions from bsp/touch.h
+* HW initialization function, which must be defined in bsp/touch.h file:
 ``` c
 esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch);
+```
+* LVGL get input device function for advanced scenarios in bsp/esp-bsp.h
+``` c
 lv_indev_t *bsp_display_get_input_dev(void);
 ```
 * See esp-box, esp-box-3 ...

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Board support packages for development boards using Espressif's SoCs, written in
 
 The BSP repository includes a lot of LCD and Touch driver components. The list of available and planned LCDs is [here](LCD.md).
 
-We offer seemless integration of LVGL graphical library into esp-idf applications in [LVGL port](components/esp_lvgl_port) component.
+We offer seamless integration of LVGL graphical library into esp-idf applications in [LVGL port](components/esp_lvgl_port) component.
 
-Moreover, LVGL port includes recommendations and tips for increasing graphical performance.
+Moreover, LVGL port includes recommendations and tips for [increasing graphical performance](components/esp_lvgl_port/docs/performance.md).
 
 ## How to use
 
@@ -48,11 +48,11 @@ Best way to start with ESP-BSP is trying one of the [examples](examples) on your
 | [display_sensors](examples/display_sensors) | Azure-IoT-kit | [Flash display_sensors](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_sensors) |
 | [mqtt_example](examples/mqtt_example) | Azure-IoT-kit | - |
 
-### BSP headers
-Each BSP provides its header file in 'bsp' subfolder, so it can be included as follows: `#include "bsp/name-of-the-bsp.h"`.
-For you convenience, each BSP also provides a wrapper header, which has the same name for all BSPs: `#include "bsp/esp-bsp.h"`.
-
-BSPs that contain LCD screen or touchscreen also provide `bsp/display.h` and `bsp/touch.h`. These files provide functions for LCD or touchscreen initialization without LVGL graphics library, which is used by default.
+### BSP headers and options
+* `bsp/name-of-the-bsp.h`: Main include file of the BSP with public API
+* `bsp/esp-bsp.h`: Convenience include file with the same name for all BPSs
+* `bsp/display.h` and `bsp/touch.h`: Only for BSPs with LCD or touch controller. Contain low level initialization functions for usage without LVGL graphical library
+    * By default, BSPs with display are shipped with LVGL, if you are interested in BSP without LVGL you can use BSP versions with `noglib` suffix (eg. `esp32_s3_eye_noglib`). 
 
 > **_NOTE:_** There can be only one BSP in a single esp-idf project.
 
@@ -62,8 +62,6 @@ You can add them to your project via `idf.py add-dependency`, e.g.
 ```
     idf.py add-dependency esp_wrover_kit==1.0.0
 ```
-
-Alternatively, you can create `idf_component.yml` file manually, such as in [this example](examples/display/main/idf_component.yml).
 
 ### Recommendation for custom projects
 
@@ -95,15 +93,17 @@ idf.py -B build/wrover_kit -D SDKCONFIG_DEFAULTS=sdkconfig.bsp.esp_wrover_kit bu
 ```
 > Note: This feature is not yet integrated to idf.py by default. If you want to use it, you must set your environmental variable `IDF_EXTRA_ACTIONS_PATH` to path to `esp-bsp/examples/bsp_ext.py`.
 
-## Additional information
+## Contributing to ESP-BSP
+
+Please check [CONTRIBUTING.md](CONTRIBUTING.md) if you'd like to contribute to ESP-BSP.
+
+Also check [BSP Development Guide](BSP_development_guide.md) to find out more about BSP API and architecture.
+
+### Additional information
 More information about idf-component-manager can be found in [Espressif API guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html)
 or [PyPi registry](https://pypi.org/project/idf-component-manager/).
 
 You can find more information about idf.py extensions [here](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/README.md).
-
-## Contributing to ESP-BSP
-
-Please check [CONTRIBUTING.md](CONTRIBUTING.md) if you'd like to contribute to ESP-BSP.
 
 ## Copyrights and License
 

--- a/bsp/esp32_s3_eye/esp32_s3_eye.c
+++ b/bsp/esp32_s3_eye/esp32_s3_eye.c
@@ -24,7 +24,6 @@
 #include "bsp/esp32_s3_eye.h"
 #include "bsp_err_check.h"
 #include "bsp/display.h"
-#include "esp_lvgl_port.h"
 
 static const char *TAG = "S3-EYE";
 
@@ -302,6 +301,7 @@ err:
     return ret;
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_display_t *bsp_display_lcd_init(void)
 {
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -385,6 +385,7 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 esp_err_t bsp_leds_init(void)
 {

--- a/bsp/esp32_s3_eye/include/bsp/config.h
+++ b/bsp/esp32_s3_eye/include/bsp/config.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**************************************************************************************************
+ * BSP configuration
+ **************************************************************************************************/
+// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
+// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
+#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+#define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#endif

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -14,10 +14,9 @@
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 #include "driver/sdmmc_host.h"
-#include "lvgl.h"
-#include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
+#include "bsp/config.h"
 #include "bsp/display.h"
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
@@ -25,6 +24,11 @@
 #else
 #include "driver/i2s_std.h"
 #endif
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+#include "lvgl.h"
+#include "esp_lvgl_port.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
  *  BSP Capabilities
@@ -89,14 +93,6 @@ typedef enum bsp_led_t {
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief BSP display configuration structure
- *
- */
-typedef struct {
-    lvgl_port_cfg_t lvgl_port_cfg;
-} bsp_display_cfg_t;
 
 /**************************************************************************************************
  *
@@ -300,13 +296,24 @@ esp_err_t bsp_sdcard_unmount(void);
  * It features 16-bit colors and 240x240 resolution.
  *
  * LVGL is used as graphics library. LVGL is NOT thread safe, therefore the user must take LVGL mutex
- * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
+ * by calling bsp_display_lock() before calling any LVGL API (lv_...) and then give the mutex with
  * bsp_display_unlock().
+ *
+ * If you want to use the display without LVGL, see bsp/display.h API and use BSP version with 'noglib' suffix.
  **************************************************************************************************/
 #define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * BSP_LCD_V_RES)
 #define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
+
+/**
+ * @brief BSP display configuration structure
+ */
+typedef struct {
+    lvgl_port_cfg_t lvgl_port_cfg;
+} bsp_display_cfg_t;
 
 /**
  * @brief Initialize display
@@ -362,6 +369,7 @@ void bsp_display_unlock(void);
  * @param[in] rotation Angle of the display rotation
  */
 void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
  *


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Add documentation for this feature
- [ ] Extend to all BSPs: Will be done in a follow up PR
- [ ] Add a CI check that build the `noglib` configurations: Will be done in a follow up PR
- [x] CI passing

# Change description
With this change we can upload No Graphical Library (-noglib) versions of the BSPs. We must remove `esp_lvgl_port` from the list of dependencies and disable the relevant parts of code.

As an example only ESP32-S3-EYE is modified for this change
