### PR TITLE
fix(ci): Use fixed version of idf-component-manager

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language: python
         files: 'bsp\/.*idf_component\.yml|bsp\/.*README\.md' # All idf_component.yml and README.md files in bsp directory
         additional_dependencies:
-          - idf_component_manager
+          - idf_component_manager==1.4.2
           - py-markdown-table
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This PR fixes errors with latest idf-component-manager

@kumekay The latest idf-component-manager v1.5.1 seems to incorrectly resolve conditional dependencies:
Here's the error: https://github.com/espressif/esp-bsp/actions/runs/7917759550/job/21614583839?pr=282#step:4:108
Here's the original idf_component.yml file: https://github.com/espressif/esp-bsp/blob/master/bsp/esp32_s3_lcd_ev_board/idf_component.yml
Could you please have a look too?

cc @espzav @pborcin 
