### PR TITLE
fix(ci): Extend noglib script to all BSPs

### DIFF
--- a/.github/ci/bsp_noglib.py
+++ b/.github/ci/bsp_noglib.py
@@ -8,8 +8,10 @@ Remove esp_lvgl_port from BSP's dependencies
 """
 
 import sys
+import argparse
 from pathlib import Path
 from idf_component_tools.manifest import ManifestManager
+from update_readme_dependencies import check_bsp_readme
 
 DEFINE_NOGLIB_OFF = '#define BSP_CONFIG_NO_GRAPHIC_LIB (0)'
 DEFINE_NOGLIB_ON = '#define BSP_CONFIG_NO_GRAPHIC_LIB (1)'
@@ -17,8 +19,8 @@ ESP_REGISTRY_URL = 'https://components.espressif.com/components/'
 README_NOGLIB_NOTICE = '> :warning: This is **No Graphical version** of {} BSP. If you want to use this BSP with LVGL use [{}]({}) component.\n'
 
 
-def select_bsp_config_no_graphic_lib(bsp_name):
-    config_path = Path('bsp') / bsp_name / 'include' / 'bsp' / 'config.h'
+def select_bsp_config_no_graphic_lib(bsp):
+    config_path = Path(bsp) / 'include' / 'bsp' / 'config.h'
     try:
         with open(config_path, encoding='utf-8', mode='r') as header:
             content = header.read()
@@ -27,29 +29,30 @@ def select_bsp_config_no_graphic_lib(bsp_name):
             header.write(content)
         return 0
     except FileNotFoundError:
-        print("{}: could not modify config.h".format(bsp_name))
+        print("{}: could not modify config.h".format(bsp))
         return 1
 
 
-def remove_esp_lvgl_port(bsp_name):
-    bsp_path = Path('bsp') / bsp_name
+def remove_esp_lvgl_port(bsp):
+    bsp_path = Path(bsp)
     manager = ManifestManager(bsp_path, 'bsp')
     try:
         del manager.manifest_tree["dependencies"]["espressif/esp_lvgl_port"]
     except KeyError:
-        print("{}: could not remove esp_lvgl_port".format(bsp_name))
+        print("{}: could not remove esp_lvgl_port".format(bsp))
         return 1
     try:
         del manager.manifest_tree["dependencies"]["lvgl/lvgl"]
     except KeyError:
-        print("{}: no lvgl dependency found".format(bsp_name))
+        print("{}: no lvgl dependency found".format(bsp))
     manager.manifest_tree["description"] = manager.manifest_tree["description"] + ' with no graphical library'
     manager.dump()
     return 0
 
 
-def add_notice_to_readme(bsp_name):
-    readme_path = Path('bsp') / bsp_name / 'README.md'
+def add_notice_to_readme(bsp):
+    readme_path = Path(bsp) / 'README.md'
+    bsp_name = Path(bsp).parts[-1].rstrip("_noglib")
     try:
         with open(readme_path, encoding='utf-8', mode='r') as readme:
             content = readme.readlines()
@@ -63,14 +66,23 @@ def add_notice_to_readme(bsp_name):
         return 1
 
 
-def bsp_no_glib_all():
-    # First version modifies only ESP32-S3-EYE BSP
-    # TODO: Add a loop that will process all BSPs
-    ret = select_bsp_config_no_graphic_lib("esp32_s3_eye")
-    ret += remove_esp_lvgl_port("esp32_s3_eye")
-    ret += add_notice_to_readme("esp32_s3_eye")
+def bsp_no_glib_all(bsp_names):
+    ret = 0
+    for bsp in bsp_names:
+        # 1. Rename the BSP to BSP_noglib
+        bsp_noglib = bsp + "_noglib"
+        Path(bsp).rename(bsp_noglib)
+
+        # 2. Modify the configuration, dependencies and README
+        ret += select_bsp_config_no_graphic_lib(bsp_noglib)
+        ret += remove_esp_lvgl_port(bsp_noglib)
+        ret += add_notice_to_readme(bsp_noglib)
+        check_bsp_readme(bsp_noglib)
     return ret
 
 
 if __name__ == '__main__':
-    sys.exit(bsp_no_glib_all())
+    parser = argparse.ArgumentParser()
+    parser.add_argument('bsp_names', nargs='*', help='BSP names to process')
+    args = parser.parse_args()
+    sys.exit(bsp_no_glib_all(args.bsp_names))

--- a/.github/ci/update_readme_dependencies.py
+++ b/.github/ci/update_readme_dependencies.py
@@ -39,8 +39,11 @@ def get_dependencies_table(manifest):
     return table
 
 
-def check_bsp_readme(file: str) -> Any:
-    bsp_path = os.path.dirname(file)  # File can be idf_component.yml or README.md
+def check_bsp_readme(bsp: str) -> Any:
+    bsp_path = bsp
+    if not os.path.isdir(bsp):
+        # In case idf_component.yml or README.md is passed here (e.g. from pre-commit)
+        bsp_path = os.path.dirname(bsp)
     # Get list of dependencies of this BSP
     manager = ManifestManager(bsp_path, 'bsp')
     table = get_dependencies_table(manager.load())
@@ -72,16 +75,16 @@ def check_bsp_readme(file: str) -> Any:
     return 1
 
 
-def check_all_bsps():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
-    args = parser.parse_args()
+def check_all_bsps(filenames):
     ret = 0
-    for f in args.filenames:
+    for f in filenames:
         ret += check_bsp_readme(f)
     return ret
 
 
 if __name__ == '__main__':
     os.environ["IDF_VERSION"] = "5.3.0"  # Let's assume IDF v5.3.0 for optional dependencies
-    sys.exit(check_all_bsps())
+    parser = argparse.ArgumentParser()
+    parser.add_argument('bsps', nargs='*', help='BSPs to check. Can be BSP path or a file in BSP.')
+    args = parser.parse_args()
+    sys.exit(check_all_bsps(args.bsps))

--- a/.github/workflows/upload_component_noglib.yml
+++ b/.github/workflows/upload_component_noglib.yml
@@ -15,12 +15,11 @@ jobs:
 
       - name: Upload noglib version of BSPs
         # TODO: Extend this part to all BSPs
+        env:
+          BSPs: "bsp/esp32_s3_eye"
         run: |
           pip install idf-component-manager py-markdown-table --upgrade
-          python .github/ci/bsp_noglib.py
-          python .github/ci/update_readme_dependencies.py bsp/esp32_s3_eye/idf_component.yml || true
-          mkdir -p bsp/esp32_s3_eye_noglib
-          mv bsp/esp32_s3_eye/* bsp/esp32_s3_eye_noglib
+          python .github/ci/bsp_noglib.py ${BSPs}
       - uses: espressif/upload-components-ci-action@v1
         with:
           directories: >

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dependencies.lock
 .vscode
 doxygen_output/**
 dist
+__pycache__


### PR DESCRIPTION
# Change description
Extend noglib python script so it 
* accepts multiple BSPs
* renames the BSP automatically
* check the dependency table in readme automatically

If you want to add a new noglib BSP, only 2 changes are needed:
1. Add the BSP to this space separated list (eventually, this will include all BSPs) https://github.com/espressif/esp-bsp/blob/c1fd14695e295ce121a734345703dc0ec93e5d42/.github/workflows/upload_component_noglib.yml#L19
2. Add the noglib BSP to upload job https://github.com/espressif/esp-bsp/blob/c1fd14695e295ce121a734345703dc0ec93e5d42/.github/workflows/upload_component_noglib.yml#L25