### PR TITLE
Descriptions and tags updates (BSP-472)

### DIFF
--- a/bsp/esp-box-3/idf_component.yml
+++ b/bsp/esp-box-3/idf_component.yml
@@ -1,10 +1,13 @@
 
 version: "1.1.3"
-description: Board Support Package for ESP32-S3-BOX-3
+description: Board Support Package (BSP) for ESP32-S3-BOX-3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box-3
 
 targets:
   - esp32s3
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp-box-lite/idf_component.yml
+++ b/bsp/esp-box-lite/idf_component.yml
@@ -1,9 +1,12 @@
 version: "2.0.4"
-description: Board Support Package for ESP32-S3-BOX-Lite
+description: Board Support Package (BSP) for ESP32-S3-BOX-Lite
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box-lite
 
 targets:
   - esp32s3
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp-box/idf_component.yml
+++ b/bsp/esp-box/idf_component.yml
@@ -1,10 +1,13 @@
 
 version: "3.0.5"
-description: Board Support Package for ESP-BOX
+description: Board Support Package (BSP) for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box
 
 targets:
   - esp32s3
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp32_azure_iot_kit/idf_component.yml
+++ b/bsp/esp32_azure_iot_kit/idf_component.yml
@@ -1,9 +1,12 @@
 version: "2.0.1"
-description: Board Support Package for ESP32-Azure-IoT-Kit
+description: Board Support Package (BSP) for ESP32-Azure-IoT-Kit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_azure_iot_kit
 
 targets:
     - esp32
+
+tags:
+   - bsp
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp32_c3_lcdkit/idf_component.yml
+++ b/bsp/esp32_c3_lcdkit/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.0.1"
-description: Board Support Package for esp32_c3_lcdkit
+description: Board Support Package (BSP) for esp32_c3_lcdkit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_c3_lcdkit
 
 targets:
   - esp32c3
+
+tags:
+  - bsp  
 
 dependencies:
   idf: ">=5.0.0"

--- a/bsp/esp32_lyrat/idf_component.yml
+++ b/bsp/esp32_lyrat/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.0.0~2"
-description: Board Support Package for ESP32-LyraT
+description: Board Support Package (BSP) for ESP32-LyraT
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_lyrat
 
 targets:
   - esp32
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4"

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.0.0"
-description: Board Support Package for ESP32-P4 Function EV Board (preview)
+description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 
 targets:
   - esp32p4
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=5.2"

--- a/bsp/esp32_s2_kaluga_kit/idf_component.yml
+++ b/bsp/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,9 +1,12 @@
 version: "3.0.1"
-description: Board Support Package for ESP32-S2-Kaluga kit
+description: Board Support Package (BSP) for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s2_kaluga_kit
 
 targets:
   - esp32s2
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp32_s3_eye/idf_component.yml
+++ b/bsp/esp32_s3_eye/idf_component.yml
@@ -1,9 +1,12 @@
 version: "3.0.4"
-description: Board Support Package for ESP32-S3-EYE
+description: Board Support Package (BSP) for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_eye
 
 targets:
   - esp32s3
+
+tags:
+  - bsp  
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp32_s3_korvo_1/idf_component.yml
+++ b/bsp/esp32_s3_korvo_1/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.1.0"
-description: Board Support Package for ESP32-S3-KORVO-1
+description: Board Support Package (BSP) for ESP32-S3-KORVO-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_1
 
 targets:
   - esp32s3
+
+tags:
+  - bsp  
 
 dependencies:
   idf: ">=4.4"

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,9 +1,12 @@
 version: "2.1.2"
-description: Board Support Package for ESP32-S3-Korvo-2
+description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 
 targets:
   - esp32s3
+
+tags:
+  - bsp  
 
 dependencies:
   idf: ">=4.4.5"

--- a/bsp/esp32_s3_lcd_ev_board/idf_component.yml
+++ b/bsp/esp32_s3_lcd_ev_board/idf_component.yml
@@ -1,9 +1,12 @@
 version: "2.1.0"
-description: Board Support Package for ESP32-S3-LCD-EV-Board
+description: Board Support Package (BSP) for ESP32-S3-LCD-EV-Board
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_lcd_ev_board
 
 targets:
   - esp32s3
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=5.0.1"

--- a/bsp/esp32_s3_usb_otg/idf_component.yml
+++ b/bsp/esp32_s3_usb_otg/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.5.1"
-description: Board Support Package for ESP32-S3-USB-OTG
+description: Board Support Package (BSP) for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg
 
 targets:
   - esp32s3
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4"

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,7 +1,10 @@
 
 version: "1.1.2"
-description: Generig Board Support Package
+description: Generig Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
+
+tags:
+  - bsp
 
 dependencies:
   idf: ">=4.4.2"

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,6 +1,6 @@
 
 version: "1.1.2"
-description: Generig Board Support Package (BSP)
+description: Generic Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
 
 tags:

--- a/bsp/esp_wrover_kit/idf_component.yml
+++ b/bsp/esp_wrover_kit/idf_component.yml
@@ -1,9 +1,12 @@
 version: "1.5.1"
-description: Board Support Package for ESP-WROVER-KIT
+description: Board Support Package (BSP) for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_wrover_kit
 
 targets:
     - esp32
+
+tags:
+   - bsp
 
 dependencies:
   idf: ">=4.4.5"


### PR DESCRIPTION
# Change description
Updating BSPs descriptions to fix searching BSP packages on https://components.espressif.com/

Also adding a tag "bsp".