### PR TITLE
SH1106 compatibility (BSP-473)

### DIFF
--- a/components/lcd/esp_lcd_sh1107/esp_lcd_sh1107.c
+++ b/components/lcd/esp_lcd_sh1107/esp_lcd_sh1107.c
@@ -142,7 +142,7 @@ static const uint8_t vendor_specific_init[] = {
     0x7f,   /* duty = 1/64 */
 
     0xd3,   /* set display offset */
-    0x60,
+    0x00,
 
     0xd5,   /* set osc division */
     0x51,


### PR DESCRIPTION
I successfully used this driver with a SH1106 display by only changing the display offset. I'd like to make this change available to everyone. This is not a new BSP, nor I would create an entirely new component for this small change, so I'm submitting this pull request to know if you want to take if from here or should I continue my plan.

I propose:
- Changing the name of the component to `esp_lcd_sh110x` 
- Extend `sh110x_panel_t` to add `offset_param` two-byte param. 
- Update `ESP_LCD_IO_I2C_SH1107_CONFIG` to add the new `offset_param` set to `0xd3 0x60`.
- Create `ESP_LCD_IO_I2C_SH1106_CONFIG` with `offset_param` set to `0xd3 0x00`.
- Update docs accordingly.

Please confirm my plans are OK and I'll make them and re-submit the pull request. 

Thanks!

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
_Please describe your change here_
