### PR TITLE
feat(GT911): added I2C addr set support. (BSP-496)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: ESP LCD Touch - main component for using touch screen controllers
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
+++ b/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
@@ -64,6 +64,8 @@ typedef struct {
     esp_lcd_touch_interrupt_callback_t interrupt_callback;
     /*!< User data passed to callback */
     void *user_data;
+    /*!< User data passed to driver */
+    void *driver_data;
 } esp_lcd_touch_config_t;
 
 typedef struct {

--- a/components/lcd_touch/esp_lcd_touch_gt911/README.md
+++ b/components/lcd_touch/esp_lcd_touch_gt911/README.md
@@ -25,6 +25,10 @@ Initialization of the touch component.
 ```
     esp_lcd_panel_io_i2c_config_t io_config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
 
+    esp_lcd_touch_io_gt911_config_t tp_gt911_config = {
+        .dev_addr = io_config.dev_addr,
+    };
+
     esp_lcd_touch_config_t tp_cfg = {
         .x_max = CONFIG_LCD_HRES,
         .y_max = CONFIG_LCD_VRES,
@@ -39,6 +43,7 @@ Initialization of the touch component.
             .mirror_x = 0,
             .mirror_y = 0,
         },
+        .driver_data = &tp_gt911_config,
     };
 
     esp_lcd_touch_handle_t tp;

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/include/esp_lcd_touch_gt911.h
+++ b/components/lcd_touch/esp_lcd_touch_gt911/include/esp_lcd_touch_gt911.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,6 +40,14 @@ esp_err_t esp_lcd_touch_new_i2c_gt911(const esp_lcd_panel_io_handle_t io, const 
  */
 #define ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS          (0x5D)
 #define ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP   (0x14)
+
+/**
+ * @brief GT911 Configuration Type
+ *
+ */
+typedef struct {
+    uint8_t dev_addr;  /*!< I2C device address */
+} esp_lcd_touch_io_gt911_config_t;
 
 /**
  * @brief Touch IO configuration structure


### PR DESCRIPTION
Closes BSP-468

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing

# Change description
1: Add dynamic setting for the I2C address.
![addr_set](https://github.com/espressif/esp-bsp/assets/111102666/f59057be-aacd-4d14-a9e6-d0b7a12cb6d8)