### PR TITLE
fix(M5Stack CoreS3): Fixed display types for noglib version

### DIFF
--- a/bsp/m5stack_core_s3/idf_component.yml
+++ b/bsp/m5stack_core_s3/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: Board Support Package (BSP) for M5Stack CoreS3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/m5stack_core_s3
 

--- a/bsp/m5stack_core_s3/m5stack_core_s3.c
+++ b/bsp/m5stack_core_s3/m5stack_core_s3.c
@@ -40,8 +40,10 @@ typedef enum {
     BSP_FEATURE_CAMERA,
 } bsp_feature_t;
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_display_t *disp;
 static lv_indev_t *disp_indev = NULL;
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static esp_lcd_touch_handle_t tp;   // LCD touch handle
 sdmmc_card_t *bsp_sdcard = NULL;    // Global SD card handler
 static bool i2c_initialized = false;


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
Fixed missing #if in LVGL display types for NOGLIB version of BSP