### PR TITLE
fix(m5stack_cores3): correct typo in header (BSP-513)

### DIFF
--- a/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
+++ b/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
@@ -316,7 +316,7 @@ extern sdmmc_card_t *bsp_sdcard;
 esp_err_t bsp_sdcard_mount(void);
 
 /**
- * @brief Unmount micorSD card from virtual file system
+ * @brief Unmount microSD card from virtual file system
  *
  * @return
  *      - ESP_OK on success


### PR DESCRIPTION


# Change description

Fixes misspelling of "microSD" in docstring.