### PR TITLE
fix(esp_lvgl_port): Fix esp_lvgl_port with local LVGL component

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+- Fixed LVGL version resolution if LVGL is not a managed component
+- Fixed link error with LVGL v9.2
+
 ## 2.3.0
 - Fixed LVGL port for using with LVGL9 OS FreeRTOS enabled
 - Fixed bad handled touch due to synchronization timer task

--- a/components/esp_lvgl_port/CMakeLists.txt
+++ b/components/esp_lvgl_port/CMakeLists.txt
@@ -1,17 +1,34 @@
 include($ENV{IDF_PATH}/tools/cmake/version.cmake) # $ENV{IDF_VERSION} was added after v4.3...
 
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "4.4")
-    return() 
+    return()
 endif()
 
-#Get LVGL version
-idf_component_get_property(lvgl_ver lvgl__lvgl COMPONENT_VERSION)
-if(lvgl_ver EQUAL "")
-    idf_component_get_property(lvgl_ver lvgl COMPONENT_VERSION)
+# This component uses a CMake workaround, so we can compile esp_lvgl_port for both LVGL8.x and LVGL9.x
+# At the time of idf_component_register() we don't know which LVGL version is used, so we only register an INTERFACE component (with no sources)
+# Later, when we know the LVGL version, we create another CMake library called 'lvgl_port_lib' and link it to the 'esp_lvgl_port' INTERFACE component
+idf_component_register(
+        INCLUDE_DIRS "include"
+        PRIV_INCLUDE_DIRS "priv_include"
+        REQUIRES "esp_lcd")
+
+# Get LVGL version
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if(lvgl IN_LIST build_components)
+    set(lvgl_name lvgl) # Local component
+    set(lvgl_ver $ENV{LVGL_VERSION}) # Get the version from env variable (set from LVGL v9.2)
+else()
+    set(lvgl_name lvgl__lvgl) # Managed component
+    idf_component_get_property(lvgl_ver ${lvgl_name} COMPONENT_VERSION) # Get the version from esp-idf build system
 endif()
+
+if("${lvgl_ver}" STREQUAL "")
+    message("Could not determine LVGL version, assuming v9.x")
+    set(lvgl_ver "9.0.0")
+endif()
+
+# Select folder by LVGL version
 message(STATUS "LVGL version: ${lvgl_ver}")
-
-#Select folder by LVGL version
 if(lvgl_ver VERSION_LESS "9.0.0")
     message(VERBOSE "Compiling esp_lvgl_port for LVGL8")
     set(PORT_FOLDER "lvgl8")
@@ -20,15 +37,8 @@ else()
     set(PORT_FOLDER "lvgl9")
 endif()
 
+# Add LVGL port extensions
 set(PORT_PATH "src/${PORT_FOLDER}")
-
-idf_component_register(
-        SRCS "${PORT_PATH}/esp_lvgl_port.c" "${PORT_PATH}/esp_lvgl_port_disp.c" 
-        INCLUDE_DIRS "include" 
-        PRIV_INCLUDE_DIRS "priv_include"
-        REQUIRES "esp_lcd" 
-        PRIV_REQUIRES "esp_timer")
-
 set(ADD_SRCS "")
 set(ADD_LIBS "")
 
@@ -66,9 +76,22 @@ if("usb_host_hid" IN_LIST build_components)
     list(APPEND ADD_LIBS idf::usb_host_hid)
 endif()
 
-if(ADD_SRCS)
-    target_sources(${COMPONENT_LIB} PRIVATE ${ADD_SRCS})
-endif()
-if(ADD_LIBS)
-    target_link_libraries(${COMPONENT_LIB} PRIVATE ${ADD_LIBS})
-endif()
+# Here we create the real lvgl_port_lib
+add_library(lvgl_port_lib STATIC
+    ${PORT_PATH}/esp_lvgl_port.c
+    ${PORT_PATH}/esp_lvgl_port_disp.c
+    ${ADD_SRCS}
+    )
+target_include_directories(lvgl_port_lib PUBLIC "include")
+target_include_directories(lvgl_port_lib PRIVATE "priv_include")
+target_link_libraries(lvgl_port_lib PUBLIC
+    idf::esp_lcd
+    idf::${lvgl_name}
+    )
+target_link_libraries(lvgl_port_lib PRIVATE
+    idf::esp_timer
+    ${ADD_LIBS}
+    )
+
+# Finally, link the lvgl_port_lib its esp-idf interface library
+target_link_libraries(${COMPONENT_LIB} INTERFACE lvgl_port_lib)


### PR DESCRIPTION
esp_lvgl_port component configuration is entirely dependent on LVGL's version. Moreover LVGL can be used as local or managed component. This PR aims to support all possible combinations

* Related to https://github.com/lvgl/lvgl/pull/6654
* esp_lvgl_port cannot be linked with LVGL's master branch, we must merge this first #362 


From esp_lvgl_port/CMakeLists.txt
``` cmake
# This component uses a CMake workaround, so we can compile esp_lvgl_port for both LVGL8.x and LVGL9.x
# At the time of idf_component_register() we don't know which LVGL version is used, so we only register an INTERFACE component (with no sources)
# Later, when we know the LVGL version, we create another CMake library called 'lvgl_port_lib' and link it to the 'esp_lvgl_port' INTERFACE component
```