### PR TITLE
fix(esp_lcd_touch): Remove i2c includes

### DIFF
--- a/components/lcd/esp_lcd_ssd1681/CMakeLists.txt
+++ b/components/lcd/esp_lcd_ssd1681/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "esp_lcd_panel_ssd1681"
+idf_component_register(SRCS "esp_lcd_panel_ssd1681.c"
                        INCLUDE_DIRS "include"
                        REQUIRES "esp_lcd"
                        PRIV_REQUIRES "driver")

--- a/components/lcd/esp_lcd_ssd1681/idf_component.yml
+++ b/components/lcd/esp_lcd_ssd1681/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.1.0~1"
 description: ESP LCD SSD1681 e-paper driver
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_ssd1681
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -10,7 +10,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_system.h"
 #include "esp_err.h"
 #include "esp_log.h"

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.3~1"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -13,7 +13,6 @@
 #include "esp_log.h"
 #include "esp_check.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_touch.h"
 

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6"
+version: "1.0.6~1"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/esp_lcd_touch_gt1151.c
@@ -11,7 +11,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_system.h"
 #include "esp_err.h"
 #include "esp_log.h"

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5~1"
+version: "1.0.5~2"
 description: ESP LCD Touch GT1151 - touch controller GT1151
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -13,7 +13,6 @@
 #include "esp_log.h"
 #include "esp_check.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_touch.h"
 #include "esp_lcd_touch_gt911.h"

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.1~1"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
@@ -13,7 +13,6 @@
 #include "esp_log.h"
 #include "esp_check.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_lcd_touch.h"
 
 static const char *TAG = "TT21100";

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.0~1"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS "../components")
+set(EXTRA_COMPONENT_DIRS "../components" "../components/lcd" "../components/lcd_touch" "../components/io_expander")
 set(EXCLUDE_COMPONENTS "es8311 es7210") # Deprecated components
 
 include($ENV{IDF_PATH}/tools/cmake/version.cmake) # $ENV{IDF_VERSION} was added after v4.3...


### PR DESCRIPTION
# Change description

All esp_lcd_touch drivers use I2C IO from esp_lcd, they do not directly depend on I2C driver.

Closes https://github.com/espressif/esp-bsp/issues/380

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing
