### PR TITLE
fix: Do not access LVGL 9.2 private members

### DIFF
--- a/examples/display/main/lvgl_demo_ui.c
+++ b/examples/display/main/lvgl_demo_ui.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -31,7 +31,7 @@ static lv_color_t arc_color[] = {
 
 static void anim_timer_cb(lv_timer_t *timer)
 {
-    my_timer_context_t *timer_ctx = (my_timer_context_t *) timer->user_data;
+    my_timer_context_t *timer_ctx = (my_timer_context_t *) lv_timer_get_user_data(timer);
     int count = timer_ctx->count_val;
     lv_obj_t *scr = timer_ctx->scr;
 

--- a/examples/display_audio_photo/main/app_disp_fs.c
+++ b/examples/display_audio_photo/main/app_disp_fs.c
@@ -215,7 +215,7 @@ static void close_window_handler(lv_event_t *e)
 
     if (code == LV_EVENT_CLICKED) {
         memset(file_buffer, 0, file_buffer_size);
-        lv_obj_del(e->user_data);
+        lv_obj_del(lv_event_get_user_data(e));
 
         /* Re-set the TAB group */
         set_tab_group();
@@ -408,7 +408,7 @@ static void play_event_cb(lv_event_t *e)
     if (code == LV_EVENT_CLICKED) {
         play_file_stop = false;
         lv_obj_add_state(obj, LV_STATE_DISABLED);
-        xTaskCreate(play_file, "audio_task", 4096, e->user_data, 6, NULL);
+        xTaskCreate(play_file, "audio_task", 4096, lv_event_get_user_data(e), 6, NULL);
     }
 }
 
@@ -451,7 +451,7 @@ static void close_window_wav_handler(lv_event_t *e)
 
     if (code == LV_EVENT_CLICKED) {
         memset(file_buffer, 0, file_buffer_size);
-        lv_obj_del(e->user_data);
+        lv_obj_del(lv_event_get_user_data(e));
         play_file_stop = true;
 
         xSemaphoreTake(audio_mux, portMAX_DELAY);
@@ -750,7 +750,7 @@ static void rec_play_event_cb(lv_event_t *e)
         assert(audio_mux);
         play_file_stop = false;
         lv_obj_add_state(obj, LV_STATE_DISABLED);
-        xTaskCreate(play_file, "audio_task", 4096, e->user_data, 6, NULL);
+        xTaskCreate(play_file, "audio_task", 4096, lv_event_get_user_data(e), 6, NULL);
     }
 }
 
@@ -848,7 +848,7 @@ static void rec_event_cb(lv_event_t *e)
             lv_obj_add_state(play1_btn, LV_STATE_DISABLED);
             lv_obj_add_state(rec_stop_btn, LV_STATE_DISABLED);
         }
-        xTaskCreate(rec_file, "rec_file", 4096, e->user_data, 6, NULL);
+        xTaskCreate(rec_file, "rec_file", 4096, lv_event_get_user_data(e), 6, NULL);
     }
 }
 

--- a/examples/display_camera/main/display_camera.c
+++ b/examples/display_camera/main/display_camera.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "sdkconfig.h"
 #include "bsp/esp-bsp.h"
 #include "freertos/FreeRTOS.h"


### PR DESCRIPTION
LVGL 9.2 makes `user_data` private. Access it with provided getter functions