### PR TITLE
[fix] use new i2c interface for esp32_p4_function_ev_board. (BSP-545)

### DIFF
--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.1"
+version: "4.0.0"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 

--- a/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
+++ b/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
@@ -13,7 +13,7 @@
 
 #include "sdkconfig.h"
 #include "driver/gpio.h"
-#include "driver/i2c.h"
+#include "driver/i2c_master.h"
 #include "driver/sdmmc_host.h"
 #include "bsp/config.h"
 #include "bsp/display.h"

--- a/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
+++ b/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
@@ -100,6 +100,15 @@ esp_err_t bsp_i2c_init(void);
  */
 esp_err_t bsp_i2c_deinit(void);
 
+/**
+ * @brief Get I2C driver handle
+ *
+ * @return
+ *      - I2C handle
+ *
+ */
+i2c_master_bus_handle_t bsp_i2c_get_handle(void);
+
 /**************************************************************************************************
  *
  * SPIFFS


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing

# Change description
BSP uses old i2c interface. when another component such as esp-video uses new i2c interface. They will conflict. 