### PR TITLE
fix(LVGL port): Fixed rotation type compatibility with LVGL8.

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.2
+
+### Fixes
+- Fixed rotation type compatibility with LVGL8.
+
 ## 2.3.1
 
 ### Fixes

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.3.1"
+version: "2.3.2"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/include/esp_lvgl_port_compatibility.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port_compatibility.h
@@ -25,6 +25,7 @@ typedef enum {
     LV_DISPLAY_ROTATION_180 = LV_DISP_ROT_180,
     LV_DISPLAY_ROTATION_270 = LV_DISP_ROT_270
 } lv_disp_rotation_t;
+typedef lv_disp_rotation_t lv_display_rotation_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Fixed rotation type compatibility with LVGL8 (issue with M5Stack Core S3 BSP)