### PR TITLE
fix(LVGL port): Fixed monochromatic screen in LVGL9 + example

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.4.3
+
+### Fixes
+- Fixed I2C example for using with LVGL9
+
+### Features
+- Support for LV_COLOR_FORMAT_I1 for monochromatic screen
+
 ## 2.4.2
 
 ### Fixes

--- a/components/esp_lvgl_port/examples/i2c_oled/README.md
+++ b/components/esp_lvgl_port/examples/i2c_oled/README.md
@@ -5,14 +5,20 @@
 
 [esp_lcd](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/lcd.html) supports I2C interfaced OLED LCD, whose color depth is usually 1bpp.
 
-This example shows how to make use of the SSD1306 panel driver from `esp_lcd` component to facilitate the porting of LVGL library. In the end, example will display a scrolling text on the OLED screen. 
+This example shows how to make use of the SSD1306 panel driver from `esp_lcd` component to facilitate the porting of LVGL library. In the end, example will display a scrolling text on the OLED screen.
 
 ## LVGL Version
 
-This example is using the **LVGL8** version. For use it with LVGL9 version, please remove this line from [idf_component.yml](main/idf_component.yml) file:
+This example is using the **LVGL8** version. For use it with LVGL9 version, please delete file [sdkconfig.defaults](sdkconfig.defaults) and change version to `"^9"` on this line in [idf_component.yml](main/idf_component.yml) file:
 ```
 lvgl/lvgl: "^8"
 ```
+
+NOTE: When you are changing LVGL versions, please remove these files and folders before new build:
+- build/
+- managed_components/
+- dependencies.lock
+- sdkconfig
 
 ## How to use the example
 

--- a/components/esp_lvgl_port/examples/i2c_oled/main/lvgl_demo_ui.c
+++ b/components/esp_lvgl_port/examples/i2c_oled/main/lvgl_demo_ui.c
@@ -13,6 +13,10 @@ void example_lvgl_demo_ui(lv_disp_t *disp)
     lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR); /* Circular scroll */
     lv_label_set_text(label, "Hello Espressif, Hello LVGL.");
     /* Size of the screen (if you use rotation 90 or 270, please set disp->driver->ver_res) */
+#if LVGL_VERSION_MAJOR >= 9
+    lv_obj_set_width(label, lv_display_get_physical_horizontal_resolution(disp));
+#else
     lv_obj_set_width(label, disp->driver->hor_res);
+#endif
     lv_obj_align(label, LV_ALIGN_TOP_MID, 0, 0);
 }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Fixed using monochromatic screens with LVGL port and LVGL9
- Support for LV_COLOR_FORMAT_I1 for monochromatic screen