### PR TITLE
fix(bsp): fix idf5.0 adc build with unknown type error

### DIFF
--- a/bsp/esp32_s3_korvo_1/CHANGELOG.md
+++ b/bsp/esp32_s3_korvo_1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# ChangeLog
+
+## v1.1.1 - 2024-09-20
+
+### Bugfix
+
+* Fix adc build error when using `ESP-IDF` `5.0`

--- a/bsp/esp32_s3_korvo_1/esp32_s3_korvo_1_idf5.c
+++ b/bsp/esp32_s3_korvo_1/esp32_s3_korvo_1_idf5.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_err.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
 #include "bsp/esp32_s3_korvo_1.h"
 #include "bsp_err_check.h"

--- a/bsp/esp32_s3_korvo_1/idf_component.yml
+++ b/bsp/esp32_s3_korvo_1/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: Board Support Package (BSP) for ESP32-S3-KORVO-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_1
 

--- a/bsp/esp32_s3_korvo_2/CHANGELOG.md
+++ b/bsp/esp32_s3_korvo_2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# ChangeLog
+
+## v2.2.1 - 2024-09-20
+
+### Bugfix
+
+* Fix adc build error when using `ESP-IDF` `5.0`

--- a/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2_idf5.c
+++ b/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2_idf5.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_err.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
 #include "bsp/esp32_s3_korvo_2.h"
 #include "bsp_err_check.h"

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.0~1"
+version: "2.2.1"
 description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 

--- a/bsp/esp32_s3_lcd_ev_board/CHANGELOG.md
+++ b/bsp/esp32_s3_lcd_ev_board/CHANGELOG.md
@@ -32,7 +32,7 @@
     * Add new APIs for spiffs, audio in `bsp/esp32_s3_lcd_ev_board.h`
     * Add new APIs for ADC in `bsp/esp32_s3_lcd_ev_board.h`
 
-## v3.0.0 - 2023-12-02
+## v2.1.0 - 2023-12-02
 
 ### Bugfix
 
@@ -52,3 +52,9 @@
 * Update the version of `ESP-IDF` to `>5.0.1`
 * Use `esp_lcd_gc9503` version `^1` when using `ESP-IDF` version `<5.1.2`
 * Use `esp_lcd_gc9503` version `^3` when using `ESP-IDF` version `>=5.1.2`
+
+## v2.2.2 - 2024-09-20
+
+### Bugfix
+
+* Fix adc build error when using `ESP-IDF` `5.0`

--- a/bsp/esp32_s3_lcd_ev_board/idf_component.yml
+++ b/bsp/esp32_s3_lcd_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.1~1"
+version: "2.2.2"
 description: Board Support Package (BSP) for ESP32-S3-LCD-EV-Board
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_lcd_ev_board
 

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
@@ -14,6 +14,7 @@
 #include "driver/i2s_std.h"
 #include "driver/gpio.h"
 #include "soc/usb_pins.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
 #include "esp_codec_dev.h"
 #include "esp_err.h"

--- a/bsp/esp32_s3_usb_otg/CHANGELOG.md
+++ b/bsp/esp32_s3_usb_otg/CHANGELOG.md
@@ -1,0 +1,7 @@
+# ChangeLog
+
+## v1.6.1 - 2024-09-20
+
+### Bugfix
+
+* Fix adc build error when using `ESP-IDF` `5.0`

--- a/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg_idf5.c
+++ b/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg_idf5.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_err.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
 #include "bsp/esp32_s3_usb_otg.h"
 #include "bsp_err_check.h"

--- a/bsp/esp32_s3_usb_otg/idf_component.yml
+++ b/bsp/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.0"
+version: "1.6.1"
 description: Board Support Package (BSP) for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing

# Change description


* Explicit include `esp_adc/adc_cali_scheme.h` in BSP header to support IDF 5.0


`bsp` like `esp32_s3_usb_otg` `esp32_s3_lcd_ev_board` build under IDF 5.0 always failed with error:

```
.../managed_components/espressif__esp32_s3_usb_otg/esp32_s3_usb_otg_idf5.c:14:8: error: unknown type name 'adc_cali_handle_t'
   14 | static adc_cali_handle_t bsp_adc_cali_handle; /* ADC1 calibration handle */

...

error: unknown type name 'adc_cali_curve_fitting_config_t'
```

The root cause is `esp_adc/adc_oneshot.h` in [IDF 5.0](https://github.com/espressif/esp-idf/blob/release/v5.0/components/esp_adc/include/esp_adc/adc_oneshot.h) not explicit include `esp_adc/adc_cali_scheme.h`

While IDF 5.1 and later versions include `esp_adc/adc_cali_scheme.h` in `esp_adc/adc_oneshot.h`