### PR TITLE
fix(esp32_p4_function_ev_board): use slot 0 for SD card

### DIFF
--- a/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
+++ b/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
@@ -89,6 +89,7 @@ esp_err_t bsp_sdcard_mount(void)
     };
 
     sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+    host.slot = SDMMC_HOST_SLOT_0;
     host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
 
     sd_pwr_ctrl_ldo_config_t ldo_config = {
@@ -103,16 +104,7 @@ esp_err_t bsp_sdcard_mount(void)
     host.pwr_ctrl_handle = pwr_ctrl_handle;
 
     const sdmmc_slot_config_t slot_config = {
-        .clk = BSP_SD_CLK,
-        .cmd = BSP_SD_CMD,
-        .d0 = BSP_SD_D0,
-        .d1 = BSP_SD_D1,
-        .d2 = BSP_SD_D2,
-        .d3 = BSP_SD_D3,
-        .d4 = GPIO_NUM_NC,
-        .d5 = GPIO_NUM_NC,
-        .d6 = GPIO_NUM_NC,
-        .d7 = GPIO_NUM_NC,
+        /* SD card is connected to Slot 0 pins. Slot 0 uses IO MUX, so not specifying the pins here */
         .cd = SDMMC_SLOT_NO_CD,
         .wp = SDMMC_SLOT_NO_WP,
         .width = 4,

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.0.0"
+version: "4.0.1"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 


### PR DESCRIPTION
SD card on P4 EV board is connected to slot 0. Previously the code used slot 1 and routed it through GPIO Matrix to slot 0 pins. This resulted in conflicts when trying to use slot 1 for connecting to ESP32-C6 over SDIO.

See https://github.com/espressif/esp-idf/issues/14699#issuecomment-2407264707 for background.