### PR TITLE
fix(lvgl_port): Fixed SW rotation in LVGL9.2 and fixed free buffers.

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 2.4.2
+
+### Fixes
+- Fixed SW rotation in LVGL9.2
+- Fixed freeing right buffers when error
+
 ## 2.4.1
 
 ### Fixes
-Fix the issue of the DPI callback function not being initialized.
+- Fixed the issue of the DPI callback function not being initialized.
 
 ## 2.4.0
 

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.1"
+version: "2.4.2"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/include/esp_lvgl_port_disp.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port_disp.h
@@ -50,7 +50,7 @@ typedef struct {
 
     bool        monochrome;     /*!< True, if display is monochrome and using 1bit for 1px */
 
-    lvgl_port_rotation_cfg_t rotation;      /*!< Default values of the screen rotation */
+    lvgl_port_rotation_cfg_t rotation;      /*!< Default values of the screen rotation (Only HW state. Not supported for default SW rotation!) */
 #if LVGL_VERSION_MAJOR >= 9
     lv_color_format_t        color_format;  /*!< The color format of the display */
 #endif

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -356,11 +356,11 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
 
 err:
     if (ret != ESP_OK) {
-        if (buf1) {
-            free(buf1);
+        if (disp_ctx->draw_buffs[0]) {
+            free(disp_ctx->draw_buffs[0]);
         }
-        if (buf2) {
-            free(buf2);
+        if (disp_ctx->draw_buffs[1]) {
+            free(disp_ctx->draw_buffs[1]);
         }
         if (disp_ctx->draw_buffs[2]) {
             free(disp_ctx->draw_buffs[2]);
@@ -534,9 +534,9 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
             if (disp_ctx->current_rotation == LV_DISPLAY_ROTATION_180) {
                 lv_draw_sw_rotate(color_map, disp_ctx->draw_buffs[2], hh, ww, h_stride, h_stride, LV_DISPLAY_ROTATION_180, cf);
             } else if (disp_ctx->current_rotation == LV_DISPLAY_ROTATION_90) {
-                lv_draw_sw_rotate(color_map, disp_ctx->draw_buffs[2], ww, hh, w_stride, h_stride, LV_DISPLAY_ROTATION_270, cf);
-            } else if (disp_ctx->current_rotation == LV_DISPLAY_ROTATION_270) {
                 lv_draw_sw_rotate(color_map, disp_ctx->draw_buffs[2], ww, hh, w_stride, h_stride, LV_DISPLAY_ROTATION_90, cf);
+            } else if (disp_ctx->current_rotation == LV_DISPLAY_ROTATION_270) {
+                lv_draw_sw_rotate(color_map, disp_ctx->draw_buffs[2], ww, hh, w_stride, h_stride, LV_DISPLAY_ROTATION_270, cf);
             }
             color_map = (uint8_t *)disp_ctx->draw_buffs[2];
             lvgl_port_rotate_area(drv, (lv_area_t *)area);


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [ ] CI passing

# Change description
- Fixed SW rotation in LVGL9.2 (https://github.com/espressif/esp-bsp/issues/400)
- Fixed freeing right buffers when error