### PR TITLE
incorporating relevant changes from led_strip v3.0.0 (BSP-574)

### DIFF
--- a/bsp/esp32_c3_lcdkit/esp32_c3_lcdkit.c
+++ b/bsp/esp32_c3_lcdkit/esp32_c3_lcdkit.c
@@ -68,7 +68,6 @@ static i2s_chan_handle_t i2s_tx_chan;
 static const led_strip_config_t bsp_strip_config = {
     .strip_gpio_num = BSP_RGB_CTRL,
     .max_leds = 1,
-    .led_pixel_format = LED_PIXEL_FORMAT_GRB,
     .led_model = LED_MODEL_WS2812,
     .flags.invert_out = false,
 };

--- a/bsp/esp32_s3_korvo_1/esp32_s3_korvo_1.c
+++ b/bsp/esp32_s3_korvo_1/esp32_s3_korvo_1.c
@@ -245,7 +245,6 @@ esp_err_t bsp_iot_button_create(button_handle_t btn_array[], int *btn_cnt, int b
 static const led_strip_config_t bsp_leds_rgb_strip_config = {
     .strip_gpio_num = BSP_LED_RGB_GPIO,   // The GPIO that connected to the LED strip's data line
     .max_leds = BSP_LED_NUM,                  // The number of LEDs in the strip,
-    .led_pixel_format = LED_PIXEL_FORMAT_GRB, // Pixel format of your LED strip
     .led_model = LED_MODEL_WS2812,            // LED strip model
     .flags.invert_out = false,                // whether to invert the output signal
 };

--- a/bsp/esp32_s3_korvo_1/idf_component.yml
+++ b/bsp/esp32_s3_korvo_1/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: Board Support Package (BSP) for ESP32-S3-KORVO-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_1
 
@@ -6,7 +6,7 @@ targets:
   - esp32s3
 
 tags:
-  - bsp  
+  - bsp
 
 dependencies:
   idf: ">=4.4"

--- a/bsp/esp_bsp_devkit/idf_component.yml
+++ b/bsp/esp_bsp_devkit/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0"
+version: "1.0.1"
 description: DevKit Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_devkit
 

--- a/bsp/esp_bsp_devkit/src/esp_bsp_devkit.c
+++ b/bsp/esp_bsp_devkit/src/esp_bsp_devkit.c
@@ -155,7 +155,6 @@ static led_indicator_gpio_config_t bsp_leds_gpio_config[] = {
 static const led_strip_config_t bsp_leds_rgb_strip_config = {
     .strip_gpio_num = CONFIG_BSP_LED_RGB_GPIO,   // The GPIO that connected to the LED strip's data line
     .max_leds = BSP_LED_NUM,                  // The number of LEDs in the strip,
-    .led_pixel_format = LED_PIXEL_FORMAT_GRB, // Pixel format of your LED strip
     .led_model = LED_MODEL_WS2812,            // LED strip model
     .flags.invert_out = false,                // whether to invert the output signal
 };

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.2.0"
+version: "1.2.1"
 description: Generic Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
 

--- a/bsp/esp_bsp_generic/src/esp_bsp_generic.c
+++ b/bsp/esp_bsp_generic/src/esp_bsp_generic.c
@@ -194,7 +194,6 @@ static led_indicator_gpio_config_t bsp_leds_gpio_config[] = {
 static const led_strip_config_t bsp_leds_rgb_strip_config = {
     .strip_gpio_num = CONFIG_BSP_LED_RGB_GPIO,   // The GPIO that connected to the LED strip's data line
     .max_leds = BSP_LED_NUM,                  // The number of LEDs in the strip,
-    .led_pixel_format = LED_PIXEL_FORMAT_GRB, // Pixel format of your LED strip
     .led_model = LED_MODEL_WS2812,            // LED strip model
     .flags.invert_out = false,                // whether to invert the output signal
 };


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Recently a new version (v3.0.0) of led_strip was pushed. This changed the `led_strip_config_t` struct in the 

> led_strip/include/led_strip_types.h

 file.

Please check the latest change of led_strip repository [here](https://github.com/espressif/idf-extra-components/commit/31585c8c97b5a403e1550270fb9fad58879cc2dd)

Closes https://github.com/espressif/esp-bsp/issues/420