### PR TITLE
fix(esp32_s3_lcd_ev_board): Fixed LVGL8 compatibility

### DIFF
--- a/bsp/esp32_s3_lcd_ev_board/CHANGELOG.md
+++ b/bsp/esp32_s3_lcd_ev_board/CHANGELOG.md
@@ -58,3 +58,9 @@
 ### Bugfix
 
 * Fix adc build error when using `ESP-IDF` `5.0`
+
+## v2.2.3 - 2024-11-07
+
+### Bugfix
+
+* Fixed LVGL8 compatibility in esp32_s3_lcd_ev_board

--- a/bsp/esp32_s3_lcd_ev_board/idf_component.yml
+++ b/bsp/esp32_s3_lcd_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.2"
+version: "2.2.3"
 description: Board Support Package (BSP) for ESP32-S3-LCD-EV-Board
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_lcd_ev_board
 

--- a/bsp/esp32_s3_lcd_ev_board/src/esp32_s3_lcd_ev_board.c
+++ b/bsp/esp32_s3_lcd_ev_board/src/esp32_s3_lcd_ev_board.c
@@ -339,7 +339,9 @@ static lv_display_t *bsp_display_lcd_init()
         .monochrome = false,
         .hres = BSP_LCD_H_RES,
         .vres = BSP_LCD_V_RES,
+#if LVGL_VERSION_MAJOR >= 9
         .color_format = LV_COLOR_FORMAT_RGB565,
+#endif
 
         .rotation = {
             .swap_xy = false,


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Fixed LVGL8 compatibility in esp32_s3_lcd_ev_board