### PR TITLE
fix: Manifest .build-test-rules.yml rule (BSP-583)

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -50,7 +50,7 @@ components/lcd/esp_lcd_gc9503:
   depends_filepatterns:
     - "components/lcd/esp_lcd_gc9503/**"
   disable:
-    - if: IDF_VERSION_MAJOR < 5 or (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 0 and ESP_IDF_VERSION_PATCH < 5) or (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 1 and ESP_IDF_VERSION_PATCH == 1)
+    - if: (IDF_VERSION_MAJOR < 5 or ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 0) and ESP_IDF_VERSION_PATCH < 5)) or ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 1) and ESP_IDF_VERSION_PATCH == 1)
       reason: Supported from version 5.0.5 and not supported in version 5.1.1
 
 components/lcd/esp_lcd_ili9341:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist
- [X] Version of modified component bumped
- [X] CI passing

# Change description
This PR fixes the `components/lcd/esp_lcd_gc9503` if rule in the manifest file `build-test-rules.yml`.

Note: It only fixes parentheses in the rule, but I have a feeling (based on the reason in the rule), that `IDF_VERSION_MAJOR < 5` is redundant. If this is the case I will update the PR, otherwise I'll leave it as it is.

Before fix:
![image](https://github.com/user-attachments/assets/4942b1b7-42ce-4197-8e06-bc2635fdb264)

After fix:
![image](https://github.com/user-attachments/assets/ef277c8f-dbac-41cd-8f0a-df741b0c2128)
