### PR TITLE
Wrong dependency version (BSP-590)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_gt911/README.md
+++ b/components/lcd_touch/esp_lcd_touch_gt911/README.md
@@ -13,7 +13,7 @@ Implementation of the GT911 touch controller with esp_lcd_touch component.
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
 You can add them to your project via `idf.py add-dependancy`, e.g.
 ```
-    idf.py add-dependency esp_lcd_touch_gt911==1.0.0
+    idf.py add-dependency esp_lcd_touch_gt911==1.1.1
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1~1"
+version: "1.1.1~2"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description
The **add-dependency** for **esp_lcd_touch_gt911** installs a version that is incompatible with the provided usage example.

**esp_lcd_touch_io_gt911_config_t** type is defined in version **1.1.1** [here](https://github.com/espressif/esp-bsp/commit/d118a01b29764b32c5ad2ec54fe0bf72f3769699#diff-9d9605942dc95af8aed100641fc40e7fe6ab8fdde90092e32197f8db3cd1bb2dR49) , so the **1.0.0** version is not compatible with the example.