### PR TITLE
Fix: knob loses diff event

### DIFF
--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.3"
+version: "2.4.4"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_knob.c
+++ b/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_knob.c
@@ -128,8 +128,10 @@ static void lvgl_port_encoder_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *d
     knob_event_t event = iot_knob_get_event(ctx->knob_handle);
 
     if (last_v ^ invd) {
+        data->enc_diff = (event == KNOB_LEFT) ? -1 :
+                         (event == KNOB_RIGHT) ? 1 :
+                         (int32_t)((uint32_t)invd - (uint32_t)last_v);
         last_v = invd;
-        data->enc_diff = (KNOB_LEFT == event) ? (-1) : ((KNOB_RIGHT == event) ? (1) : (0));
     } else {
         data->enc_diff = 0;
     }

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_knob.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_knob.c
@@ -139,8 +139,10 @@ static void lvgl_port_encoder_read(lv_indev_t *indev_drv, lv_indev_data_t *data)
     knob_event_t event = iot_knob_get_event(ctx->knob_handle);
 
     if (last_v ^ invd) {
+        data->enc_diff = (event == KNOB_LEFT) ? -1 :
+                         (event == KNOB_RIGHT) ? 1 :
+                         (int32_t)((uint32_t)invd - (uint32_t)last_v);
         last_v = invd;
-        data->enc_diff = (KNOB_LEFT == event) ? (-1) : ((KNOB_RIGHT == event) ? (1) : (0));
     } else {
         data->enc_diff = 0;
     }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
1: The new component of the `knob`  will clear the flag of  [knob->event](https://github.com/espressif/esp-iot-solution/blob/c683b16aa9f7c3202952fb814d19ed126847e75d/components/knob/iot_knob.c#L195), so we add `count_value`  for conditional checks.