### PR TITLE
Use driver_data instead of user_data (BSP-600)

### DIFF
--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_button.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_button.c
@@ -91,7 +91,7 @@ lv_indev_t *lvgl_port_add_navigation_buttons(const lvgl_port_nav_btns_cfg_t *but
     lv_indev_set_mode(indev, LV_INDEV_MODE_EVENT);
     lv_indev_set_read_cb(indev, lvgl_port_navigation_buttons_read);
     lv_indev_set_disp(indev, buttons_cfg->disp);
-    lv_indev_set_user_data(indev, buttons_ctx);
+    lv_indev_set_driver_data(indev, buttons_ctx);
     //buttons_ctx->indev->long_press_repeat_time = 300;
     buttons_ctx->indev = indev;
     lvgl_port_unlock();
@@ -117,7 +117,7 @@ err:
 esp_err_t lvgl_port_remove_navigation_buttons(lv_indev_t *buttons)
 {
     assert(buttons);
-    lvgl_port_nav_btns_ctx_t *buttons_ctx = (lvgl_port_nav_btns_ctx_t *)lv_indev_get_user_data(buttons);
+    lvgl_port_nav_btns_ctx_t *buttons_ctx = (lvgl_port_nav_btns_ctx_t *)lv_indev_get_driver_data(buttons);
 
     lvgl_port_lock(0);
     /* Remove input device driver */
@@ -141,7 +141,7 @@ static void lvgl_port_navigation_buttons_read(lv_indev_t *indev_drv, lv_indev_da
     static uint32_t last_key = 0;
 
     assert(indev_drv);
-    lvgl_port_nav_btns_ctx_t *ctx = (lvgl_port_nav_btns_ctx_t *)lv_indev_get_user_data(indev_drv);
+    lvgl_port_nav_btns_ctx_t *ctx = (lvgl_port_nav_btns_ctx_t *)lv_indev_get_driver_data(indev_drv);
     assert(ctx);
 
     /* Buttons */

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -87,7 +87,7 @@ lv_display_t *lvgl_port_add_disp(const lvgl_port_display_cfg_t *disp_cfg)
     lv_disp_t *disp = lvgl_port_add_disp_priv(disp_cfg, NULL);
 
     if (disp != NULL) {
-        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp);
+        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp);
         /* Set display type */
         disp_ctx->disp_type = LVGL_PORT_DISP_TYPE_OTHER;
 
@@ -119,7 +119,7 @@ lv_display_t *lvgl_port_add_disp_dsi(const lvgl_port_display_cfg_t *disp_cfg, co
     lv_disp_t *disp = lvgl_port_add_disp_priv(disp_cfg, &priv_cfg);
 
     if (disp != NULL) {
-        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp);
+        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp);
         /* Set display type */
         disp_ctx->disp_type = LVGL_PORT_DISP_TYPE_DSI;
 
@@ -154,7 +154,7 @@ lv_display_t *lvgl_port_add_disp_rgb(const lvgl_port_display_cfg_t *disp_cfg, co
     lv_disp_t *disp = lvgl_port_add_disp_priv(disp_cfg, &priv_cfg);
 
     if (disp != NULL) {
-        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp);
+        lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp);
         /* Set display type */
         disp_ctx->disp_type = LVGL_PORT_DISP_TYPE_RGB;
 
@@ -190,7 +190,7 @@ lv_display_t *lvgl_port_add_disp_rgb(const lvgl_port_display_cfg_t *disp_cfg, co
 esp_err_t lvgl_port_remove_disp(lv_display_t *disp)
 {
     assert(disp);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp);
 
     lvgl_port_lock(0);
     lv_disp_remove(disp);
@@ -366,7 +366,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
     lv_display_add_event_cb(disp, lvgl_port_display_invalidate_callback, LV_EVENT_INVALIDATE_AREA, disp_ctx);
     lv_display_add_event_cb(disp, lvgl_port_display_invalidate_callback, LV_EVENT_REFR_REQUEST, disp_ctx);
 
-    lv_display_set_user_data(disp, disp_ctx);
+    lv_display_set_driver_data(disp, disp_ctx);
     disp_ctx->disp_drv = disp;
 
     /* Use SW rotation */
@@ -425,7 +425,7 @@ static bool lvgl_port_flush_dpi_vsync_ready_callback(esp_lcd_panel_handle_t pane
 
     lv_display_t *disp_drv = (lv_display_t *)user_ctx;
     assert(disp_drv != NULL);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp_drv);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp_drv);
     assert(disp_ctx != NULL);
 
     if (disp_ctx->trans_sem) {
@@ -443,7 +443,7 @@ static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t pane
 
     lv_display_t *disp_drv = (lv_display_t *)user_ctx;
     assert(disp_drv != NULL);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(disp_drv);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(disp_drv);
     assert(disp_ctx != NULL);
 
     if (disp_ctx->trans_sem) {
@@ -461,7 +461,7 @@ static void _lvgl_port_transform_monochrome(lv_display_t *display, const lv_area
     assert(*color_map);
     uint8_t *src = *color_map;
     lv_color16_t *color = (lv_color16_t *)*color_map;
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(display);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(display);
     uint16_t hor_res = lv_display_get_physical_horizontal_resolution(display);
     uint16_t ver_res = lv_display_get_physical_vertical_resolution(display);
     uint16_t res = hor_res;
@@ -558,7 +558,7 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
     assert(drv != NULL);
     assert(area != NULL);
     assert(color_map != NULL);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_user_data(drv);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_display_get_driver_data(drv);
     assert(disp_ctx != NULL);
 
     int offsetx1 = area->x1;
@@ -665,7 +665,7 @@ static void lvgl_port_disp_rotation_update(lvgl_port_display_ctx_t *disp_ctx)
 static void lvgl_port_disp_size_update_callback(lv_event_t *e)
 {
     assert(e);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_event_get_user_data(e);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_event_get_driver_data(e);
     lvgl_port_disp_rotation_update(disp_ctx);
 }
 

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -665,7 +665,7 @@ static void lvgl_port_disp_rotation_update(lvgl_port_display_ctx_t *disp_ctx)
 static void lvgl_port_disp_size_update_callback(lv_event_t *e)
 {
     assert(e);
-    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_event_get_driver_data(e);
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)lv_event_get_user_data(e);
     lvgl_port_disp_rotation_update(disp_ctx);
 }
 

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_knob.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_knob.c
@@ -76,7 +76,7 @@ lv_indev_t *lvgl_port_add_encoder(const lvgl_port_encoder_cfg_t *encoder_cfg)
     lv_indev_set_mode(indev, LV_INDEV_MODE_EVENT);
     lv_indev_set_read_cb(indev, lvgl_port_encoder_read);
     lv_indev_set_disp(indev, encoder_cfg->disp);
-    lv_indev_set_user_data(indev, encoder_ctx);
+    lv_indev_set_driver_data(indev, encoder_ctx);
     encoder_ctx->indev = indev;
     lvgl_port_unlock();
 
@@ -102,7 +102,7 @@ err:
 esp_err_t lvgl_port_remove_encoder(lv_indev_t *encoder)
 {
     assert(encoder);
-    lvgl_port_encoder_ctx_t *encoder_ctx = (lvgl_port_encoder_ctx_t *)lv_indev_get_user_data(encoder);
+    lvgl_port_encoder_ctx_t *encoder_ctx = (lvgl_port_encoder_ctx_t *)lv_indev_get_driver_data(encoder);
 
     if (encoder_ctx->knob_handle != NULL) {
         iot_knob_delete(encoder_ctx->knob_handle);
@@ -132,7 +132,7 @@ static void lvgl_port_encoder_read(lv_indev_t *indev_drv, lv_indev_data_t *data)
 {
     static int32_t last_v = 0;
     assert(indev_drv);
-    lvgl_port_encoder_ctx_t *ctx = (lvgl_port_encoder_ctx_t *)lv_indev_get_user_data(indev_drv);
+    lvgl_port_encoder_ctx_t *ctx = (lvgl_port_encoder_ctx_t *)lv_indev_get_driver_data(indev_drv);
     assert(ctx);
 
     int32_t invd = iot_knob_get_count_value(ctx->knob_handle);

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_touch.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_touch.c
@@ -132,7 +132,7 @@ static void lvgl_port_touchpad_read(lv_indev_t *indev_drv, lv_indev_data_t *data
 
 static void IRAM_ATTR lvgl_port_touch_interrupt_callback(esp_lcd_touch_handle_t tp)
 {
-    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *) tp->config.driver_data;
+    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *) tp->config.user_data;
 
     /* Wake LVGL task, if needed */
     lvgl_port_task_wake(LVGL_PORT_EVENT_TOUCH, touch_ctx->indev);

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_touch.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_touch.c
@@ -64,7 +64,7 @@ lv_indev_t *lvgl_port_add_touch(const lvgl_port_touch_cfg_t *touch_cfg)
     }
     lv_indev_set_read_cb(indev, lvgl_port_touchpad_read);
     lv_indev_set_disp(indev, touch_cfg->disp);
-    lv_indev_set_user_data(indev, touch_ctx);
+    lv_indev_set_driver_data(indev, touch_ctx);
     touch_ctx->indev = indev;
     lvgl_port_unlock();
 
@@ -81,7 +81,7 @@ err:
 esp_err_t lvgl_port_remove_touch(lv_indev_t *touch)
 {
     assert(touch);
-    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *)lv_indev_get_user_data(touch);
+    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *)lv_indev_get_driver_data(touch);
 
     lvgl_port_lock(0);
     /* Remove input device driver */
@@ -107,7 +107,7 @@ esp_err_t lvgl_port_remove_touch(lv_indev_t *touch)
 static void lvgl_port_touchpad_read(lv_indev_t *indev_drv, lv_indev_data_t *data)
 {
     assert(indev_drv);
-    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *)lv_indev_get_user_data(indev_drv);
+    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *)lv_indev_get_driver_data(indev_drv);
     assert(touch_ctx);
     assert(touch_ctx->handle);
 
@@ -132,7 +132,7 @@ static void lvgl_port_touchpad_read(lv_indev_t *indev_drv, lv_indev_data_t *data
 
 static void IRAM_ATTR lvgl_port_touch_interrupt_callback(esp_lcd_touch_handle_t tp)
 {
-    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *) tp->config.user_data;
+    lvgl_port_touch_ctx_t *touch_ctx = (lvgl_port_touch_ctx_t *) tp->config.driver_data;
 
     /* Wake LVGL task, if needed */
     lvgl_port_task_wake(LVGL_PORT_EVENT_TOUCH, touch_ctx->indev);

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_usbhid.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_usbhid.c
@@ -98,7 +98,7 @@ lv_indev_t *lvgl_port_add_usb_hid_mouse_input(const lvgl_port_hid_mouse_cfg_t *m
     lv_indev_set_mode(indev, LV_INDEV_MODE_EVENT);
     lv_indev_set_read_cb(indev, lvgl_port_usb_hid_read_mouse);
     lv_indev_set_disp(indev, mouse_cfg->disp);
-    lv_indev_set_user_data(indev, hid_ctx);
+    lv_indev_set_driver_data(indev, hid_ctx);
     hid_ctx->mouse.indev = indev;
     lvgl_port_unlock();
 
@@ -132,7 +132,7 @@ lv_indev_t *lvgl_port_add_usb_hid_keyboard_input(const lvgl_port_hid_keyboard_cf
     lv_indev_set_mode(indev, LV_INDEV_MODE_EVENT);
     lv_indev_set_read_cb(indev, lvgl_port_usb_hid_read_kb);
     lv_indev_set_disp(indev, keyboard_cfg->disp);
-    lv_indev_set_user_data(indev, hid_ctx);
+    lv_indev_set_driver_data(indev, hid_ctx);
     hid_ctx->kb.indev = indev;
     lvgl_port_unlock();
 
@@ -142,7 +142,7 @@ lv_indev_t *lvgl_port_add_usb_hid_keyboard_input(const lvgl_port_hid_keyboard_cf
 esp_err_t lvgl_port_remove_usb_hid_input(lv_indev_t *hid)
 {
     assert(hid);
-    lvgl_port_usb_hid_ctx_t *hid_ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_user_data(hid);
+    lvgl_port_usb_hid_ctx_t *hid_ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_driver_data(hid);
 
     lvgl_port_lock(0);
     /* Remove input device driver */
@@ -408,7 +408,7 @@ static void lvgl_port_usb_hid_read_mouse(lv_indev_t *indev_drv, lv_indev_data_t 
     int16_t width = 0;
     int16_t height = 0;
     assert(indev_drv);
-    lvgl_port_usb_hid_ctx_t *ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_user_data(indev_drv);
+    lvgl_port_usb_hid_ctx_t *ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_driver_data(indev_drv);
     assert(ctx);
 
     lv_display_t *disp = lv_indev_get_display(indev_drv);
@@ -463,7 +463,7 @@ static void lvgl_port_usb_hid_read_mouse(lv_indev_t *indev_drv, lv_indev_data_t 
 static void lvgl_port_usb_hid_read_kb(lv_indev_t *indev_drv, lv_indev_data_t *data)
 {
     assert(indev_drv);
-    lvgl_port_usb_hid_ctx_t *ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_user_data(indev_drv);
+    lvgl_port_usb_hid_ctx_t *ctx = (lvgl_port_usb_hid_ctx_t *)lv_indev_get_driver_data(indev_drv);
     assert(ctx);
 
     data->key = ctx->kb.last_key;


### PR DESCRIPTION
# Change description

`esp_lvgl_port` was using user data to store data. When I started wrapping the drivers in my project and using the user data, this broke `esp_lvgl_port`.
Since LVGL9, there's a "driver data" attribute, so I refactored the existing drivers to use the driver data functions instead, which frees up the user data, which can then be left to the user.
