### PR TITLE
feat: add_esp32c5_target (BSP-602)

### DIFF
--- a/bsp/esp_bsp_devkit/Kconfig
+++ b/bsp/esp_bsp_devkit/Kconfig
@@ -662,6 +662,23 @@ menu "Board Support Package (generic)"
             int
             default ENV_GPIO_RANGE_MAX
     endif
+    if IDF_TARGET_ESP32C5
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 32
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
     if IDF_TARGET_ESP32C6
         config ENV_GPIO_RANGE_MIN
             int

--- a/bsp/esp_bsp_devkit/idf_component.yml
+++ b/bsp/esp_bsp_devkit/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.0.0"
+version: "2.0.1"
 description: DevKit Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_devkit
 


### PR DESCRIPTION
**Description:**
- add support for the esp32c5 chip.
- modify files in Kconfig to add support for esp32c5 related pins