### PR TITLE
fix(esp_lvgl_port): Make sure LVGL is initialize at the end of lvgl_port_init() call

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+- Fixed a crash when esp_lvgl_port was initialized from high priority task https://github.com/espressif/esp-bsp/issues/455
+
 ## 2.4.3
 
 ### Fixes


### PR DESCRIPTION
Previously, we initialized LVGL in the new LVGL handling task. If lvgl_port_init() was called from high priority task, it could return with uninitialized LVGL.

Closes https://github.com/espressif/esp-bsp/issues/455
Closes https://github.com/espressif/esp-bsp/issues/475
