### PR TITLE
Fix(esp_lcd_gc9a01): Missing field initializers and wrong order under C++ (BSP-610)

### DIFF
--- a/components/lcd/esp_lcd_gc9a01/idf_component.yml
+++ b/components/lcd/esp_lcd_gc9a01/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: ESP LCD GC9A01
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_gc9a01
 dependencies:

--- a/components/lcd/esp_lcd_gc9a01/include/esp_lcd_gc9a01.h
+++ b/components/lcd/esp_lcd_gc9a01/include/esp_lcd_gc9a01.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,12 +66,19 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
  */
 #define GC9A01_PANEL_BUS_SPI_CONFIG(sclk, mosi, max_trans_sz)   \
     {                                                           \
-        .sclk_io_num = sclk,                                    \
         .mosi_io_num = mosi,                                    \
-        .miso_io_num = -1,                                      \
-        .quadhd_io_num = -1,                                    \
+        .miso_io_num = 0,                                       \
+        .sclk_io_num = sclk,                                    \
         .quadwp_io_num = -1,                                    \
+        .quadhd_io_num = -1,                                    \
+        .data4_io_num = 0,                                      \
+        .data5_io_num = 0,                                      \
+        .data6_io_num = 0,                                      \
+        .data7_io_num = 0,                                      \
         .max_transfer_sz = max_trans_sz,                        \
+        .flags = 0,                                             \
+        .isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO,               \
+        .intr_flags = 0                                         \
     }
 
 /**
@@ -94,6 +101,7 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
         .user_ctx = callback_ctx,                                   \
         .lcd_cmd_bits = 8,                                          \
         .lcd_param_bits = 8,                                        \
+        .flags = {}                                                 \
     }
 
 #ifdef __cplusplus

--- a/components/lcd/esp_lcd_gc9a01/include/esp_lcd_gc9a01.h
+++ b/components/lcd/esp_lcd_gc9a01/include/esp_lcd_gc9a01.h
@@ -67,14 +67,14 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
 #define GC9A01_PANEL_BUS_SPI_CONFIG(sclk, mosi, max_trans_sz)   \
     {                                                           \
         .mosi_io_num = mosi,                                    \
-        .miso_io_num = 0,                                       \
+        .miso_io_num = -1,                                      \
         .sclk_io_num = sclk,                                    \
         .quadwp_io_num = -1,                                    \
         .quadhd_io_num = -1,                                    \
-        .data4_io_num = 0,                                      \
-        .data5_io_num = 0,                                      \
-        .data6_io_num = 0,                                      \
-        .data7_io_num = 0,                                      \
+        .data4_io_num = -1,                                     \
+        .data5_io_num = -1,                                     \
+        .data6_io_num = -1,                                     \
+        .data7_io_num = -1,                                     \
         .max_transfer_sz = max_trans_sz,                        \
         .flags = 0,                                             \
         .isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO,               \


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description
GC9A01_PANEL_BUS_SPI_CONFIG and GC9A01_PANEL_IO_SPI_CONFIG macros were causing project to fail to compile in under C++23 (ESP-IDF 5.3.2). I've added initializers with default values for each member and fixed field order in BUS_SPI_CONFIG.