### PR TITLE
Fix(esp_lcd_touch_cst816s): Missing field initializers under C++ (BSP-609)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3~1"
+version: "1.0.4"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,15 +41,20 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
  *
  */
 #define ESP_LCD_TOUCH_IO_I2C_CST816S_CONFIG()             \
-    {                                                    \
+    {                                                     \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_CST816S_ADDRESS, \
-        .control_phase_bytes = 1,                        \
-        .dc_bit_offset = 0,                              \
-        .lcd_cmd_bits = 8,                              \
-        .flags =                                         \
-        {                                                \
-            .disable_control_phase = 1,                  \
-        }                                                \
+        .on_color_trans_done = 0,                         \
+        .user_ctx = 0,                                    \
+        .control_phase_bytes = 1,                         \
+        .dc_bit_offset = 0,                               \
+        .lcd_cmd_bits = 8,                                \
+        .lcd_param_bits = 0,                              \
+        .flags =                                          \
+        {                                                 \
+            .dc_low_on_data = 0,                          \
+            .disable_control_phase = 1,                   \
+        },                                                \
+        .scl_speed_hz = 0                                 \
     }
 
 #ifdef __cplusplus


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description
ESP_LCD_TOUCH_IO_I2C_CST816S_CONFIG macro was causing warning under C++. I've added initialization to all fields.