### PR TITLE
fix(esp32_s3_usb_otg): Renamed Kconfig SD mount option.

### DIFF
--- a/bsp/esp32_s3_usb_otg/Kconfig
+++ b/bsp/esp32_s3_usb_otg/Kconfig
@@ -39,7 +39,7 @@ menu "Board Support Package"
             help
                 The SDMMC host will format (FAT) the uSD card if it fails to mount the filesystem.
 
-        config BSP_uSD_MOUNT_POINT
+        config BSP_SD_MOUNT_POINT
             string "uSD card mount point"
             default "/sdcard"
             help

--- a/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg.c
+++ b/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg.c
@@ -141,12 +141,12 @@ esp_err_t bsp_sdcard_mount(void)
         .flags = 0,
     };
 
-    return esp_vfs_fat_sdmmc_mount(CONFIG_BSP_uSD_MOUNT_POINT, &host, &slot_config, &mount_config, &bsp_sdcard);
+    return esp_vfs_fat_sdmmc_mount(BSP_SD_MOUNT_POINT, &host, &slot_config, &mount_config, &bsp_sdcard);
 }
 
 esp_err_t bsp_sdcard_unmount(void)
 {
-    return esp_vfs_fat_sdcard_unmount(CONFIG_BSP_uSD_MOUNT_POINT, bsp_sdcard);
+    return esp_vfs_fat_sdcard_unmount(BSP_SD_MOUNT_POINT, bsp_sdcard);
 }
 
 esp_err_t bsp_button_init(void)

--- a/bsp/esp32_s3_usb_otg/idf_component.yml
+++ b/bsp/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.1"
+version: "1.6.2"
 description: Board Support Package (BSP) for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg
 

--- a/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
+++ b/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
@@ -123,7 +123,7 @@ typedef struct {
  * fclose(f);
  * \endcode
  **************************************************************************************************/
-#define BSP_MOUNT_POINT      CONFIG_BSP_SD_MOUNT_POINT
+#define BSP_SD_MOUNT_POINT      CONFIG_BSP_SD_MOUNT_POINT
 extern sdmmc_card_t *bsp_sdcard;
 
 /**


### PR DESCRIPTION
Closes #463 