### PR TITLE
fix(ci): Build i2c_example only for IDF >= 5.2

### DIFF
--- a/components/.build-test-rules.yml
+++ b/components/.build-test-rules.yml
@@ -4,7 +4,21 @@ components/esp_lvgl_port:
     - "components/esp_lvgl_port/**"
     - "components/lcd_touch/esp_lcd_touch_tt21100/**"
     - "components/lcd_touch/esp_lcd_touch_gt1151/**"
+
+components/esp_lvgl_port/examples/i2c_oled:
+  depends_filepatterns:
+    - "components/esp_lvgl_port/**"
     - "components/lcd/sh1107/**"
+  disable:
+    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+      reason: Requires I2C Driver-NG which was introduced in v5.2
+
+components/esp_lvgl_port/test_apps/simd:
+  depends_filepatterns:
+    - "components/esp_lvgl_port/**"
+  enable:
+    - if: IDF_TARGET in ["esp32", "esp32s3"]
+      reason: Supports only xtensa targets
 
 components/ds18b20:
   depends_filepatterns:

--- a/components/esp_lvgl_port/examples/i2c_oled/main/CMakeLists.txt
+++ b/components/esp_lvgl_port/examples/i2c_oled/main/CMakeLists.txt
@@ -1,2 +1,5 @@
-idf_component_register(SRCS "i2c_oled_example_main.c" "lvgl_demo_ui.c"
-                       INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS "i2c_oled_example_main.c" "lvgl_demo_ui.c"
+    INCLUDE_DIRS "."
+    REQUIRES driver
+)


### PR DESCRIPTION
Our CI was broken for some time and did not catch this issue.
Could close #481

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Build i2c_example only for IDF >= 5.2