### PR TITLE
Adding creation of the bus instance without which the code crashes (BSP-622)

### DIFF
--- a/components/ds18b20/README.md
+++ b/components/ds18b20/README.md
@@ -27,6 +27,7 @@ DS18B20 temperature sensor only uses a single wire to write and read data, the i
     esp_err_t search_result = ESP_OK;
 
     // create 1-wire device iterator, which is used for device search
+    ESP_ERROR_CHECK(onewire_new_bus_rmt(&bus_config, &rmt_config, &bus));
     ESP_ERROR_CHECK(onewire_new_device_iter(bus, &iter));
     ESP_LOGI(TAG, "Device iterator created, start searching...");
     do {


### PR DESCRIPTION
Simply a change to the README.md of the ds18b20.  The sample code crashed.  This fixes it.