### PR TITLE
fix(cst816s): Provide 100kHz default value for SCL

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5"
+version: "1.0.6"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
@@ -72,7 +72,7 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
             .dc_low_on_data = 0,                          \
             .disable_control_phase = 1,                   \
         },                                                \
-        .scl_speed_hz = 0                                 \
+        .scl_speed_hz = 100000                            \
     }
 #endif
 


### PR DESCRIPTION
Bug introduced in https://github.com/espressif/esp-bsp/pull/470
Closes https://github.com/espressif/esp-bsp/issues/485

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing
