### PR TITLE
Feat/esp32 s3 eye/spi dma

### DIFF
--- a/bsp/esp32_s3_eye/Kconfig
+++ b/bsp/esp32_s3_eye/Kconfig
@@ -88,7 +88,8 @@ menu "Board Support Package"
                 Maximum time for task sleep in ms.
         
         config BSP_DISPLAY_LVGL_BUFFER_IN_PSRAM
-            bool "Allocate LVGL buffer in PSRAM "
+            bool "Allocate LVGL buffer in PSRAM"
+            depends on SPI_DMA_SUPPORT_PSRAM
             default n
             help
                 LVGL buffer will be allocated in PSRAM instead of internal RAM with DMA.

--- a/bsp/esp32_s3_eye/esp32_s3_eye.c
+++ b/bsp/esp32_s3_eye/esp32_s3_eye.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -357,13 +357,12 @@ lv_display_t *bsp_display_start(void)
         .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
         .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
         .flags = {
-#if (CONFIG_BSP_DISPLAY_LVGL_BUFFER_IN_PSRAM && CONFIG_SPIRAM)
-            .buff_dma = false,
+#if CONFIG_BSP_DISPLAY_LVGL_BUFFER_IN_PSRAM
             .buff_spiram = true,
 #else
-            .buff_dma = true,
             .buff_spiram = false,
 #endif
+            .buff_dma = true,
         }
     };
     return bsp_display_start_with_config(&cfg);

--- a/bsp/esp32_s3_eye/idf_component.yml
+++ b/bsp/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.0.1"
+version: "4.0.2"
 description: Board Support Package (BSP) for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_eye
 

--- a/bsp/esp32_s3_eye/include/bsp/display.h
+++ b/bsp/esp32_s3_eye/include/bsp/display.h
@@ -24,7 +24,7 @@
 /* LCD display color format */
 #define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
 /* LCD display color bytes endianess */
-#define BSP_LCD_BIGENDIAN           (1)
+#define BSP_LCD_BIGENDIAN           (0)
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,7 @@
 
 #include "sdkconfig.h"
 #include "driver/gpio.h"
+#include "driver/i2c_master.h"
 #include "driver/sdmmc_host.h"
 #include "esp_codec_dev.h"
 #include "iot_button.h"
@@ -308,7 +309,12 @@ esp_err_t bsp_sdcard_unmount(void);
  *
  * If you want to use the display without LVGL, see bsp/display.h API and use BSP version with 'noglib' suffix.
  **************************************************************************************************/
+
+#if CONFIG_SPI_DMA_SUPPORT_PSRAM
+#define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
+#else
 #define BSP_LCD_PIXEL_CLOCK_HZ     (80 * 1000 * 1000)
+#endif
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)

--- a/components/esp_lvgl_port/CMakeLists.txt
+++ b/components/esp_lvgl_port/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 idf_component_register(
         INCLUDE_DIRS "include"
         PRIV_INCLUDE_DIRS "priv_include"
-        REQUIRES "esp_lcd")
+        REQUIRES "esp_lcd esp_mm")
 
 # Get LVGL version
 idf_build_get_property(build_components BUILD_COMPONENTS)
@@ -116,6 +116,7 @@ target_link_libraries(lvgl_port_lib PUBLIC
     )
 target_link_libraries(lvgl_port_lib PRIVATE
     idf::esp_timer
+    idf::esp_mm
     ${ADD_LIBS}
     )
 

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.3"
+version: "2.4.4"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.4"
+version: "2.4.5"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
1. Add esp32_s3_eye spi dma support. Currently this is not support in esp-idf. As soon as esp-idf supports it, it will take affect.