### PR TITLE
Fix I2C NG includes

### DIFF
--- a/bsp/esp-box-3/include/bsp/esp-box-3.h
+++ b/bsp/esp-box-3/include/bsp/esp-box-3.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,7 +16,6 @@
 #include "driver/i2s_std.h"
 #include "driver/i2c_master.h"
 #include "driver/sdmmc_host.h"
-#include "soc/usb_pins.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
@@ -63,8 +62,8 @@
 #define BSP_LCD_TOUCH_INT     (GPIO_NUM_3)
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 
 /* Buttons */
 #define BSP_BUTTON_CONFIG_IO  (GPIO_NUM_0)

--- a/bsp/esp-box-lite/include/bsp/esp-box-lite.h
+++ b/bsp/esp-box-lite/include/bsp/esp-box-lite.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,6 @@
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 #include "driver/i2c.h"
-#include "soc/usb_pins.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
@@ -63,8 +62,8 @@
 #define BSP_LCD_BACKLIGHT     (GPIO_NUM_45)
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 
 /* Buttons */
 #define BSP_BUTTON_CONFIG_IO  (GPIO_NUM_0)

--- a/bsp/esp-box/include/bsp/esp-box.h
+++ b/bsp/esp-box/include/bsp/esp-box.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,6 @@
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 #include "driver/i2c.h"
-#include "soc/usb_pins.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
 #include "esp_codec_dev.h"
@@ -65,8 +64,8 @@
 #define BSP_LCD_TOUCH_INT     (GPIO_NUM_3)
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 
 /* Buttons */
 #define BSP_BUTTON_CONFIG_IO  (GPIO_NUM_0)

--- a/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
+++ b/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
@@ -53,8 +53,8 @@
 #define BSP_I2S_CLK           (GPIO_NUM_NC)
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 
 /* Buttons */
 typedef enum {

--- a/bsp/esp32_s3_eye/CMakeLists.txt
+++ b/bsp/esp32_s3_eye/CMakeLists.txt
@@ -2,6 +2,6 @@ idf_component_register(
     SRCS "esp32_s3_eye.c" "esp32_s3_eye_idf5.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_gpio esp_driver_sdmmc spiffs
-    PRIV_REQUIRES fatfs esp_lcd esp_driver_i2c esp_driver_ledc esp_driver_spi
+    REQUIRES esp_driver_gpio esp_driver_sdmmc spiffs esp_driver_i2c
+    PRIV_REQUIRES fatfs esp_lcd esp_driver_ledc esp_driver_spi
 )

--- a/bsp/esp32_s3_eye/idf_component.yml
+++ b/bsp/esp32_s3_eye/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.0.1"
+version: "4.0.2"
 description: Board Support Package (BSP) for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_eye
 

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,7 @@
 #include "bsp/config.h"
 #include "bsp/display.h"
 #include "driver/i2s_std.h"
+#include "driver/i2c_master.h"
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #include "lvgl.h"

--- a/bsp/esp32_s3_korvo_2/CHANGELOG.md
+++ b/bsp/esp32_s3_korvo_2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v3.0.1
+
+* Added missing public driver/i2c_master.h include
+
 ## v3.0.0
 
 * Migrated to I2C Driver-NG (https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/5.2/peripherals.html#i2c)

--- a/bsp/esp32_s3_korvo_2/CMakeLists.txt
+++ b/bsp/esp32_s3_korvo_2/CMakeLists.txt
@@ -2,6 +2,6 @@ idf_component_register(
     SRCS "esp32_s3_korvo_2.c" "esp32_s3_korvo_2_idf5.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_adc
-    PRIV_REQUIRES spiffs fatfs esp_lcd esp_driver_i2c esp_driver_spi esp_driver_ledc
+    REQUIRES esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_i2c esp_adc
+    PRIV_REQUIRES spiffs fatfs esp_lcd esp_driver_spi esp_driver_ledc
 )

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.0"
+version: "3.0.1"
 description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 

--- a/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -12,7 +12,6 @@
 #include "driver/sdmmc_host.h"
 #include "driver/i2c_master.h"
 #include "esp_adc/adc_oneshot.h"
-#include "soc/usb_pins.h"
 #include "iot_button.h"
 #include "esp_io_expander.h"
 #include "esp_codec_dev.h"

--- a/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 #include "driver/gpio.h"
 #include "driver/i2s_std.h"
 #include "driver/sdmmc_host.h"
+#include "driver/i2c_master.h"
 #include "esp_adc/adc_oneshot.h"
 #include "soc/usb_pins.h"
 #include "iot_button.h"

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,6 @@
 #include "driver/i2s_std.h"
 #include "driver/i2c_master.h"
 #include "driver/gpio.h"
-#include "soc/usb_pins.h"
 #include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
 #include "esp_codec_dev.h"
@@ -91,8 +90,8 @@
 #define BSP_LCD_SUB_BOARD_2_SPI_SDO     (IO_EXPANDER_PIN_NUM_3)
 
 /* USB */
-#define BSP_USB_POS             (USBPHY_DP_NUM)
-#define BSP_USB_NEG             (USBPHY_DM_NUM)
+#define BSP_USB_POS             ((GPIO_NUM_20))
+#define BSP_USB_NEG             ((GPIO_NUM_19))
 
 /* Button */
 

--- a/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
+++ b/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,6 @@
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 #include "driver/sdmmc_host.h"
-#include "soc/usb_pins.h"
 #include "iot_button.h"
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
@@ -81,8 +80,8 @@ typedef enum {
 } bsp_button_t;
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 #define BSP_USB_MODE_SEL      (GPIO_NUM_18) // Select Host (high level) or Device (low level, default) mode
 #define BSP_USB_HOST_VOLTAGE  (GPIO_NUM_1)  // Voltage at this pin = (V_BUS / 3.7), ADC1 channel 0
 #define BSP_USB_HOST_VOLTAGE_DIV (3.7f)

--- a/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
+++ b/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,6 @@
 #include "driver/gpio.h"
 #include "driver/i2s_std.h"
 #include "driver/sdmmc_host.h"
-#include "soc/usb_pins.h"
 #include "esp_codec_dev.h"
 #include "bsp/config.h"
 #include "bsp/display.h"
@@ -86,8 +85,8 @@
 #define BSP_SD_CS             (GPIO_NUM_4)
 
 /* USB */
-#define BSP_USB_POS           USBPHY_DP_NUM
-#define BSP_USB_NEG           USBPHY_DM_NUM
+#define BSP_USB_POS           (GPIO_NUM_20)
+#define BSP_USB_NEG           (GPIO_NUM_19)
 
 
 #ifdef __cplusplus

--- a/examples/display_camera/main/display_camera.c
+++ b/examples/display_camera/main/display_camera.c
@@ -55,9 +55,9 @@ void app_main(void)
     while (1) {
         pic = esp_camera_fb_get();
         if (pic) {
-            esp_camera_fb_return(pic);
             bsp_display_lock(0);
             memcpy(cam_buff, pic->buf, cam_buff_size);
+            esp_camera_fb_return(pic);
             if (BSP_LCD_BIGENDIAN) {
                 /* Swap bytes in RGB565 */
                 lv_draw_sw_rgb565_swap(cam_buff, cam_buff_size);


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing

# Change description
* For BSP that exposed public function `i2c_master_bus_handle_t bsp_i2c_get_handle(void);` (korvo-2 and s3-eye), the `esp_driver_i2c` component must be listed in public dependencies
* On CoreS3 the camera is now enabled during `bsp_i2c_init()` call. Previously it was enabled during `bsp_display_new()`, but this caused problems if the users wanted to initialize the camera before LCD initialization