### PR TITLE
Fix flickering when GT911 has no data to read (BSP-636)

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -248,15 +248,12 @@ static esp_err_t esp_lcd_touch_gt911_read_data(esp_lcd_touch_handle_t tp)
         portENTER_CRITICAL(&tp->data.lock);
         /* Invalidate */
         tp->data.points = 0;
-        portEXIT_CRITICAL(&tp->data.lock);
-        
 #if (CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS > 0)
-        portENTER_CRITICAL(&tp->data.lock);
         for (i = 0; i < CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS; i++) {
             tp->data.button[i].status = 0;
         }
-        portEXIT_CRITICAL(&tp->data.lock);
 #endif
+        portEXIT_CRITICAL(&tp->data.lock);
         /* Count of touched points */
         touch_cnt = buf[0] & 0x0f;
         if (touch_cnt > 5 || touch_cnt == 0) {

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -245,6 +245,11 @@ static esp_err_t esp_lcd_touch_gt911_read_data(esp_lcd_touch_handle_t tp)
         portEXIT_CRITICAL(&tp->data.lock);
 #endif
     } else if ((buf[0] & 0x80) == 0x80) {
+        portENTER_CRITICAL(&tp->data.lock);
+        /* Invalidate */
+        tp->data.points = 0;
+        portEXIT_CRITICAL(&tp->data.lock);
+        
 #if (CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS > 0)
         portENTER_CRITICAL(&tp->data.lock);
         for (i = 0; i < CONFIG_ESP_LCD_TOUCH_MAX_BUTTONS; i++) {
@@ -307,9 +312,6 @@ static bool esp_lcd_touch_gt911_get_xy(esp_lcd_touch_handle_t tp, uint16_t *x, u
             strength[i] = tp->data.coords[i].strength;
         }
     }
-
-    /* Invalidate */
-    tp->data.points = 0;
 
     portEXIT_CRITICAL(&tp->data.lock);
 


### PR DESCRIPTION
Points should only get cleared on successfully read operations.

Before this patch, the touch driver reported no touch, when in fact there was touch but the GT911 was not ready to report data.

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
_Please describe your change here_