### PR TITLE
fix(lcd_touch): avoid assigning a value to handle after creation failure

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/esp_lcd_touch_ft5x06.c
@@ -153,6 +153,8 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
     ret = touch_ft5x06_init(esp_lcd_touch_ft5x06);
     ESP_GOTO_ON_ERROR(ret, err, TAG, "FT5x06 init failed");
 
+    *out_touch = esp_lcd_touch_ft5x06;
+
 err:
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Error (0x%x)! Touch controller FT5x06 initialization failed!", ret);
@@ -160,8 +162,6 @@ err:
             esp_lcd_touch_ft5x06_del(esp_lcd_touch_ft5x06);
         }
     }
-
-    *out_touch = esp_lcd_touch_ft5x06;
 
     return ret;
 }

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6~1"
+version: "1.0.7"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
+++ b/components/lcd_touch/esp_lcd_touch_gt911/esp_lcd_touch_gt911.c
@@ -158,6 +158,8 @@ esp_err_t esp_lcd_touch_new_i2c_gt911(const esp_lcd_panel_io_handle_t io, const 
     ret = touch_gt911_read_cfg(esp_lcd_touch_gt911);
     ESP_GOTO_ON_ERROR(ret, err, TAG, "GT911 init failed");
 
+    *out_touch = esp_lcd_touch_gt911;
+
 err:
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Error (0x%x)! Touch controller GT911 initialization failed!", ret);
@@ -165,8 +167,6 @@ err:
             esp_lcd_touch_gt911_del(esp_lcd_touch_gt911);
         }
     }
-
-    *out_touch = esp_lcd_touch_gt911;
 
     return ret;
 }

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1~2"
+version: "1.1.2"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/esp_lcd_touch_stmpe610.c
@@ -143,6 +143,8 @@ esp_err_t esp_lcd_touch_new_spi_stmpe610(const esp_lcd_panel_io_handle_t io, con
     ret = touch_stmpe610_read_cfg(esp_lcd_touch_stmpe610);
     ESP_GOTO_ON_ERROR(ret, err, TAG, "STMPE610 init failed");
 
+    *out_touch = esp_lcd_touch_stmpe610;
+
 err:
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Error (0x%x)! Touch controller STMPE610 initialization failed!", ret);
@@ -150,8 +152,6 @@ err:
             esp_lcd_touch_stmpe610_del(esp_lcd_touch_stmpe610);
         }
     }
-
-    *out_touch = esp_lcd_touch_stmpe610;
 
     return ret;
 }

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6"
+version: "1.0.7"
 description: ESP LCD Touch STMPE610 - touch controller STMPE610
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lcd_touch_stmpe610
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/esp_lcd_touch_tt21100.c
@@ -108,6 +108,8 @@ esp_err_t esp_lcd_touch_new_i2c_tt21100(const esp_lcd_panel_io_handle_t io, cons
     ret = esp_lcd_touch_tt21100_read_data(esp_lcd_touch_tt21100);
     ESP_GOTO_ON_ERROR(ret, err, TAG, "TT21100 init failed");
 
+    *out_touch = esp_lcd_touch_tt21100;
+
 err:
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Error (0x%x)! Touch controller TT21100 initialization failed!", ret);
@@ -115,8 +117,6 @@ err:
             esp_lcd_touch_tt21100_del(esp_lcd_touch_tt21100);
         }
     }
-
-    *out_touch = esp_lcd_touch_tt21100;
 
     return ret;
 }

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~1"
+version: "1.1.1"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description

Taking the `esp_lcd_touch_ft5x06` component as an example, when `esp_lcd_touch_new_i2c_ft5x06()` fails, `out_touch` is still assigned a freed memory address. 

This PR fixes the issue by assigning the value before handling the `err:` label.