### PR TITLE
feat(ds18b20): Add single device mode (no enumeration 1-Wire bus) (BSP-637)

### DIFF
--- a/components/ds18b20/CHANGELOG.md
+++ b/components/ds18b20/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Add single device function (ds18b20_new_single_device) to create a new DS18B20 device instance without enumerating all devices on the bus.
+
 ## 0.1.1
 
 - Fix the issue that sign-bit is not extended properly when doing temperature value conversion.

--- a/components/ds18b20/idf_component.yml
+++ b/components/ds18b20/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.1.2"
 description: DS18B20 device driver
 url: https://github.com/espressif/esp-bsp/tree/master/components/ds18b20
 dependencies:

--- a/components/ds18b20/include/ds18b20.h
+++ b/components/ds18b20/include/ds18b20.h
@@ -43,6 +43,21 @@ typedef struct {
 esp_err_t ds18b20_new_device(onewire_device_t *device, const ds18b20_config_t *config, ds18b20_device_handle_t *ret_ds18b20);
 
 /**
+ * @brief Create a new singe device bus DS18B20 device based on a 1-Wire bus (not enumerated)
+ * 		  this function assumes that the device is a DS18B20 device and there is only one device on the bus
+ * 
+ * @param[in] bus 1-Wire bus handle
+ * @param[in] config DS18B20 configuration
+ * @param[out] ret_ds18b20 Returned DS18B20 device handle
+ * @return esp_err_t 
+ * 		- ESP_OK: Create DS18B20 device successfully
+ * 		- ESP_ERR_INVALID_ARG: Create DS18B20 device failed due to invalid argument
+ * 		- ESP_ERR_NO_MEM: Create DS18B20 device failed due to out of memory
+ * 		- ESP_FAIL: Create DS18B20 device failed due to other reasons
+ */
+esp_err_t ds18b20_new_single_device(onewire_bus_handle_t bus, const ds18b20_config_t *config, ds18b20_device_handle_t *ret_ds18b20);
+
+/**
  * @brief Delete DS18B20 device
  *
  * @param ds18b20 DS18B20 device handle returned by `ds18b20_new_device`

--- a/components/ds18b20/include/ds18b20.h
+++ b/components/ds18b20/include/ds18b20.h
@@ -44,16 +44,16 @@ esp_err_t ds18b20_new_device(onewire_device_t *device, const ds18b20_config_t *c
 
 /**
  * @brief Create a new singe device bus DS18B20 device based on a 1-Wire bus (not enumerated)
- * 		  this function assumes that the device is a DS18B20 device and there is only one device on the bus
- * 
+ *        this function assumes that the device is a DS18B20 device and there is only one device on the bus
+ *
  * @param[in] bus 1-Wire bus handle
  * @param[in] config DS18B20 configuration
  * @param[out] ret_ds18b20 Returned DS18B20 device handle
- * @return esp_err_t 
- * 		- ESP_OK: Create DS18B20 device successfully
- * 		- ESP_ERR_INVALID_ARG: Create DS18B20 device failed due to invalid argument
- * 		- ESP_ERR_NO_MEM: Create DS18B20 device failed due to out of memory
- * 		- ESP_FAIL: Create DS18B20 device failed due to other reasons
+ * @return esp_err_t
+ *      - ESP_OK: Create DS18B20 device successfully
+ *      - ESP_ERR_INVALID_ARG: Create DS18B20 device failed due to invalid argument
+ *      - ESP_ERR_NO_MEM: Create DS18B20 device failed due to out of memory
+ *      - ESP_FAIL: Create DS18B20 device failed due to other reasons
  */
 esp_err_t ds18b20_new_single_device(onewire_bus_handle_t bus, const ds18b20_config_t *config, ds18b20_device_handle_t *ret_ds18b20);
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description
Add single ds18b20 device functionality with SKIP_ROM command, this way it safes the hassle of enumaration the bus when only 1 device is on the bus