### PR TITLE
feature(ili9341): Add alternative driver configuration for LCD ILI9341

### DIFF
--- a/components/lcd/esp_lcd_ili9341/README.md
+++ b/components/lcd/esp_lcd_ili9341/README.md
@@ -4,19 +4,22 @@
 
 Implementation of the ILI9341 LCD controller with esp_lcd component.
 
-| LCD controller | Communication interface | Component name | Link to datasheet |
-| :------------: | :---------------------: | :------------: | :---------------: |
-| ILI9341        | SPI                     | esp_lcd_ili9341     | [Specification](https://cdn-shop.adafruit.com/datasheets/ILI9341.pdf) |
+| LCD controller | Communication interface | Component name  | Link to datasheet                                                     |
+|:--------------:|:-----------------------:|:---------------:|:---------------------------------------------------------------------:|
+| ILI9341        | SPI                     | esp_lcd_ili9341 | [Specification](https://cdn-shop.adafruit.com/datasheets/ILI9341.pdf) |
 
 ## Add to project
 
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
 You can add them to your project via `idf.py add-dependancy`, e.g.
+
 ```
     idf.py add-dependency esp_lcd_ili9341==1.0.0
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
+
+**NOTE:** if your display is not initilized properly, try using config **ALTERNATIVE_DRIVER**
 
 ## Example use
 

--- a/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
+++ b/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
@@ -16,6 +16,7 @@
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "sdkconfig.h"
 
 #include "esp_lcd_ili9341.h"
 
@@ -171,6 +172,45 @@ static esp_err_t panel_ili9341_reset(esp_lcd_panel_t *panel)
     return ESP_OK;
 }
 
+#ifdef CONFIG_ALTERNATIVE_DRIVER
+static const ili9341_lcd_init_cmd_t vendor_specific_init_default[] = {
+    //  {cmd, { data }, data_size, delay_ms}
+    /* Power control B */
+    {0xCF, (uint8_t []){0x00, 0xC1, 0x30}, 3, 0},
+    /* Power on sequence control */
+    {0xED, (uint8_t []){0x64, 0x03, 0x12, 0x81}, 4, 0},
+    /* Driver timing control A */
+    {0xE8, (uint8_t []){0x85, 0x00, 0x78}, 3, 0},
+    /* Power control A */
+    {0xCB, (uint8_t []){0x39, 0x2C, 0x00, 0x34, 0x02}, 5, 0},
+    /* Pump ratio control */
+    {0xF7, (uint8_t []){0x20}, 1, 0},
+    /* Driver timing control */
+    {0xEA, (uint8_t []){0x00, 0x00}, 2, 0},
+    /* Power control 1 */
+    {0xC0, (uint8_t []){0x10}, 1, 0},
+    /* Power control 2 */
+    {0xC1, (uint8_t []){0x00}, 1, 0},
+    /* VCOM control 1 */
+    {0xC5, (uint8_t []){0x30, 0x30}, 2, 0},
+    /* VCOM control 2 */
+    {0xC7, (uint8_t []){0xB7}, 1, 0},
+    /* Frame rate control */
+    {0xB1, (uint8_t []){0x00, 0x1A}, 2, 0},
+    /* Enable 3G */
+    {0xF2, (uint8_t []){0x00}, 1, 0},
+    /* Gamma set */
+    {0x26, (uint8_t []){0x01}, 1, 0},
+    /* Positive gamma correction */
+    {0xE0, (uint8_t []){0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, 0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00}, 15, 0}, // Adjusted for ILI9341_2_DRIVER
+    /* Negative gamma correction */
+    {0xE1, (uint8_t []){0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, 0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F}, 15, 0}, // Adjusted for ILI9341_2_DRIVER
+    /* Entry mode set */
+    {0xB7, (uint8_t []){0x07}, 1, 0},
+    /* Display function control */
+    {0xB6, (uint8_t []){0x08, 0x82, 0x27}, 3, 0},
+    };
+#else
 static const ili9341_lcd_init_cmd_t vendor_specific_init_default[] = {
 //  {cmd, { data }, data_size, delay_ms}
     /* Power contorl B, power control = 0, DC_ENA = 1 */
@@ -218,6 +258,7 @@ static const ili9341_lcd_init_cmd_t vendor_specific_init_default[] = {
     /* Display function control */
     {0xB6, (uint8_t []){0x08, 0x82, 0x27}, 3, 0},
 };
+#endif
 
 static esp_err_t panel_ili9341_init(esp_lcd_panel_t *panel)
 {

--- a/components/lcd/esp_lcd_ili9341/idf_component.yml
+++ b/components/lcd/esp_lcd_ili9341/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: ESP LCD ILI9341
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_ili9341
 dependencies:


### PR DESCRIPTION
This is an alternative driver option that works with some LCD displays. The same as in TFT_eSPI library here: https://github.com/Bodmer/TFT_eSPI/blob/5793878d24161c1ed23ccb136f8564f332506d53/TFT_Drivers/ILI9341_Init.h#L127