### PR TITLE
fix(lvgl_port): Fixed memory leak in LVGL8 in display removing

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - Fixed buffer size by selected color format
+- Fixed memory leak in LVGL8 in display removing https://github.com/espressif/esp-bsp/issues/462
 
 ## 2.4.4
 

--- a/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_disp.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -177,6 +177,11 @@ esp_err_t lvgl_port_remove_disp(lv_disp_t *disp)
     lv_disp_remove(disp);
 
     if (disp_drv) {
+        if (disp_drv->draw_ctx) {
+            disp_drv->draw_ctx_deinit(disp_drv, disp_drv->draw_ctx);
+            lv_mem_free(disp_drv->draw_ctx);
+            disp_drv->draw_ctx = NULL;
+        }
         if (disp_drv->draw_buf && disp_drv->draw_buf->buf1) {
             free(disp_drv->draw_buf->buf1);
             disp_drv->draw_buf->buf1 = NULL;


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
- Fixed memory leak in LVGL8 in display removing
Closes #462 