### PR TITLE
bsp(esp-box-3): Release latest fix.

### DIFF
--- a/bsp/esp-box-3/idf_component.yml
+++ b/bsp/esp-box-3/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.0.0"
+version: "2.0.1"
 description: Board Support Package (BSP) for ESP32-S3-BOX-3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box-3
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- BSP for ESP-BOX-3 is not updated in component manager (missing button v4 fix)