### PR TITLE
ci: Update runners image to ubuntu-24.04

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-docu:
     name: Build Doxygen documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: mattnotmitt/doxygen-action@v1.9.5

--- a/.github/workflows/squareline.yml
+++ b/.github/workflows/squareline.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create-squareline-packages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Generate the packages
@@ -23,7 +23,7 @@ jobs:
           path: SquareLine/out_dir/espressif/
 
   update-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ create-squareline-packages ]
     steps:
       - name: Download artifacts


### PR DESCRIPTION
Previously used ubuntu-20.04 will be deprecated by 1.4.2025.

https://github.com/actions/runner-images/issues/11101