### PR TITLE
feat(bsp): New SD card API (proposal) (BSP-189)

### DIFF
--- a/bsp/esp32_p4_function_ev_board/CMakeLists.txt
+++ b/bsp/esp32_p4_function_ev_board/CMakeLists.txt
@@ -3,6 +3,6 @@ idf_component_register(
     SRCS "esp32_p4_function_ev_board.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES driver vfs fatfs
+    PRIV_REQUIRES esp_lcd usb spiffs
 )

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.2.3"
+version: "5.0.0"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 

--- a/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
+++ b/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
@@ -15,6 +15,8 @@
 #include "driver/gpio.h"
 #include "driver/i2c_master.h"
 #include "driver/sdmmc_host.h"
+#include "driver/sdspi_host.h"
+#include "esp_vfs_fat.h"
 #include "driver/i2s_std.h"
 #include "bsp/config.h"
 #include "bsp/display.h"
@@ -67,13 +69,19 @@
 #define BSP_LCD_TOUCH_INT     (GPIO_NUM_NC)
 #endif
 
-/* uSD card */
+/* uSD card MMC */
 #define BSP_SD_D0             (GPIO_NUM_39)
 #define BSP_SD_D1             (GPIO_NUM_40)
 #define BSP_SD_D2             (GPIO_NUM_41)
 #define BSP_SD_D3             (GPIO_NUM_42)
 #define BSP_SD_CMD            (GPIO_NUM_44)
 #define BSP_SD_CLK            (GPIO_NUM_43)
+
+/* uSD card SPI */
+#define BSP_SD_SPI_MISO       (GPIO_NUM_39)
+#define BSP_SD_SPI_CS         (GPIO_NUM_42)
+#define BSP_SD_SPI_MOSI       (GPIO_NUM_44)
+#define BSP_SD_SPI_CLK        (GPIO_NUM_43)
 
 #ifdef __cplusplus
 extern "C" {
@@ -180,6 +188,7 @@ esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void);
  * \endcode
  **************************************************************************************************/
 #define BSP_SPIFFS_MOUNT_POINT      CONFIG_BSP_SPIFFS_MOUNT_POINT
+#define BSP_SDSPI_HOST              (SDSPI_DEFAULT_HOST)
 
 /**
  * @brief Mount SPIFFS to virtual file system
@@ -218,7 +227,15 @@ esp_err_t bsp_spiffs_unmount(void);
  * \endcode
  **************************************************************************************************/
 #define BSP_SD_MOUNT_POINT      CONFIG_BSP_SD_MOUNT_POINT
-extern sdmmc_card_t *bsp_sdcard;
+
+typedef struct {
+    const esp_vfs_fat_sdmmc_mount_config_t *mount;
+    sdmmc_host_t *host;
+    union {
+        const sdmmc_slot_config_t   *sdmmc;
+        const sdspi_device_config_t *sdspi;
+    } slot;
+} bsp_sdcard_cfg_t;
 
 /**
  * @brief Mount microSD card to virtual file system
@@ -244,6 +261,73 @@ esp_err_t bsp_sdcard_mount(void);
  *      - other error codes from wear levelling library, SPI flash driver, or FATFS drivers
  */
 esp_err_t bsp_sdcard_unmount(void);
+
+/**
+ * @brief Get SD card handle
+ *
+ * @return SD card handle
+ */
+sdmmc_card_t *bsp_sdcard_get_handle(void);
+
+/**
+ * @brief Get SD card MMC host config
+ *
+ * @param slot SD card slot
+ * @param config Structure which will be filled
+ */
+void bsp_sdcard_get_sdmmc_host(const int slot, sdmmc_host_t *config);
+
+/**
+ * @brief Get SD card SPI host config
+ *
+ * @param slot SD card slot
+ * @param config Structure which will be filled
+ */
+void bsp_sdcard_get_sdspi_host(const int slot, sdmmc_host_t *config);
+
+/**
+ * @brief Get SD card MMC slot config
+ *
+ * @param slot SD card slot
+ * @param config Structure which will be filled
+ */
+void bsp_sdcard_sdmmc_get_slot(const int slot, sdmmc_slot_config_t *config);
+
+/**
+ * @brief Get SD card SPI slot config
+ *
+ * @param spi_host SPI host ID
+ * @param config Structure which will be filled
+ */
+void bsp_sdcard_sdspi_get_slot(const spi_host_device_t spi_host, sdspi_device_config_t *config);
+
+/**
+ * @brief Mount microSD card to virtual file system (MMC mode)
+ *
+ * @param cfg SD card configuration
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_sdmmc_mount was already called
+ *      - ESP_ERR_NO_MEM if memory cannot be allocated
+ *      - ESP_FAIL if partition cannot be mounted
+ *      - other error codes from SDMMC or SPI drivers, SDMMC protocol, or FATFS drivers
+ */
+esp_err_t bsp_sdcard_sdmmc_mount(bsp_sdcard_cfg_t *cfg);
+
+/**
+ * @brief Mount microSD card to virtual file system (SPI mode)
+ *
+ * @param cfg SD card configuration
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_sdmmc_mount was already called
+ *      - ESP_ERR_NO_MEM if memory cannot be allocated
+ *      - ESP_FAIL if partition cannot be mounted
+ *      - other error codes from SDMMC or SPI drivers, SDMMC protocol, or FATFS drivers
+ */
+esp_err_t bsp_sdcard_sdspi_mount(bsp_sdcard_cfg_t *cfg);
 
 /**************************************************************************************************
  *


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- This is the proposal of the new API for SD card. There can be used MMC mode or SPI.
- Initialization is same and there is not breaking change.
- Only one breaking change: 
- - Removed `extern sdmmc_card_t *bsp_card;` --> New function `bsp_sdcard_get_handle()`

Closes #149 