### PR TITLE
ci(runner): Fix benchmark results releases

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -224,7 +224,7 @@ jobs:
           fi
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: github.ref_name == 'master' && env.files_exist == 'true'
+        if: github.ref_name == 'master' && env.benchmark_files_exist == 'true'
         with:
           name: ${{ env.BENCHMARK_RESULT_NAME }}
           path: |
@@ -232,7 +232,7 @@ jobs:
             benchmark_*.json
       - name: Update benchmark release
         uses: pyTooling/Actions/releaser@r0
-        if: github.ref_name == 'master' && env.files_exist == 'true'
+        if: github.ref_name == 'master' && env.benchmark_files_exist == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
- I found my issue in CI - new benchmarks was not saved into releases

Reverted (I am not sure with this change):
- Changed `on pull_request` to `on pull_request_target` (https://github.com/thollander/actions-comment-pull-request?tab=readme-ov-file#permissions)