### PR TITLE
fix(korvo_2): Fix I2C master transmission issue by adding glitch filtering (BSP-663)

### DIFF
--- a/bsp/esp32_s3_korvo_2/CHANGELOG.md
+++ b/bsp/esp32_s3_korvo_2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## V3.0.2
+
+* Fix I2C master transmission issue by adding glitch filtering
+
 ## v3.0.1
 
 * Added missing public driver/i2c_master.h include

--- a/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -120,6 +120,7 @@ esp_err_t bsp_i2c_init(void)
         .sda_io_num = BSP_I2C_SDA,
         .scl_io_num = BSP_I2C_SCL,
         .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
         .flags.enable_internal_pullup = true,
     };
     BSP_ERROR_CHECK_RETURN_ERR(i2c_new_master_bus(&i2c_config, &i2c_handle));

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.1"
+version: "3.0.2"
 description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 


### PR DESCRIPTION
# Change description

I found that when using the esp32_s3_korvo_2 v3.0.1 BSP component, the I2C bus sometimes hangs (I2C master transmission gets stuck, triggering the task watchdog).

This issue can be reproduced using esp-bsp/examples/audio with IDF release/v5.4 or master.

```log
E (5794) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (5794) task_wdt:  - IDLE0 (CPU 0)
E (5794) task_wdt: Tasks currently running:
E (5794) task_wdt: CPU 0: audio_task
E (5794) task_wdt: CPU 1: IDLE1
E (5794) task_wdt: Print CPU 0 (current core) backtrace


Backtrace: 0x4201E1BA:0x3FC968B0 0x4201E5D0:0x3FC968D0 0x403777E1:0x3FC96900 0x4202DD7A:0x3FCEC6E0 0x4202DF88:0x3FCEC710 0x4202E06A:0x3FCEC750 0x4202EC3A:0x3FCEC780 0x4202ED12:0x3FCEC830 0x4200C0C9:0x3FCEC870 0x4200C122:0x3FCEC8A0 0x4202C779:0x3FCEC8C0 0x4200D3A2:0x3FCEC8F0 0x4200D629:0x3FCEC920 0x4200B4F5:0x3FCEC950 0x4200AECB:0x3FCEC9C0 0x4037C129:0x3FCECA70
--- 0x4201e1ba: task_wdt_timeout_handling at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_system/task_wdt/task_wdt.c:430
--- 0x4201e5d0: task_wdt_isr at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_system/task_wdt/task_wdt.c:503
--- 0x403777e1: _xt_lowint1 at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/xtensa/xtensa_vectors.S:1240
--- 0x4202dd7a: i2c_ll_is_bus_busy at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/hal/esp32s3/include/hal/i2c_ll.h:577
---  (inlined by) s_i2c_send_commands at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_driver_i2c/i2c_master.c:526
--- 0x4202df88: s_i2c_transaction_start at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_driver_i2c/i2c_master.c:631
--- 0x4202e06a: s_i2c_synchronous_transaction at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_driver_i2c/i2c_master.c:924
--- 0x4202ec3a: i2c_master_multi_buffer_transmit at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_driver_i2c/i2c_master.c:1193
--- 0x4202ed12: i2c_master_transmit at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/esp_driver_i2c/i2c_master.c:1208
--- 0x4200c0c9: _i2c_master_write_reg at /home/user/esp_adf_master/esp-bsp/examples/audio/managed_components/espressif__esp_codec_dev/platform/audio_codec_ctrl_i2c.c:105
--- 0x4200c122: _i2c_ctrl_write_reg at /home/user/esp_adf_master/esp-bsp/examples/audio/managed_components/espressif__esp_codec_dev/platform/audio_codec_ctrl_i2c.c:165
--- 0x4202c779: es8311_write_reg at /home/user/esp_adf_master/esp-bsp/examples/audio/managed_components/espressif__esp_codec_dev/device/es8311/es8311.c:159
--- 0x4200d3a2: es8311_open at /home/user/esp_adf_master/esp-bsp/examples/audio/managed_components/espressif__esp_codec_dev/device/es8311/es8311.c:496
--- 0x4200d629: es8311_codec_new at /home/user/esp_adf_master/esp-bsp/examples/audio/managed_components/espressif__esp_codec_dev/device/es8311/es8311.c:682
--- 0x4200b4f5: bsp_audio_codec_speaker_init at /home/user/esp_adf_master/esp-bsp/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c:223
--- 0x4200aecb: audio_task at /home/user/esp_adf_master/esp-bsp/examples/audio/main/bsp_audio_example.c:52
--- 0x4037c129: vPortTaskWrapper at /home/user/esp_adf_master/esp-adf-internal/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:139
```

As a workaround, I discovered that configuring `glitch_ignore_cnt` in the I2C initialization structure helps filter out glitches and prevent the issue.