### PR TITLE
feat(ci): Update pre-commit actions due to deprecation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5.2.0
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description

This MR updates actions in `pre-commit.yml` to unlock CI

pre-commit CI fail discovered in #559 
Failing CI Job [here](https://github.com/espressif/esp-bsp/actions/runs/14337518945/job/40188307139?pr=559#step:4:52)

The `pre-commit.yml` updated in accordance with `pre-commit.yml` from [esp-usb](https://github.com/espressif/esp-usb/blob/master/.github/workflows/pre-commit.yml)