### PR TITLE
feat(esp_lvgl_port): Add LVGL task stack capabilities

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Features
+- Added option to place LVGL task stack to external RAM
+
 ## 2.6.0
 
 ### Features

--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "esp_err.h"
+#include "esp_heap_caps.h"
 #include "lvgl.h"
 #include "esp_lvgl_port_disp.h"
 #include "esp_lvgl_port_touch.h"
@@ -48,24 +49,26 @@ typedef struct {
  * @brief Init configuration structure
  */
 typedef struct {
-    int task_priority;      /*!< LVGL task priority */
-    int task_stack;         /*!< LVGL task stack size */
-    int task_affinity;      /*!< LVGL task pinned to core (-1 is no affinity) */
-    int task_max_sleep_ms;  /*!< Maximum sleep in LVGL task */
-    int timer_period_ms;    /*!< LVGL timer tick period in ms */
+    int task_priority;        /*!< LVGL task priority */
+    int task_stack;           /*!< LVGL task stack size */
+    int task_affinity;        /*!< LVGL task pinned to core (-1 is no affinity) */
+    int task_max_sleep_ms;    /*!< Maximum sleep in LVGL task */
+    unsigned task_stack_caps; /*!< LVGL task stack memory capabilities (see esp_heap_caps.h) */
+    int timer_period_ms;      /*!< LVGL timer tick period in ms */
 } lvgl_port_cfg_t;
 
 /**
  * @brief LVGL port configuration structure
  *
  */
-#define ESP_LVGL_PORT_INIT_CONFIG() \
-    {                               \
-        .task_priority = 4,       \
-        .task_stack = 7168,       \
-        .task_affinity = -1,      \
-        .task_max_sleep_ms = 500, \
-        .timer_period_ms = 5,     \
+#define ESP_LVGL_PORT_INIT_CONFIG()                \
+    {                                              \
+        .task_priority = 4,                        \
+        .task_stack = 7168,                        \
+        .task_affinity = -1,                       \
+        .task_max_sleep_ms = 500,                  \
+        .task_stack_caps = MALLOC_CAP_DEFAULT,     \
+        .timer_period_ms = 5,                      \
     }
 
 /**

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port.c
@@ -15,6 +15,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include "freertos/event_groups.h"
+#include "freertos/idf_additions.h"
 #include "esp_lvgl_port.h"
 #include "esp_lvgl_port_priv.h"
 #include "lvgl.h"
@@ -84,10 +85,11 @@ esp_err_t lvgl_port_init(const lvgl_port_cfg_t *cfg)
     ESP_GOTO_ON_FALSE(lvgl_port_ctx.lvgl_events, ESP_ERR_NO_MEM, err, TAG, "Create LVGL Event Group fail!");
 
     BaseType_t res;
+    const uint32_t caps = cfg->task_stack_caps ? cfg->task_stack_caps : MALLOC_CAP_DEFAULT; // caps cannot be zero
     if (cfg->task_affinity < 0) {
-        res = xTaskCreate(lvgl_port_task, "taskLVGL", cfg->task_stack, xTaskGetCurrentTaskHandle(), cfg->task_priority, &lvgl_port_ctx.lvgl_task);
+        res = xTaskCreateWithCaps(lvgl_port_task, "taskLVGL", cfg->task_stack, xTaskGetCurrentTaskHandle(), cfg->task_priority, &lvgl_port_ctx.lvgl_task, caps);
     } else {
-        res = xTaskCreatePinnedToCore(lvgl_port_task, "taskLVGL", cfg->task_stack, xTaskGetCurrentTaskHandle(), cfg->task_priority, &lvgl_port_ctx.lvgl_task, cfg->task_affinity);
+        res = xTaskCreatePinnedToCoreWithCaps(lvgl_port_task, "taskLVGL", cfg->task_stack, xTaskGetCurrentTaskHandle(), cfg->task_priority, &lvgl_port_ctx.lvgl_task, cfg->task_affinity, caps);
     }
     ESP_GOTO_ON_FALSE(res == pdPASS, ESP_FAIL, err, TAG, "Create LVGL task fail!");
 


### PR DESCRIPTION
Closes https://github.com/espressif/esp-bsp/issues/567

# Change description
Add option to pass memory capabilities to LVGL task. This gives users the flexibility to place LVGL's task stack to external RAM