### PR TITLE
 refactor(bh1750): migrate to esp_i2c_driver, add example and update test app (BSP-681)

### DIFF
--- a/components/bh1750/CMakeLists.txt
+++ b/components/bh1750/CMakeLists.txt
@@ -1,5 +1,3 @@
-idf_component_register(
-    SRCS "bh1750.c"
-    INCLUDE_DIRS "include"
-    REQUIRES "driver"
-)
+idf_component_register(SRCS "bh1750.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES "esp_driver_i2c")

--- a/components/bh1750/Kconfig
+++ b/components/bh1750/Kconfig
@@ -1,0 +1,11 @@
+menu "BH1750 : CONFIGURATION"
+
+    config BH1750_I2C_CLK_SPEED
+        int "I2C clock speed"
+		default 200000
+	range 1 400000
+        help
+            Clock speed used for i2c communication by AHT20 device.
+	    Limited to maximum of 400KHZ.
+
+endmenu

--- a/components/bh1750/bh1750.c
+++ b/components/bh1750/bh1750.c
@@ -1,11 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
-#include "driver/i2c.h"
 #include "bh1750.h"
 
 #define BH_1750_MEASUREMENT_ACCURACY    1.2    /*!< the typical measurement accuracy of  BH1750 sensor */
@@ -13,101 +12,78 @@
 #define BH1750_POWER_DOWN        0x00    /*!< Command to set Power Down*/
 #define BH1750_POWER_ON          0x01    /*!< Command to set Power On*/
 
-typedef struct {
-    i2c_port_t bus;
-    uint16_t dev_addr;
-} bh1750_dev_t;
+const char *s_TAG = "BH1750";
 
-static esp_err_t bh1750_write_byte(const bh1750_dev_t *const sens, const uint8_t byte)
+
+bh1750_handle_t bh1750_create(i2c_master_bus_handle_t bus_handle, const uint8_t bh1750_addr)
 {
-    esp_err_t ret;
+    bh1750_handle_t bh1750_handle =  malloc(sizeof(bh1750_dev_t));
+    if (bh1750_handle == NULL) {
+        ESP_LOGE(s_TAG, "unable to allocate memory to initialize bh1750 handle");
+        return bh1750_handle;
+    }
+    i2c_device_config_t bh1750_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = bh1750_addr,
+        .scl_speed_hz = CONFIG_BH1750_I2C_CLK_SPEED,
+    };
 
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ret = i2c_master_start(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, sens->dev_addr | I2C_MASTER_WRITE, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, byte, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_stop(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
+    ESP_LOGI(s_TAG, "adding BH1750 as device to bus\n");
+    i2c_master_bus_add_device(bus_handle, &bh1750_config, &(bh1750_handle->bh1750_i2c_handle) );
+    ESP_LOGI(s_TAG, "device added to bus\n");
 
-    return ret;
+    return bh1750_handle;
 }
 
-bh1750_handle_t bh1750_create(i2c_port_t port, const uint16_t dev_addr)
+esp_err_t bh1750_delete(bh1750_handle_t *sensor)
 {
-    bh1750_dev_t *sensor = (bh1750_dev_t *) calloc(1, sizeof(bh1750_dev_t));
-    sensor->bus = port;
-    sensor->dev_addr = dev_addr << 1;
-    return (bh1750_handle_t) sensor;
-}
 
-esp_err_t bh1750_delete(bh1750_handle_t sensor)
-{
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
-    free(sens);
+    i2c_master_bus_rm_device( (*sensor)->bh1750_i2c_handle);
+
+    free(*sensor);
+    *sensor = NULL; // Not a dangling pointer anymore
+
     return ESP_OK;
 }
 
 esp_err_t bh1750_power_down(bh1750_handle_t sensor)
 {
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
-    return bh1750_write_byte(sens, BH1750_POWER_DOWN);
+    uint8_t cmd = BH1750_POWER_DOWN;
+
+    ESP_RETURN_ON_ERROR (i2c_master_transmit(sensor->bh1750_i2c_handle, &cmd, sizeof(cmd), 50), s_TAG, "unable to power down\n");
+    return ESP_OK;
 }
 
 esp_err_t bh1750_power_on(bh1750_handle_t sensor)
 {
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
-    return bh1750_write_byte(sens, BH1750_POWER_ON);
+    uint8_t cmd = BH1750_POWER_ON;
+    ESP_RETURN_ON_ERROR (i2c_master_transmit(sensor->bh1750_i2c_handle, &cmd, sizeof(cmd), 50), s_TAG, "unable to power up\n");
+    return ESP_OK;
 }
 
 esp_err_t bh1750_set_measure_time(bh1750_handle_t sensor, const uint8_t measure_time)
 {
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
-    uint32_t i = 0;
     uint8_t buf[2] = {0x40, 0x60}; // constant part of the the MTreg
     buf[0] |= measure_time >> 5;
     buf[1] |= measure_time & 0x1F;
-    for (i = 0; i < 2; i++) {
-        esp_err_t ret = bh1750_write_byte(sens, buf[i]);
-        if (ESP_OK != ret) {
-            return ret;
-        }
-    }
+
+    ESP_RETURN_ON_ERROR (i2c_master_transmit(sensor->bh1750_i2c_handle, buf, sizeof(buf), 50), s_TAG, "unable to set measurement time\n");
     return ESP_OK;
 }
 
+
 esp_err_t bh1750_set_measure_mode(bh1750_handle_t sensor, const bh1750_measure_mode_t cmd_measure)
 {
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
-    return bh1750_write_byte(sens, (uint8_t)cmd_measure);
+    ESP_RETURN_ON_ERROR (i2c_master_transmit(sensor->bh1750_i2c_handle, (uint8_t *)cmd_measure, sizeof(cmd_measure), 50), s_TAG, "unable to set measurement mode\n");
+    return ESP_OK;
 }
 
 esp_err_t bh1750_get_data(bh1750_handle_t sensor, float *const data)
 {
-    esp_err_t ret;
-    uint8_t bh1750_data_h, bh1750_data_l;
-    bh1750_dev_t *sens = (bh1750_dev_t *) sensor;
+    uint8_t bh1750_data[2];
 
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ret = i2c_master_start(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_write_byte(cmd, sens->dev_addr | I2C_MASTER_READ, true);
-    assert(ESP_OK == ret);
-    ret = i2c_master_read_byte(cmd, &bh1750_data_h, I2C_MASTER_ACK);
-    assert(ESP_OK == ret);
-    ret = i2c_master_read_byte(cmd, &bh1750_data_l, I2C_MASTER_NACK);
-    assert(ESP_OK == ret);
-    ret = i2c_master_stop(cmd);
-    assert(ESP_OK == ret);
-    ret = i2c_master_cmd_begin(sens->bus, cmd, 1000 / portTICK_PERIOD_MS);
-    i2c_cmd_link_delete(cmd);
-    if (ESP_OK != ret) {
-        return ret;
-    }
-    *data = (( bh1750_data_h << 8 | bh1750_data_l ) / BH_1750_MEASUREMENT_ACCURACY);
+    ESP_RETURN_ON_ERROR (i2c_master_receive(sensor->bh1750_i2c_handle, bh1750_data, 2, 1000 / portTICK_PERIOD_MS), s_TAG, "unable to read\n");
+
+    *data = (( bh1750_data[0] << 8 | bh1750_data[1] ) / BH_1750_MEASUREMENT_ACCURACY);
     return ESP_OK;
 }

--- a/components/bh1750/examples/bh1750_demo/.cproject
+++ b/components/bh1750/examples/bh1750_demo/.cproject
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="org.eclipse.cdt.core.default.config.2141143988">
+			<storageModule buildSystemId="org.eclipse.cdt.core.defaultConfigDataProvider" id="org.eclipse.cdt.core.default.config.2141143988" moduleId="org.eclipse.cdt.core.settings" name="Configuration">
+				<externalSettings/>
+				<extensions/>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.pathentry">
+		<pathentry excluding="**/CMakeFiles/**" kind="out" path="build"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+</cproject>

--- a/components/bh1750/examples/bh1750_demo/.project
+++ b/components/bh1750/examples/bh1750_demo/.project
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>bh1750_demo</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.core.cBuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.cmake.core.cmakeNature</nature>
+	</natures>
+</projectDescription>

--- a/components/bh1750/examples/bh1750_demo/CMakeLists.txt
+++ b/components/bh1750/examples/bh1750_demo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The following five lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
+
 set(COMPONENTS main)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(test)
+project(bh1750_demo)

--- a/components/bh1750/examples/bh1750_demo/main/.cproject
+++ b/components/bh1750/examples/bh1750_demo/main/.cproject
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="org.eclipse.cdt.core.default.config.2026640853">
+			<storageModule buildSystemId="org.eclipse.cdt.core.defaultConfigDataProvider" id="org.eclipse.cdt.core.default.config.2026640853" moduleId="org.eclipse.cdt.core.settings" name="Configuration">
+				<externalSettings/>
+				<extensions/>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.pathentry">
+		<pathentry excluding="**/CMakeFiles/**" kind="out" path="build"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+</cproject>

--- a/components/bh1750/examples/bh1750_demo/main/.project
+++ b/components/bh1750/examples/bh1750_demo/main/.project
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>main</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.core.cBuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.cmake.core.cmakeNature</nature>
+	</natures>
+</projectDescription>

--- a/components/bh1750/examples/bh1750_demo/main/CMakeLists.txt
+++ b/components/bh1750/examples/bh1750_demo/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "bh1750_demo.c"
+                    INCLUDE_DIRS ".")

--- a/components/bh1750/examples/bh1750_demo/main/bh1750_demo.c
+++ b/components/bh1750/examples/bh1750_demo/main/bh1750_demo.c
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+#include <stdio.h>
+#include "bh1750.h"
+
+
+#define I2C_MASTER_SCL_IO 26      /*!< gpio number for I2C master clock */
+#define I2C_MASTER_SDA_IO 25      /*!< gpio number for I2C master data  */
+#define I2C_MASTER_NUM I2C_NUM_0  /*!< I2C port number for master dev */
+#define I2C_MASTER_FREQ_HZ 100000 /*!< I2C master clock frequency */
+
+
+
+i2c_master_bus_handle_t my_i2c_bus_handle = NULL;
+
+void read_bh1750 (void *my_bh1750_handle)
+{
+    float bh1750_data;
+
+    bh1750_handle_t bh1750 = (bh1750_handle_t) my_bh1750_handle; //retrieve the BH1750 device handle copy
+
+    while (1) {
+        //read the sensor
+        bh1750_get_data(bh1750, &bh1750_data);
+
+        printf("Luminenence = %.2f Lux \n", bh1750_data);
+        vTaskDelay(30 / portTICK_PERIOD_MS);
+    }
+}
+
+void bh1750_init(void)
+{
+
+    bh1750_handle_t bh1750 = bh1750_create(my_i2c_bus_handle, BH1750_I2C_ADDRESS_DEFAULT);
+
+    bh1750_measure_mode_t cmd_measure = BH1750_CONTINUE_4LX_RES;
+    bh1750_set_measure_mode(bh1750, cmd_measure);
+    vTaskDelay( 25 / portTICK_PERIOD_MS);
+    //creating a task to read from BH1750, passing the BH1750 device handle copy
+    xTaskCreate(read_bh1750, "bh1750_demo", 2500, bh1750, 5, NULL);
+}
+
+/**
+ * @brief i2c master initialization
+ */
+static void i2c_master_init(void)
+{
+    i2c_master_bus_config_t i2c_mst_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = I2C_MASTER_NUM,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+
+    printf("Requesting I2C bus handle\n");
+    ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_mst_config, &my_i2c_bus_handle));
+    printf("I2C bus handle acquired\n");
+}
+
+void app_main(void)
+{
+    i2c_master_init();
+    bh1750_init();
+}

--- a/components/bh1750/examples/bh1750_demo/main/idf_component.yml
+++ b/components/bh1750/examples/bh1750_demo/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  bh1750:
+    version: "*"
+    override_path: "../../../"

--- a/components/bh1750/idf_component.yml
+++ b/components/bh1750/idf_component.yml
@@ -1,5 +1,6 @@
-version: "1.0.3"
+version: "1.1.3"
 description: I2C driver for BH1750 light sensor
 url: https://github.com/espressif/esp-bsp/tree/master/components/bh1750
 dependencies:
-  idf : ">=4.0"
+  idf : ">=5.2"
+  esp_driver_i2c : "*"

--- a/components/bh1750/test/main/CMakeLists.txt
+++ b/components/bh1750/test/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "bh1750_test.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES "bh1750" "unity" "test_utils")

--- a/components/bh1750/test/main/bh1750_test.c
+++ b/components/bh1750/test/main/bh1750_test.c
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include "unity.h"
+#include "driver/i2c_master.h"
+#include "bh1750.h"
+#include "esp_log.h"
+
+#define I2C_MASTER_SCL_IO 26      /*!< gpio number for I2C master clock */
+#define I2C_MASTER_SDA_IO 25      /*!< gpio number for I2C master data  */
+#define I2C_MASTER_NUM I2C_NUM_0  /*!< I2C port number for master dev */
+#define I2C_MASTER_FREQ_HZ 100000 /*!< I2C master clock frequency */
+
+static const char *TAG = "bh1750 test";
+static bh1750_handle_t bh1750 = NULL;
+i2c_master_bus_handle_t my_i2c_bus_handle = NULL;
+
+/**
+ * @brief i2c master initialization
+ */
+static void i2c_master_init(void)
+{
+    i2c_master_bus_config_t i2c_mst_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = I2C_MASTER_NUM,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+
+    printf("Requesting I2C bus handle\n");
+    ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_mst_config, &my_i2c_bus_handle));
+    printf("I2C bus handle acquired\n");
+}
+void bh1750_init(void)
+{
+    i2c_master_init();
+    bh1750 = bh1750_create(my_i2c_bus_handle, BH1750_I2C_ADDRESS_DEFAULT);
+    TEST_ASSERT_NOT_NULL_MESSAGE(bh1750, "BH1750 create returned NULL");
+}
+
+TEST_CASE("Sensor BH1750 test", "[bh1750][iot][sensor]")
+{
+    esp_err_t ret;
+    bh1750_measure_mode_t cmd_measure;
+    float bh1750_data;
+
+    bh1750_init();
+
+    ret = bh1750_power_on(bh1750);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+
+    // one-shot mode
+    cmd_measure = BH1750_ONETIME_4LX_RES;
+    ret = bh1750_set_measure_mode(bh1750, cmd_measure);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+    vTaskDelay(30 / portTICK_PERIOD_MS);
+
+    ret = bh1750_get_data(bh1750, &bh1750_data);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+    ESP_LOGI(TAG, "bh1750 val(one time mode): %f\n", bh1750_data);
+
+    // continous mode
+    cmd_measure = BH1750_CONTINUE_4LX_RES;
+    ret = bh1750_set_measure_mode(bh1750, cmd_measure);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+    vTaskDelay(30 / portTICK_PERIOD_MS);
+
+    ret = bh1750_get_data(bh1750, &bh1750_data);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+    ESP_LOGI(TAG, "bh1750 val(continuously mode): %f\n", bh1750_data);
+
+    // clean-up
+    ret = bh1750_delete(&bh1750);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+    ret = i2c_del_master_bus(my_i2c_bus_handle);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+}
+
+void app_main(void)
+{
+    printf("\n=== BH1750 Sensor Test Menu ===\n");
+    unity_run_menu();  // Run test selection menu in flash monitor
+}

--- a/components/bh1750/test/main/idf_component.yml
+++ b/components/bh1750/test/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  bh1750:
+    version : ">=1.1"
+    override_path: "../../"


### PR DESCRIPTION

	- Refactored BH1750 driver to use esp_i2c_driver framework (IDF ≥ 5.2)
	- Added a new example demonstrating usage with the updated driver
	- Updated test application accordingly

 Changes to be committed:
	modified:   bh1750/CMakeLists.txt
	new file:   bh1750/Kconfig
	modified:   bh1750/bh1750.c
	new file:   bh1750/examples/bh1750_demo/.cproject
	new file:   bh1750/examples/bh1750_demo/.project
	new file:   bh1750/examples/bh1750_demo/CMakeLists.txt
	new file:   bh1750/examples/bh1750_demo/main/.cproject
	new file:   bh1750/examples/bh1750_demo/main/.project
	new file:   bh1750/examples/bh1750_demo/main/CMakeLists.txt
	new file:   bh1750/examples/bh1750_demo/main/bh1750_demo.c
	new file:   bh1750/examples/bh1750_demo/main/idf_component.yml
	modified:   bh1750/idf_component.yml
	modified:   bh1750/include/bh1750.h
	modified:   bh1750/test/CMakeLists.txt
	new file:   bh1750/test/main/CMakeLists.txt
	new file:   bh1750/test/main/bh1750_test.c
	new file:   bh1750/test/main/idf_component.yml

# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Updated the existing BH1750 driver to use the new I2C drivers from esp-idf >=5.2, added a new example and updated the test app.