### PR TITLE
components: Add maintanance status badges

### DIFF
--- a/components/bh1750/README.md
+++ b/components/bh1750/README.md
@@ -1,6 +1,9 @@
 # Component: BH1750
 
 [![Component Registry](https://components.espressif.com/components/espressif/bh1750/badge.svg)](https://components.espressif.com/components/espressif/bh1750)
+![maintenance-status](https://img.shields.io/badge/maintenance-deprecated-red.svg)
+
+:warning: **BH1750 component is deprecated. Users can use BH1750 from new [Sensor HUB](https://components.espressif.com/components/espressif/sensor_hub) component.**
 
 * This component will show you how to use I2C module read external i2c sensor data, here we use BH1750 light sensor(GY-30 module).
 * BH1750 measurement mode:

--- a/components/fbm320/README.md
+++ b/components/fbm320/README.md
@@ -1,6 +1,9 @@
 # Component: FBM320
 
 [![Component Registry](https://components.espressif.com/components/espressif/fbm320/badge.svg)](https://components.espressif.com/components/espressif/fbm320)
+![maintenance-status](https://img.shields.io/badge/maintenance-as--is-yellow.svg)
+
+:warning: **FBM320 component is provided as-is with no further development and compatibility maintenance**
 
 * I2C driver and definition of FBM320 digital barometer
 * See [datasheet](http://www.fmti.com.tw/fmti689/program_download/good/201702101732113548.pdf)

--- a/components/hts221/README.md
+++ b/components/hts221/README.md
@@ -1,6 +1,9 @@
 # Component: HTS221
 
 [![Component Registry](https://components.espressif.com/components/espressif/hts221/badge.svg)](https://components.espressif.com/components/espressif/hts221)
+![maintenance-status](https://img.shields.io/badge/maintenance-deprecated-red.svg)
+
+:warning: **HTS221 component is deprecated. Users can use HTS221 from new [Sensor HUB](https://components.espressif.com/components/espressif/sensor_hub) component.**
 
 I2C driver and definition of HTS221 humidity and temperature sensor.
 

--- a/components/mag3110/README.md
+++ b/components/mag3110/README.md
@@ -1,6 +1,9 @@
 # Component: MAG3110
 
 [![Component Registry](https://components.espressif.com/components/espressif/mag3110/badge.svg)](https://components.espressif.com/components/espressif/mag3110)
+![maintenance-status](https://img.shields.io/badge/maintenance-as--is-yellow.svg)
+
+:warning: **MAG3110 component is provided as-is with no further development and compatibility maintenance**
 
 * I2C driver and definition of MAG3110 3-axis digital magnetometer
 * See [datasheet](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf)

--- a/components/mpu6050/README.md
+++ b/components/mpu6050/README.md
@@ -1,6 +1,7 @@
 # MPU6050 Driver Component
 
 [![Component Registry](https://components.espressif.com/components/espressif/mpu6050/badge.svg)](https://components.espressif.com/components/espressif/mpu6050)
+![maintenance-status](https://img.shields.io/badge/maintenance-passively--maintained-yellowgreen.svg)
 
 C driver for Invensense MPU6050 6-axis gyroscope and accelerometer based on I2C communication.
 

--- a/test_apps/.build-test-rules.yml
+++ b/test_apps/.build-test-rules.yml
@@ -3,14 +3,13 @@ test_apps/noglib:
   disable:
     - if: ENV_BUILD_NOGLIB == 0
 
-# Common components test_app: Build for changes in components which do not have their own test_app or example
+# Legacy common components test_app: Build for changes in components which do not have their own test_app or example
 test_apps/components:
   depends_filepatterns:
     - "components/bh1750/**"
     - "components/fbm320/**"
     - "components/hts221/**"
     - "components/lcd/esp_lcd_ra8875/**"
-    - "components/lcd/esp_lcd_sh1107/**"
     - "components/lcd_touch/**"
     - "components/mag3110/**"
     - "components/mpu6050/**"

--- a/test_apps/components/CMakeLists.txt
+++ b/test_apps/components/CMakeLists.txt
@@ -9,7 +9,6 @@ set(EXTRA_COMPONENT_DIRS "../../components/lcd_touch")
 # Explicitly add components that do not have an test_app
 # Must be kept in sync with list in .build-test-rules.yml
 list(APPEND EXTRA_COMPONENT_DIRS
-    "../../components/lcd/esp_lcd_sh1107"
     "../../components/lcd/esp_lcd_ra8875"
     "../../components/bh1750"
     "../../components/fbm320"


### PR DESCRIPTION
## Update maintenance status badges for various sensor components

### HTS221
1. Almost 0 usages in public projects
2. New driver in Sensor HUB
3. -> Deprecated

### BH1750
1. Few usages in public projects
2. New driver in Sensor HUB
3. -> Deprecated

### MAG3110
1. Almost 0 usages in public projects
2. No other Espressif driver
3. -> As-is

### MPU6050
1. Most used
2. New driver in Sensor HUB, but without ISR configuration
3. -> Passively maintained

### FBM320
1. Almost 0 usages in public projects
2. No other Espressif driver
3. -> As-is