### PR TITLE
feat: Add noglib options to Korvo 2 and LCD-EV board

### DIFF
--- a/.github/workflows/upload_component_noglib.yml
+++ b/.github/workflows/upload_component_noglib.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Upload noglib version of BSPs
         # TODO: Extend this part to all BSPs
         env:
-          BSPs: "bsp/esp_wrover_kit bsp/esp32_s3_eye bsp/esp32_p4_function_ev_board bsp/m5stack_core_s3 bsp/m5stack_core_2 bsp/m5stack_core bsp/m5dial bsp/m5_atom_s3 bsp/esp-box-3"
+          BSPs: "bsp/esp_wrover_kit bsp/esp32_s3_eye bsp/esp32_p4_function_ev_board bsp/m5stack_core_s3 bsp/m5stack_core_2 bsp/m5stack_core bsp/m5dial bsp/m5_atom_s3 bsp/esp-box-3 bsp/esp32_s3_lcd_ev_board bsp/esp32_s3_korvo_2"
         run: |
           pip install idf-component-manager==1.* py-markdown-table --upgrade
           python .github/ci/bsp_noglib.py ${BSPs}
-      - uses: espressif/upload-components-ci-action@v1
+      - uses: espressif/upload-components-ci-action@v2
         with:
-          directories: >
+          components: >
             bsp/esp32_s3_eye_noglib;
             bsp/esp32_p4_function_ev_board_noglib;
             bsp/m5stack_core_s3_noglib;
@@ -32,7 +32,9 @@ jobs:
             bsp/esp_wrover_kit_noglib;
             bsp/m5_atom_s3_noglib;
             bsp/esp-box-3_noglib;
+            bsp/esp32_s3_lcd_ev_board_noglib;
+            bsp/esp32_s3_korvo_2_noglib;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
           dry_run: ${{ github.ref_name != 'master' || github.repository_owner != 'espressif' }}
-          commit_sha: ''
+          commit_sha: '' # Use empty string not to include commit SHA in the component version

--- a/bsp/esp32_s3_korvo_2/API.md
+++ b/bsp/esp32_s3_korvo_2/API.md
@@ -937,8 +937,8 @@ Below are some of the most relevant predefined constants:
 
 | Type | Name |
 | ---: | :--- |
-|  esp\_err\_t | [**bsp\_display\_backlight\_off**](#function-bsp_display_backlight_off) (void) <br> |
-|  esp\_err\_t | [**bsp\_display\_backlight\_on**](#function-bsp_display_backlight_on) (void) <br> |
+|  esp\_err\_t | [**bsp\_display\_backlight\_off**](#function-bsp_display_backlight_off) (void) <br>_Turn off display backlight._ |
+|  esp\_err\_t | [**bsp\_display\_backlight\_on**](#function-bsp_display_backlight_on) (void) <br>_Turn on display backlight._ |
 |  esp\_err\_t | [**bsp\_display\_brightness\_init**](#function-bsp_display_brightness_init) (void) <br> |
 |  esp\_err\_t | [**bsp\_display\_brightness\_set**](#function-bsp_display_brightness_set) (int brightness\_percent) <br> |
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)_ |
@@ -1019,20 +1019,44 @@ Variables:
 
 ### function `bsp_display_backlight_off`
 
+_Turn off display backlight._
 ```c
 esp_err_t bsp_display_backlight_off (
     void
 ) 
 ```
 
+
+Backlight is controlled with IO expander TCA9554.
+
+
+
+**Returns:**
+
+
+
+* ESP\_OK On success
+* Else Failure to initialize IO expander or set backlight level
 ### function `bsp_display_backlight_on`
 
+_Turn on display backlight._
 ```c
 esp_err_t bsp_display_backlight_on (
     void
 ) 
 ```
 
+
+Backlight is controlled with IO expander TCA9554.
+
+
+
+**Returns:**
+
+
+
+* ESP\_OK On success
+* Else Failure to initialize IO expander or set backlight level
 ### function `bsp_display_brightness_init`
 
 ```c

--- a/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -23,12 +23,16 @@
 #include "esp_lcd_ili9341.h"
 #include "esp_io_expander_tca9554.h"
 #include "esp_lcd_touch_tt21100.h"
-#include "esp_lvgl_port.h"
 #include "esp_vfs_fat.h"
 #include "esp_codec_dev_defaults.h"
 #include "bsp_err_check.h"
 #include "iot_button.h"
 #include "button_adc.h"
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+#include "lvgl.h"
+#include "esp_lvgl_port.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 static const char *TAG = "S3-KORVO-2";
 
@@ -45,7 +49,9 @@ static bool i2c_initialized = false;
 static esp_io_expander_handle_t io_expander = NULL; // IO expander tca9554 handle
 static sdmmc_card_t *bsp_sdcard = NULL;    // Global uSD card handler
 static esp_lcd_touch_handle_t tp;   // LCD touch handle
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_indev_t *disp_indev = NULL;
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static adc_oneshot_unit_handle_t bsp_adc_handle = NULL;
 
 // This is just a wrapper to get function signature for espressif/button API callback
@@ -451,6 +457,7 @@ err:
     return ret;
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 {
     assert(cfg != NULL);
@@ -490,6 +497,7 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 
     return lvgl_port_add_disp(&disp_cfg);
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch)
 {
@@ -519,6 +527,7 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
     return esp_lcd_touch_new_i2c_tt21100(tp_io_handle, &tp_cfg, ret_touch);
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_indev_t *bsp_display_indev_init(lv_display_t *disp)
 {
     if (tp == NULL) {
@@ -534,6 +543,7 @@ static lv_indev_t *bsp_display_indev_init(lv_display_t *disp)
 
     return lvgl_port_add_touch(&touch_cfg);
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 esp_err_t bsp_display_brightness_init(void)
 {
@@ -559,6 +569,7 @@ esp_err_t bsp_display_backlight_on(void)
     return esp_io_expander_set_level(io_expander, BSP_LCD_IO_BACKLIGHT, 1);
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 lv_display_t *bsp_display_start(void)
 {
     bsp_display_cfg_t cfg = {
@@ -605,6 +616,7 @@ void bsp_display_unlock(void)
 {
     lvgl_port_unlock();
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 esp_err_t bsp_leds_init(void)
 {

--- a/bsp/esp32_s3_korvo_2/include/bsp/config.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/config.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**************************************************************************************************
+ * BSP configuration
+ **************************************************************************************************/
+// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
+// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
+#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+#define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#endif

--- a/bsp/esp32_s3_korvo_2/include/bsp/display.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/display.h
@@ -75,12 +75,32 @@ typedef struct {
  */
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
 
-/* Backlight functions are not implemented - Board doesn't provide backlight control
+/**
+ * @brief Turn on display backlight
+ *
+ * Backlight is controlled with IO expander TCA9554.
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  Failure to initialize IO expander or set backlight level
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Backlight is controlled with IO expander TCA9554.
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - Else                  Failure to initialize IO expander or set backlight level
+ */
+esp_err_t bsp_display_backlight_off(void);
+
+/* Brightness functions are not implemented on this board.
    These functions are here to provide consistent API with other Board Support Packages */
 esp_err_t bsp_display_brightness_init(void);
 esp_err_t bsp_display_brightness_set(int brightness_percent);
-esp_err_t bsp_display_backlight_on(void);
-esp_err_t bsp_display_backlight_off(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -22,9 +22,13 @@
 #include "iot_button.h"
 #include "esp_io_expander.h"
 #include "esp_codec_dev.h"
+#include "bsp/config.h"
+#include "bsp/display.h"
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #include "lvgl.h"
 #include "esp_lvgl_port.h"
-#include "bsp/display.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
  *  BSP Board Name
@@ -608,6 +612,8 @@ esp_io_expander_handle_t bsp_io_expander_init(void);
 #define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50)
 #define BSP_LCD_DRAW_BUFF_DOUBLE   (1)
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+
 /**
  * @brief BSP display configuration structure
  *
@@ -677,6 +683,8 @@ void bsp_display_unlock(void);
  * @param[in] rotation Angle of the display rotation
  */
 void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display
 

--- a/bsp/esp32_s3_lcd_ev_board/API.md
+++ b/bsp/esp32_s3_lcd_ev_board/API.md
@@ -785,6 +785,7 @@ Below are some of the most relevant predefined constants:
 
 | Type | Name |
 | ---: | :--- |
+| define  | [**BSP\_LCD\_BITS\_PER\_PIXEL**](#define-bsp_lcd_bits_per_pixel)  (16)<br> |
 | define  | [**BSP\_LCD\_H\_RES**](#define-bsp_lcd_h_res)  [**bsp\_display\_get\_h\_res**](#function-bsp_display_get_h_res)()<br> |
 | define  | [**BSP\_LCD\_SUB\_BOARD\_2\_3\_DATA0**](#define-bsp_lcd_sub_board_2_3_data0)  (GPIO\_NUM\_10)<br> |
 | define  | [**BSP\_LCD\_SUB\_BOARD\_2\_3\_DATA1**](#define-bsp_lcd_sub_board_2_3_data1)  (GPIO\_NUM\_11)<br> |

--- a/bsp/esp32_s3_lcd_ev_board/README.md
+++ b/bsp/esp32_s3_lcd_ev_board/README.md
@@ -96,29 +96,29 @@ Based on the above configurations, there are three different anti-tearing modes 
 
 ## LVGL Benchmark
 
-**DATE:** 11.06.2025 02:31
+**DATE:** 28.06.2025 02:23
 
 **LVGL version:** 9.3.0
 
 | Name | Avg. CPU | Avg. FPS | Avg. time | render time | flush time |
 | ---- | :------: | :------: | :-------: | :---------: | :--------: |
 | Empty screen | 98%  | 18  | 51  | 30  | 21  |
-| Moving wallpaper | 100%  | 8  | 109  | 84  | 25  |
-| Single rectangle | 99%  | 35  | 24  | 1  | 23  |
+| Moving wallpaper | 100%  | 8  | 110  | 85  | 25  |
+| Single rectangle | 99%  | 35  | 25  | 2  | 23  |
 | Multiple rectangles | 99%  | 32  | 27  | 18  | 9  |
-| Multiple RGB images | 99%  | 27  | 30  | 23  | 7  |
-| Multiple ARGB images | 99%  | 16  | 51  | 36  | 15  |
-| Rotated ARGB images | 99%  | 14  | 62  | 53  | 9  |
-| Multiple labels | 100%  | 18  | 49  | 36  | 13  |
-| Screen sized text | 100%  | 8  | 108  | 92  | 16  |
+| Multiple RGB images | 99%  | 26  | 33  | 24  | 9  |
+| Multiple ARGB images | 100%  | 16  | 51  | 36  | 15  |
+| Rotated ARGB images | 99%  | 14  | 62  | 52  | 10  |
+| Multiple labels | 99%  | 17  | 47  | 35  | 12  |
+| Screen sized text | 100%  | 8  | 109  | 91  | 18  |
 | Multiple arcs | 99%  | 35  | 23  | 7  | 16  |
-| Containers | 99%  | 15  | 55  | 42  | 13  |
-| Containers with overlay | 99%  | 9  | 87  | 75  | 12  |
-| Containers with opa | 99%  | 12  | 71  | 57  | 14  |
-| Containers with opa_layer | 99%  | 6  | 147  | 134  | 13  |
-| Containers with scrolling | 99%  | 11  | 81  | 62  | 19  |
-| Widgets demo | 99%  | 7  | 99  | 86  | 13  |
-| All scenes avg. | 99%  | 16  | 66  | 52  | 14  |
+| Containers | 99%  | 15  | 56  | 44  | 12  |
+| Containers with overlay | 100%  | 9  | 90  | 76  | 14  |
+| Containers with opa | 100%  | 11  | 73  | 57  | 16  |
+| Containers with opa_layer | 100%  | 5  | 149  | 135  | 14  |
+| Containers with scrolling | 99%  | 11  | 81  | 63  | 18  |
+| Widgets demo | 99%  | 7  | 100  | 87  | 13  |
+| All scenes avg. | 99%  | 16  | 67  | 52  | 15  |
 
 
 

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/config.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/config.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**************************************************************************************************
+ * BSP configuration
+ **************************************************************************************************/
+// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
+// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
+#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+#define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#endif

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/display.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/display.h
@@ -28,6 +28,11 @@
 extern "C" {
 #endif
 
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+#define BSP_LCD_H_RES               bsp_display_get_h_res()
+#define BSP_LCD_V_RES               bsp_display_get_v_res()
+
 /**
  * @brief BSP display configuration structure
  *
@@ -93,6 +98,24 @@ esp_err_t bsp_display_backlight_on(void);
  *      - ESP_ERR_NOT_SUPPORTED: Always
  */
 esp_err_t bsp_display_backlight_off(void);
+
+/**
+ * @brief Get display horizontal resolution
+ *
+ * @note  This function should be called after calling `bsp_display_new()` or `bsp_display_start()`
+ *
+ * @return Horizontal resolution. Return 0 if error occurred.
+ */
+uint16_t bsp_display_get_h_res(void);
+
+/**
+ * @brief Get display vertical resolution
+ *
+ * @note  This function should be called after calling `bsp_display_new()` or `bsp_display_start()`
+ *
+ * @return Vertical resolution. Return 0 if error occurred.
+ */
+uint16_t bsp_display_get_v_res(void);
 
 #ifdef __cplusplus
 }

--- a/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
+++ b/bsp/esp32_s3_lcd_ev_board/include/bsp/esp32_s3_lcd_ev_board.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "sdkconfig.h"
 #include "driver/i2s_std.h"
 #include "driver/i2c_master.h"
 #include "driver/gpio.h"
@@ -21,11 +22,13 @@
 #include "esp_io_expander.h"
 #include "esp_lcd_gc9503.h"
 #include "iot_button.h"
-#include "lvgl.h"
+#include "bsp/config.h"
 #include "bsp/display.h"
-#include "esp_lvgl_port.h"
 
-#include "sdkconfig.h"
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+#include "lvgl.h"
+#include "esp_lvgl_port.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
  *  BSP Board Name
@@ -386,8 +389,7 @@ esp_err_t bsp_audio_poweramp_enable(bool enable);
         .flags.pclk_active_neg = true,              \
     }
 
-#define BSP_LCD_H_RES   bsp_display_get_h_res()
-#define BSP_LCD_V_RES   bsp_display_get_v_res()
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 /* LVGL related parameters */
 #define LVGL_BUFFER_HEIGHT          (CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT)
@@ -465,23 +467,7 @@ void bsp_display_unlock(void);
  */
 void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
-/**
- * @brief Get display horizontal resolution
- *
- * @note  This function should be called after calling `bsp_display_new()` or `bsp_display_start()`
- *
- * @return Horizontal resolution. Return 0 if error occurred.
- */
-uint16_t bsp_display_get_h_res(void);
-
-/**
- * @brief Get display vertical resolution
- *
- * @note  This function should be called after calling `bsp_display_new()` or `bsp_display_start()`
- *
- * @return Vertical resolution. Return 0 if error occurred.
- */
-uint16_t bsp_display_get_v_res(void);
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display
 

--- a/bsp/esp32_s3_lcd_ev_board/src/esp32_s3_lcd_ev_board.c
+++ b/bsp/esp32_s3_lcd_ev_board/src/esp32_s3_lcd_ev_board.c
@@ -18,15 +18,18 @@
 #include "esp_spiffs.h"
 #include "iot_button.h"
 #include "button_gpio.h"
-#include "lvgl.h"
 
-#include "bsp/display.h"
 #include "bsp/esp32_s3_lcd_ev_board.h"
 #include "bsp/touch.h"
 #include "bsp_err_check.h"
 #include "bsp_probe.h"
+#include "bsp/config.h"
+#include "bsp/display.h"
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+#include "lvgl.h"
 #include "esp_lvgl_port.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 #define BSP_ES7210_CODEC_ADDR   (0x82)
 
@@ -71,9 +74,11 @@ static i2s_chan_handle_t i2s_rx_chan = NULL;
 static esp_io_expander_handle_t io_expander = NULL; // IO expander tca9554 handle
 static adc_oneshot_unit_handle_t bsp_adc_handle = NULL;
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_display_t *disp;
 static lv_indev_t *disp_indev = NULL;
 static esp_lcd_touch_handle_t tp;   // LCD touch handle
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 static const button_gpio_config_t bsp_button_config[BSP_BUTTON_NUM] = {
     {
@@ -330,6 +335,7 @@ esp_err_t bsp_audio_poweramp_enable(bool enable)
     return ESP_OK;
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 static lv_display_t *bsp_display_lcd_init()
 {
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -443,6 +449,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
 {
     return disp_indev;
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 esp_err_t bsp_display_brightness_init(void)
 {
@@ -466,6 +473,7 @@ esp_err_t bsp_display_backlight_on(void)
     return bsp_display_brightness_set(100);
 }
 
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
@@ -480,10 +488,11 @@ void bsp_display_unlock(void)
 {
     lvgl_port_unlock();
 }
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
 /**************************************************************************************************
  *
- * Button Funciton
+ * Button Function
  *
  **************************************************************************************************/
 esp_err_t bsp_button_init(const bsp_button_t btn)


### PR DESCRIPTION
# Change description
Often used boards, Korvo-2 and LCD-EV board now have noglib versions.
\+ minor fixes

CI blocked by https://github.com/espressif/esp32-camera/pull/754

TODO
- [x] Test on LCD-EV board
- [x] Test on Korvo 2