### PR TITLE
fix(forms): fixing wrong label used and switching to double quotes (BSP-695)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_Feature-Request.yml
+++ b/.github/ISSUE_TEMPLATE/01_Feature-Request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
-labels: ["Type: Feature request"]
+labels: ["Type: Feature Request"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_Issue-Report.yml
+++ b/.github/ISSUE_TEMPLATE/02_Issue-Report.yml
@@ -1,6 +1,6 @@
 name: Issue report
 description: Report any problem here
-labels: ['Type: Bug', 'Status: Awaiting triage']
+labels: ["Type: Bug", "Status: Awaiting triage"]
 body:
   - type: markdown
     attributes:
@@ -23,15 +23,15 @@ body:
       description: What display or other hardware is the chip attached to?
       placeholder: ex. DevKitC, plain module on breadboard, etc. If your hardware is custom or unusual, please attach a photo.
     validations:
-       required: true
+      required: true
   - type: input
     id: IDE
     attributes:
-     label: IDE Name
-     description: What IDE are you using?
-     placeholder: eg. VSCode, Espressif-IDE...
+      label: IDE Name
+      description: What IDE are you using?
+      placeholder: eg. VSCode, Espressif-IDE...
     validations:
-     required: true
+      required: true
   - type: input
     id: os
     attributes:
@@ -56,11 +56,11 @@ body:
       placeholder: ex. Related part of the code to replicate the issue
       render: cpp
     validations:
-     required: true
+      required: true
   - type: textarea
     id: other-remarks
     attributes:
-      label: Other Steps to Reproduce 
+      label: Other Steps to Reproduce
       description: Is there any other information you can think of which will help us reproduce this problem? Any additional info can be added as well.
       placeholder: ex. I also tried on other OS, HW...it works correctly on that setup.
   - type: checkboxes


### PR DESCRIPTION
This PR has 2 changes:
1. There was typo in issue forms for feature request. Correct label should be Feature Request with capital R
2. I changed single quotes to double ones in issue forms for bug, because documentation always uses double quotes