### PR TITLE
feat(cst816s): support disabling ID read via Kconfig

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/Kconfig
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/Kconfig
@@ -1,0 +1,9 @@
+menu "ESP LCD TOUCH - CST816S"
+
+    config ESP_LCD_TOUCH_CST816S_DISABLE_READ_ID
+        bool "Disable reading ID during initialization"
+        default n
+        help
+            For some CST816 series chips, reading ID may cause initialization failure.
+
+endmenu

--- a/components/lcd_touch/esp_lcd_touch_cst816s/README.md
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/README.md
@@ -8,12 +8,11 @@ Implementation of the CST816S touch controller with esp_lcd_touch component.
 | :--------------: | :---------------------: | :-------------------: | :------------------------------------------------------------------------: |
 |     CST816S      |           I2C           | esp_lcd_touch_cst816s | [datasheet](https://www.buydisplay.com/download/ic/DS-CST816S_DS_V1.3.pdf) |
 
-**Note, there are two things about the driver are noteworthy (from [document](https://doc.riot-os.org/group__drivers__cst816s.html)):**
-
-* It only responds to I2C commands after an event, such as a touch detection. Do not expect it to respond on init. Instead after a touch event, it will assert the IRQ and respond to I2C reads for a short time.
-* While it should be able to detect multiple finger events, this version of the chip always returns only a single finger event and a gesture.
-
-Reading the display data multiple times during a single event will return the last sampled finger position.
+> [!NOTE]
+> * There are two things about the driver are noteworthy (from [document](https://doc.riot-os.org/group__drivers__cst816s.html)):
+>   * It only responds to I2C commands after an event, such as a touch detection. Do not expect it to respond on init. Instead after a touch event, it will assert the IRQ and respond to I2C reads for a short time.
+>   * While it should be able to detect multiple finger events, this version of the chip always returns only a single finger event and a gesture. Reading the display data multiple times during a single event will return the last sampled finger position.
+> * For some chips, reading ID may cause initialization failure. Disable reading ID by setting `CONFIG_ESP_LCD_TOUCH_CST816S_DISABLE_READ_ID` to `y` in `menuconfig`.
 
 ## Add to project
 

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -80,7 +80,11 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
     /* Reset controller */
     ESP_GOTO_ON_ERROR(reset(cst816s), err, TAG, "Reset failed");
     /* Read product id */
-    ESP_GOTO_ON_ERROR(read_id(cst816s), err, TAG, "Read version failed");
+#ifdef CONFIG_ESP_LCD_TOUCH_CST816S_DISABLE_READ_ID
+    ESP_LOGI(TAG, "Read ID disabled");
+#else
+    ESP_GOTO_ON_ERROR(read_id(cst816s), err, TAG, "Read ID failed");
+#endif
     *tp = cst816s;
 
     return ESP_OK;
@@ -170,6 +174,7 @@ static esp_err_t reset(esp_lcd_touch_handle_t tp)
     return ESP_OK;
 }
 
+#ifndef CONFIG_ESP_LCD_TOUCH_CST816S_DISABLE_READ_ID
 static esp_err_t read_id(esp_lcd_touch_handle_t tp)
 {
     uint8_t id;
@@ -177,6 +182,7 @@ static esp_err_t read_id(esp_lcd_touch_handle_t tp)
     ESP_LOGI(TAG, "IC id: %d", id);
     return ESP_OK;
 }
+#endif
 
 static esp_err_t i2c_read_bytes(esp_lcd_touch_handle_t tp, uint16_t reg, uint8_t *data, uint8_t len)
 {

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.6"
+version: "1.1.0"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description

Some chips in the CST816 series may fail to read the ID during initialization. Therefore, Kconfig is added to allow the function of disabling ID reading.