### PR TITLE
fix(esp_lvgl_port): Place LVGL task stack to internal RAM

### DIFF
--- a/components/esp_lvgl_port/include/esp_lvgl_port.h
+++ b/components/esp_lvgl_port/include/esp_lvgl_port.h
@@ -67,7 +67,7 @@ typedef struct {
         .task_stack = 7168,                        \
         .task_affinity = -1,                       \
         .task_max_sleep_ms = 500,                  \
-        .task_stack_caps = MALLOC_CAP_DEFAULT,     \
+        .task_stack_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_DEFAULT,    \
         .timer_period_ms = 5,                      \
     }
 

--- a/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port.c
+++ b/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port.c
@@ -78,7 +78,7 @@ esp_err_t lvgl_port_init(const lvgl_port_cfg_t *cfg)
     ESP_GOTO_ON_FALSE(lvgl_port_ctx.task_mux, ESP_ERR_NO_MEM, err, TAG, "Create LVGL task sem fail!");
 
     BaseType_t res;
-    const uint32_t caps = cfg->task_stack_caps ? cfg->task_stack_caps : MALLOC_CAP_DEFAULT; // caps cannot be zero
+    const uint32_t caps = cfg->task_stack_caps ? cfg->task_stack_caps : MALLOC_CAP_INTERNAL | MALLOC_CAP_DEFAULT; // caps cannot be zero
     if (cfg->task_affinity < 0) {
         res = xTaskCreateWithCaps(lvgl_port_task, "taskLVGL", cfg->task_stack, NULL, cfg->task_priority, &lvgl_port_ctx.lvgl_task, caps);
     } else {

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port.c
@@ -85,7 +85,7 @@ esp_err_t lvgl_port_init(const lvgl_port_cfg_t *cfg)
     ESP_GOTO_ON_FALSE(lvgl_port_ctx.lvgl_events, ESP_ERR_NO_MEM, err, TAG, "Create LVGL Event Group fail!");
 
     BaseType_t res;
-    const uint32_t caps = cfg->task_stack_caps ? cfg->task_stack_caps : MALLOC_CAP_DEFAULT; // caps cannot be zero
+    const uint32_t caps = cfg->task_stack_caps ? cfg->task_stack_caps : MALLOC_CAP_INTERNAL | MALLOC_CAP_DEFAULT; // caps cannot be zero
     if (cfg->task_affinity < 0) {
         res = xTaskCreateWithCaps(lvgl_port_task, "taskLVGL", cfg->task_stack, xTaskGetCurrentTaskHandle(), cfg->task_priority, &lvgl_port_ctx.lvgl_task, caps);
     } else {


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] CI passing
- [x] Test on Wrover-kit

# Change description
By default, place LVGL task stack in internal RAM to avoid issues with cache if SPIRAM is used.

If placed in external RAM, following error can raise:

```
assert failed: spi_flash_disable_interrupts_caches_and_other_cpu cache_utils.c:127 (esp_task_stack_is_sane_cache_disabled())
```