### PR TITLE
Properly swap bytes and draw to display for direct mode in LVGL9 (BSP-700)

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- LVGL9 direct/full_refresh: dirty-area RGB565 swap and last-flush full-screen draw for all panel types
+
 ## 2.9.0
 
 ### Features

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -102,6 +102,7 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
 static void lvgl_port_disp_size_update_callback(lv_event_t *e);
 static void lvgl_port_disp_rotation_update(lvgl_port_display_ctx_t *disp_ctx);
 static void lvgl_port_display_invalidate_callback(lv_event_t *e);
+static void lvgl_port_draw_sw_rgb565_swap_area(void *buf, uint32_t screen_width, uint32_t screen_height, const lv_area_t *area);
 
 /*******************************************************************************
 * Public API functions
@@ -737,22 +738,27 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
     }
 
     if (disp_ctx->flags.swap_bytes) {
-        size_t len = lv_area_get_size(area);
-        lv_draw_sw_rgb565_swap(color_map, len);
+        if (disp_ctx->flags.direct_mode) {
+            // in direct mode, color_map is full size but we only need to swap the dirty area
+            lvgl_port_draw_sw_rgb565_swap_area(color_map, lv_disp_get_hor_res(drv), lv_disp_get_ver_res(drv), area);
+        } else {
+            size_t len = lv_area_get_size(area);
+            lv_draw_sw_rgb565_swap(color_map, len);
+        }
     }
     /* Transfer data in buffer for monochromatic screen */
     if (disp_ctx->flags.monochrome) {
         _lvgl_port_transform_monochrome(drv, area, &color_map);
     }
 
-    if ((disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_RGB || disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_DSI)
-            && (disp_ctx->flags.direct_mode || disp_ctx->flags.full_refresh)) {
+    if (disp_ctx->flags.direct_mode || disp_ctx->flags.full_refresh) {
         if (lv_disp_flush_is_last(drv)) {
-            /* If the interface is I80 or SPI, this step cannot be used for drawing. */
             esp_lcd_panel_draw_bitmap(disp_ctx->panel_handle, 0, 0, lv_disp_get_hor_res(drv), lv_disp_get_ver_res(drv), color_map);
-            /* Waiting for the last frame buffer to complete transmission */
-            xSemaphoreTake(disp_ctx->trans_sem, 0);
-            xSemaphoreTake(disp_ctx->trans_sem, portMAX_DELAY);
+            if (disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_RGB || disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_DSI) {
+                /* Waiting for the last frame buffer to complete transmission */
+                xSemaphoreTake(disp_ctx->trans_sem, 0);
+                xSemaphoreTake(disp_ctx->trans_sem, portMAX_DELAY);
+            }
         }
     } else {
         esp_lcd_panel_draw_bitmap(disp_ctx->panel_handle, offsetx1, offsety1, offsetx2 + 1, offsety2 + 1, color_map);
@@ -827,4 +833,22 @@ static void lvgl_port_display_invalidate_callback(lv_event_t *e)
 
     /* Wake LVGL task, if needed */
     lvgl_port_task_wake(LVGL_PORT_EVENT_DISPLAY, NULL);
+}
+
+static void lvgl_port_draw_sw_rgb565_swap_area(void *buf, uint32_t screen_width, uint32_t screen_height, const lv_area_t *area) {
+    if (!buf || !area)
+        return;
+    if (area->x1 > area->x2 || area->y1 > area->y2)
+        return;
+    if (area->x2 >= (int32_t)screen_width || area->y2 >= (int32_t)screen_height)
+        return;
+
+    uint16_t *buf16 = (uint16_t *)buf;
+    for (int32_t y = area->y1; y <= area->y2; ++y) {
+        uint32_t row_start = y * screen_width + area->x1;
+        for (int32_t x = area->x1; x <= area->x2; ++x) {
+            uint32_t idx = row_start + (x - area->x1);
+            buf16[idx] = ((buf16[idx] & 0xff00) >> 8) | ((buf16[idx] & 0x00ff) << 8);
+        }
+    }
 }

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -751,9 +751,11 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
         _lvgl_port_transform_monochrome(drv, area, &color_map);
     }
 
+    bool transfer_started = false;
     if (disp_ctx->flags.direct_mode || disp_ctx->flags.full_refresh) {
         if (lv_disp_flush_is_last(drv)) {
             esp_lcd_panel_draw_bitmap(disp_ctx->panel_handle, 0, 0, lv_disp_get_hor_res(drv), lv_disp_get_ver_res(drv), color_map);
+            transfer_started = true;
             if (disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_RGB || disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_DSI) {
                 /* Waiting for the last frame buffer to complete transmission */
                 xSemaphoreTake(disp_ctx->trans_sem, 0);
@@ -762,10 +764,15 @@ static void lvgl_port_flush_callback(lv_display_t *drv, const lv_area_t *area, u
         }
     } else {
         esp_lcd_panel_draw_bitmap(disp_ctx->panel_handle, offsetx1, offsety1, offsetx2 + 1, offsety2 + 1, color_map);
+        transfer_started = true;
     }
 
+    /* RGB / DSI(+direct/full_refresh): ready here (master). SPI/I80 after draw: panel IO callback.
+     * SPI/I80 intermediate direct/full: no draw — signal ready so multi-area frames cannot hang. */
     if (disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_RGB || (disp_ctx->disp_type == LVGL_PORT_DISP_TYPE_DSI
             && (disp_ctx->flags.direct_mode || disp_ctx->flags.full_refresh))) {
+        lv_disp_flush_ready(drv);
+    } else if (!transfer_started) {
         lv_disp_flush_ready(drv);
     }
 }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description

## Problem

In LVGL9 **direct mode** / **full_refresh**, draw buffers are screen-sized and store a complete frame at absolute coordinates. The flush path had two issues:

1. **RGB565 `swap_bytes`** treated `color_map` as a partial crop (`lv_draw_sw_rgb565_swap` over `area` size). In direct mode, `color_map` is the full framebuffer base, so that swapped the wrong span of pixels.
2. **Last-flush presentation** used full-screen `esp_lcd_panel_draw_bitmap` only for RGB/MIPI-DSI. Other panel types (e.g. SPI/I80) used area `draw_bitmap` with an unoffset full-frame `color_map`, which is incorrect for direct/full_refresh buffer layout.

## Changes (`esp_lvgl_port` LVGL9)

1. **Dirty-area byte swap** — new `lvgl_port_draw_sw_rgb565_swap_area()` swaps RGB565 endianness only within the dirty `area` when `direct_mode` and `swap_bytes` are enabled. Partial mode keeps the existing full-`area` swap.
2. **Full-frame present on last flush** — for `direct_mode` or `full_refresh`, on the last flush of a frame, always draw fullscreen `(0,0)→(hor,ver)` for **all** panel types (not only RGB/DSI).
3. **Transfer wait** — `trans_sem` wait after that draw still applies **only** to RGB/DSI.
4. **`lv_disp_flush_ready`** — **unchanged** from master: still gated for RGB and for DSI under direct/full_refresh. SPI/I80 continue to complete via panel IO `on_color_trans_done` (avoids double-ready / early buffer reuse with DMA).

## Non-goals / notes

- Does not call `lv_disp_flush_ready` unconditionally at end of flush (original draft did; rebased out for SPI safety).
- Component version not bumped; entry added under **CHANGELOG → Unreleased → Features**.
- Rebased onto current `espressif:master`.

## Residual risk

SPI/I80 direct or full_refresh may transfer a full frame on each last flush (expected full-FB present cost). Color corruption if area-swap bounds were wrong — logic is limited to LVGL9 flush in `esp_lvgl_port_disp.c`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core display flush timing and buffer layout for direct/full_refresh across panel types; wrong bounds or ready signaling could cause corruption or hangs on SPI/I80 DMA paths.
> 
> **Overview**
> Fixes **LVGL9** flush behavior when **direct mode** or **full refresh** uses a screen-sized framebuffer with **RGB565 byte swap**.
> 
> **RGB565 swap:** With `direct_mode` and `swap_bytes`, the flush path now swaps endianness only inside the dirty `area` via `lvgl_port_draw_sw_rgb565_swap_area()` instead of treating `color_map` as a partial buffer. Partial rendering still uses the existing full-region swap.
> 
> **Present:** On the last flush of a frame, **all** panel types get a full-screen `esp_lcd_panel_draw_bitmap(0,0→hor,ver)` (not only RGB/MIPI-DSI). SPI/I80 no longer use area-scoped draws against an unoffset full frame. `trans_sem` blocking after that draw remains **RGB/DSI only**.
> 
> **Flush ready:** Intermediate direct/full flushes that skip a draw call `lv_disp_flush_ready` when no transfer started, so multi-area frames do not hang on SPI/I80 while DMA completion still uses the panel IO callback when a draw runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0361a8d13bd2ac1b9c0b291f466b10927dc16a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->