### PR TITLE
fix(esp32_s3_korvo_2): Fixed LED states for V3.1 board

### DIFF
--- a/bsp/esp32_s3_korvo_2/README.md
+++ b/bsp/esp32_s3_korvo_2/README.md
@@ -15,6 +15,8 @@ The ESP32-S3-Korvo-2 is a multimedia development board based on the ESP32-S3 chi
 </td></tr>
 </table>
 
+> **_NOTE:_** Compatible with V3.0 a V3.1 boards.
+
 ![image](doc/pic.png)
 
 ## Capabilities and dependencies

--- a/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
+++ b/bsp/esp32_s3_korvo_2/esp32_s3_korvo_2.c
@@ -623,14 +623,14 @@ esp_err_t bsp_leds_init(void)
     BSP_NULL_CHECK(bsp_io_expander_init(), ESP_ERR_INVALID_STATE);
     BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_dir(io_expander, BSP_LED_RED, IO_EXPANDER_OUTPUT));
     BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_dir(io_expander, BSP_LED_BLUE, IO_EXPANDER_OUTPUT));
-    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LED_RED, true));
-    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LED_BLUE, true));
+    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LED_RED, false));
+    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, BSP_LED_BLUE, false));
     return ESP_OK;
 }
 
 esp_err_t bsp_led_set(const bsp_led_t led_io, const bool on)
 {
-    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, led_io, !on));
+    BSP_ERROR_CHECK_RETURN_ERR(esp_io_expander_set_level(io_expander, led_io, on));
     return ESP_OK;
 }
 

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.0.1~2"
+version: "4.0.2"
 description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Fixed LED state

Closes #608 