### PR TITLE
Refactor/set rgb element order

### DIFF
--- a/components/lcd/esp_lcd_gc9a01/README.md
+++ b/components/lcd/esp_lcd_gc9a01/README.md
@@ -11,9 +11,10 @@ Implementation of the GC9A01 LCD controller with esp_lcd component.
 ## Add to project
 
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
-You can add them to your project via `idf.py add-dependancy`, e.g.
-```
-    idf.py add-dependency esp_lcd_gc9a01==1.0.0
+You can add them to your project via `idf.py add-dependency`, e.g.
+
+```bash
+idf.py add-dependency "espressif/esp_lcd_gc9a01^2.0.0"
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
@@ -51,23 +52,15 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
     //     .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(gc9a01_lcd_init_cmd_t),
     // };
     const esp_lcd_panel_dev_config_t panel_config = {
-        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,      // Set to -1 if not use
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-#else
-        .rgb_endian = LCD_RGB_ENDIAN_RGB,
-#endif
-        .bits_per_pixel = 16,                           // Implemented by LCD command `3Ah` (16/18)
-        // .vendor_config = &vendor_config,            // Uncomment this line if use custom initialization commands
+        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,   // Set to -1 if not use
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,  // RGB element order: R-G-B
+        .bits_per_pixel = 16,                        // Implemented by LCD command `3Ah` (16/18)
+        // .vendor_config = &vendor_config,          // Uncomment this line if use custom initialization commands
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_gc9a01(io_handle, &panel_config, &panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-    ESP_ERROR_CHECK(esp_lcd_panel_disp_off(panel_handle, false));
-#else
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
-#endif
 ```
 
 There is an example in ESP-IDF with this LCD controller. Please follow this [link](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/lcd/spi_lcd_touch).

--- a/components/lcd/esp_lcd_gc9a01/esp_lcd_gc9a01.c
+++ b/components/lcd/esp_lcd_gc9a01/esp_lcd_gc9a01.c
@@ -73,7 +73,7 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported color space");
         break;
     }
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     switch (panel_dev_config->rgb_endian) {
     case LCD_RGB_ENDIAN_RGB:
         gc9a01->madctl_val = 0;
@@ -83,6 +83,18 @@ esp_err_t esp_lcd_new_panel_gc9a01(const esp_lcd_panel_io_handle_t io, const esp
         break;
     default:
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb endian");
+        break;
+    }
+#else
+    switch (panel_dev_config->rgb_ele_order) {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+        gc9a01->madctl_val = 0;
+        break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+        gc9a01->madctl_val |= LCD_CMD_BGR_BIT;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb element order");
         break;
     }
 #endif

--- a/components/lcd/esp_lcd_gc9a01/idf_component.yml
+++ b/components/lcd/esp_lcd_gc9a01/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.0.3"
 description: ESP LCD GC9A01
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_gc9a01
 dependencies:

--- a/components/lcd/esp_lcd_gc9a01/test_apps/main/test_esp_lcd_gc9a01.c
+++ b/components/lcd/esp_lcd_gc9a01/test_apps/main/test_esp_lcd_gc9a01.c
@@ -88,8 +88,10 @@ TEST_CASE("test gc9a01 to draw color bar with SPI interface", "[gc9a01][spi]")
         .reset_gpio_num = TEST_PIN_NUM_LCD_RST,
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
         .color_space = ESP_LCD_COLOR_SPACE_BGR,
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .rgb_endian = LCD_RGB_ENDIAN_BGR,
+#else
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
 #endif
         .bits_per_pixel = TEST_LCD_BIT_PER_PIXEL,
     };

--- a/components/lcd/esp_lcd_ili9341/README.md
+++ b/components/lcd/esp_lcd_ili9341/README.md
@@ -11,9 +11,10 @@ Implementation of the ILI9341 LCD controller with esp_lcd component.
 ## Add to project
 
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
-You can add them to your project via `idf.py add-dependancy`, e.g.
-```
-    idf.py add-dependency esp_lcd_ili9341==1.0.0
+You can add them to your project via `idf.py add-dependency`, e.g.
+
+```bash
+idf.py add-dependency "espressif/esp_lcd_ili9341^2.0.0"
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
@@ -51,23 +52,15 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
     //     .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(ili9341_lcd_init_cmd_t),
     // };
     const esp_lcd_panel_dev_config_t panel_config = {
-        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,      // Set to -1 if not use
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)      // Implemented by LCD command `36h`
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-#else
-        .rgb_endian = LCD_RGB_ENDIAN_RGB,
-#endif
-        .bits_per_pixel = 16,                           // Implemented by LCD command `3Ah` (16/18)
-        // .vendor_config = &vendor_config,            // Uncomment this line if use custom initialization commands
+        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,   // Set to -1 if not use
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,  // RGB element order: R-G-B
+        .bits_per_pixel = 16,                        // Implemented by LCD command `3Ah` (16/18)
+        // .vendor_config = &vendor_config,          // Uncomment this line if use custom initialization commands
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_ili9341(io_handle, &panel_config, &panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-    ESP_ERROR_CHECK(esp_lcd_panel_disp_off(panel_handle, false));
-#else
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
-#endif
 ```
 
 There is an example in ESP-IDF with this LCD controller. Please follow this [link](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/lcd/spi_lcd_touch).

--- a/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
+++ b/components/lcd/esp_lcd_ili9341/esp_lcd_ili9341.c
@@ -73,7 +73,7 @@ esp_err_t esp_lcd_new_panel_ili9341(const esp_lcd_panel_io_handle_t io, const es
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported color space");
         break;
     }
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     switch (panel_dev_config->rgb_endian) {
     case LCD_RGB_ENDIAN_RGB:
         ili9341->madctl_val = 0;
@@ -83,6 +83,18 @@ esp_err_t esp_lcd_new_panel_ili9341(const esp_lcd_panel_io_handle_t io, const es
         break;
     default:
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb endian");
+        break;
+    }
+#else
+    switch (panel_dev_config->rgb_ele_order) {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+        ili9341->madctl_val = 0;
+        break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+        ili9341->madctl_val |= LCD_CMD_BGR_BIT;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb element order");
         break;
     }
 #endif

--- a/components/lcd/esp_lcd_ili9341/idf_component.yml
+++ b/components/lcd/esp_lcd_ili9341/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: ESP LCD ILI9341
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_ili9341
 dependencies:

--- a/components/lcd/esp_lcd_ili9341/test_apps/main/test_esp_lcd_ili9341.c
+++ b/components/lcd/esp_lcd_ili9341/test_apps/main/test_esp_lcd_ili9341.c
@@ -108,8 +108,10 @@ TEST_CASE("test ili9341 to draw color bar with SPI interface", "[ili9341][spi]")
         .reset_gpio_num = TEST_PIN_NUM_LCD_RST, // Shared with Touch reset
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
         .color_space = ESP_LCD_COLOR_SPACE_BGR,
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .rgb_endian = LCD_RGB_ENDIAN_BGR,
+#else
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
 #endif
         .bits_per_pixel = TEST_LCD_BIT_PER_PIXEL,
     };

--- a/components/lcd/esp_lcd_st7796/README.md
+++ b/components/lcd/esp_lcd_st7796/README.md
@@ -14,7 +14,7 @@ Packages from this repository are uploaded to [Espressif's component service](ht
 You can add them to your project via `idf.py add-dependency`, e.g.
 
 ```bash
-compote manifest add-dependency espressif/esp_lcd_st7796==1.0.0
+idf.py add-dependency "espressif/esp_lcd_st7796^1.3.0"
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
@@ -59,23 +59,15 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
     //     .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st7796_lcd_init_cmd_t),
     // };
     const esp_lcd_panel_dev_config_t panel_config = {
-        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,      // Set to -1 if not use
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)      // Implemented by LCD command `36h`
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
-#else
-        .rgb_endian = LCD_RGB_ENDIAN_RGB,
-#endif
-        .bits_per_pixel = EXAMPLE_LCD_BIT_PER_PIXEL,    // Implemented by LCD command `3Ah` (16/18/24)
-        // .vendor_config = &vendor_config,            // Uncomment this line if use custom initialization commands
+        .reset_gpio_num = EXAMPLE_PIN_NUM_LCD_RST,   // Set to -1 if not use
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,  // RGB element order: R-G-B
+        .bits_per_pixel = EXAMPLE_LCD_BIT_PER_PIXEL, // Implemented by LCD command `3Ah` (16/18/24)
+        // .vendor_config = &vendor_config,          // Uncomment this line if use custom initialization commands
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_st7796(io_handle, &panel_config, &panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-    ESP_ERROR_CHECK(esp_lcd_panel_disp_off(panel_handle, false));
-#else
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
-#endif
 ```
 
 ### MIPI Interface

--- a/components/lcd/esp_lcd_st7796/esp_lcd_st7796_general.c
+++ b/components/lcd/esp_lcd_st7796/esp_lcd_st7796_general.c
@@ -74,7 +74,7 @@ esp_err_t esp_lcd_new_panel_st7796_general(const esp_lcd_panel_io_handle_t io, c
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported color space");
         break;
     }
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     switch (panel_dev_config->rgb_endian) {
     case LCD_RGB_ENDIAN_RGB:
         st7796->madctl_val = 0;
@@ -84,6 +84,18 @@ esp_err_t esp_lcd_new_panel_st7796_general(const esp_lcd_panel_io_handle_t io, c
         break;
     default:
         ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb endian");
+        break;
+    }
+#else
+    switch (panel_dev_config->rgb_ele_order) {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+        st7796->madctl_val = 0;
+        break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+        st7796->madctl_val |= LCD_CMD_BGR_BIT;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported rgb element order");
         break;
     }
 #endif

--- a/components/lcd/esp_lcd_st7796/idf_component.yml
+++ b/components/lcd/esp_lcd_st7796/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.2"
+version: "1.3.3"
 targets:
   - esp32
   - esp32s2

--- a/components/lcd/esp_lcd_st7796/test_apps/main/test_esp_lcd_st7796_general.c
+++ b/components/lcd/esp_lcd_st7796/test_apps/main/test_esp_lcd_st7796_general.c
@@ -110,8 +110,10 @@ TEST_CASE("test st7796 to draw color bar with I80 interface", "[st7796][i80]")
         .reset_gpio_num = TEST_PIN_NUM_LCD_RST,
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
         .color_space = ESP_LCD_COLOR_SPACE_BGR,
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .rgb_endian = LCD_RGB_ENDIAN_BGR,
+#else
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
 #endif
         .bits_per_pixel = TEST_LCD_BIT_PER_PIXEL,
     };


### PR DESCRIPTION
IDF recommend to use rgb_ele_order to specify the RGB element order. 

In v4.x, we use "color_space" to distinguish RGB and BGR, but in fact they're the same color space. Thus we deprecate that name.
In v5.x, we use "rgb_endian" to distinguish RGB and BGR, but in practice, users are confused by the "rgb_endian" and the "data_endian" (a new config). Thus we start to recommend to use "rgb_ele_order".
