### PR TITLE
fix: Use new IDF_VERSION symbol in .build-test-rules.yml files

### DIFF
--- a/components/.build-test-rules.yml
+++ b/components/.build-test-rules.yml
@@ -10,7 +10,7 @@ components/esp_lvgl_port/examples/i2c_oled:
     - "components/esp_lvgl_port/**"
     - "components/lcd/sh1107/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2
 
 components/esp_lvgl_port/test_apps/simd:
@@ -31,12 +31,12 @@ components/icm42670:
   depends_filepatterns:
     - "components/icm42670/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2
 
 components/qma6100p:
   depends_filepatterns:
     - "components/qma6100p/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2

--- a/components/io_expander/.build-test-rules.yml
+++ b/components/io_expander/.build-test-rules.yml
@@ -3,7 +3,7 @@ components/io_expander/esp_io_expander_ht8574:
     - "components/io_expander/esp_io_expander/**"
     - "components/io_expander/esp_io_expander_ht8574/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2
 
 components/io_expander/esp_io_expander_tca95xx_16bit:
@@ -11,7 +11,7 @@ components/io_expander/esp_io_expander_tca95xx_16bit:
     - "components/io_expander/esp_io_expander/**"
     - "components/io_expander/esp_io_expander_tca95xx_16bit/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2
 
 components/io_expander/esp_io_expander_tca9554:
@@ -19,5 +19,5 @@ components/io_expander/esp_io_expander_tca9554:
     - "components/io_expander/esp_io_expander/**"
     - "components/io_expander/esp_io_expander_tca9554/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2

--- a/components/lcd/.build-test-rules.yml
+++ b/components/lcd/.build-test-rules.yml
@@ -7,7 +7,7 @@ components/lcd/esp_lcd_gc9503:
   depends_filepatterns:
     - "components/lcd/esp_lcd_gc9503/**"
   disable:
-    - if: (IDF_VERSION_MAJOR < 5 or ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 0) and ESP_IDF_VERSION_PATCH < 5)) or ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR == 1) and ESP_IDF_VERSION_PATCH == 1)
+    - if: (IDF_VERSION < "5.0.5") or (IDF_VERSION == "5.1.1")
       reason: Supported from version 5.0.5 and not supported in version 5.1.1
 
 components/lcd/esp_lcd_ili9341:
@@ -18,7 +18,7 @@ components/lcd/esp_lcd_ili9881c:
   depends_filepatterns:
     - "components/lcd/esp_lcd_ili9881c/**"
   disable:
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 3) or IDF_VERSION_MAJOR < 5
+    - if: IDF_VERSION < "5.3.0"
       reason: Component is supported only for IDF >= 5.3
     - if: IDF_TARGET not in ["esp32p4"]
       reason: Component is supported only for esp32p4 target

--- a/examples/.build-test-rules.yml
+++ b/examples/.build-test-rules.yml
@@ -3,14 +3,14 @@ examples:
   disable:
     - if: CONFIG_NAME in ["esp-box", "esp-box-lite", "esp32_azure_iot_kit"]
       reason: Do not build examples for deprecated BSPs
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2) and CONFIG_NAME in ["esp_bsp_generic", "esp_bsp_devkit", "m5stack_core"]
+    - if: (IDF_VERSION < "5.2.0") and CONFIG_NAME in ["esp_bsp_generic", "esp_bsp_devkit", "m5stack_core"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.2
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 3) and CONFIG_NAME in ["esp32_p4_function_ev_board", "esp-box-3", "esp32_s3_lcd_ev_board", "m5_atom_s3"]
+    - if: (IDF_VERSION < "5.3.0") and CONFIG_NAME in ["esp32_p4_function_ev_board", "esp-box-3", "esp32_s3_lcd_ev_board", "m5_atom_s3"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.3
-    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 4) and CONFIG_NAME in ["m5stack_core_s3", "esp32_s2_kaluga_kit", "esp32_s3_korvo_2", "esp32_s3_eye"]
+    - if: (IDF_VERSION < "5.4.0") and CONFIG_NAME in ["m5stack_core_s3", "esp32_s2_kaluga_kit", "esp32_s3_korvo_2", "esp32_s3_eye"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.4
 
 examples/generic_button_led:
   disable:
-    - if: IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 2
+    - if: IDF_VERSION < "5.2.0"
       reason: Requires I2C Driver-NG which was introduced in v5.2


### PR DESCRIPTION
Small fix for better readability of .build-test-rules.yml files