### PR TITLE
refactor(mipi_lcd): set phy_clk_src to 0 as default clock source

### DIFF
--- a/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
+++ b/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
@@ -975,7 +975,6 @@ lv_display_t *bsp_display_start(void)
             .hdmi_resolution = BSP_HDMI_RES_NONE,
 #endif
             .dsi_bus = {
-                .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
                 .lane_bit_rate_mbps = BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS,
             }
         },

--- a/components/lcd/esp_lcd_ili9881c/idf_component.yml
+++ b/components/lcd/esp_lcd_ili9881c/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 targets:
   - esp32p4
 description: ESP LCD ILI9881C (MIPI DSI)

--- a/components/lcd/esp_lcd_ili9881c/include/esp_lcd_ili9881c.h
+++ b/components/lcd/esp_lcd_ili9881c/include/esp_lcd_ili9881c.h
@@ -75,7 +75,7 @@ esp_err_t esp_lcd_new_panel_ili9881c(const esp_lcd_panel_io_handle_t io, const e
     {                                                    \
         .bus_id = 0,                                     \
         .num_data_lanes = 2,                             \
-        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,     \
+        .phy_clk_src = 0,                                \
         .lane_bit_rate_mbps = 1000,                      \
     }
 

--- a/components/lcd/esp_lcd_lt8912b/idf_component.yml
+++ b/components/lcd/esp_lcd_lt8912b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.1.2"
 description: ESP LCD LT8912B (MIPI DSI - HDMI)
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_lt8912b
 repository: "https://github.com/espressif/esp-bsp.git"

--- a/components/lcd/esp_lcd_lt8912b/include/esp_lcd_lt8912b.h
+++ b/components/lcd/esp_lcd_lt8912b/include/esp_lcd_lt8912b.h
@@ -107,7 +107,7 @@ bool esp_lcd_panel_lt8912b_is_ready(esp_lcd_panel_t *panel);
     {                                                    \
         .bus_id = 0,                                     \
         .num_data_lanes = 2,                             \
-        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,     \
+        .phy_clk_src = 0,                                \
         .lane_bit_rate_mbps = 1000,                      \
     }
 

--- a/components/lcd/esp_lcd_st7796/idf_component.yml
+++ b/components/lcd/esp_lcd_st7796/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.4"
+version: "1.3.5"
 targets:
   - esp32
   - esp32s2

--- a/components/lcd/esp_lcd_st7796/include/esp_lcd_st7796.h
+++ b/components/lcd/esp_lcd_st7796/include/esp_lcd_st7796.h
@@ -171,7 +171,7 @@ esp_err_t esp_lcd_new_panel_st7796(const esp_lcd_panel_io_handle_t io, const esp
     {                                                    \
         .bus_id = 0,                                     \
         .num_data_lanes = 1,                             \
-        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,     \
+        .phy_clk_src = 0,                                \
         .lane_bit_rate_mbps = 480,                       \
     }
 


### PR DESCRIPTION
The dphy pll reference clock got changed in esp32p4 version 3.0. The real default clock source are different between major versions.

But using `0` as default can work for all P4 version, the driver will select a default clock source automatically.
