### PR TITLE
fix(esp_lvgl_port): Change minimum IDF version

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## 2.6.2
+
+- Changed minimum IDF version to IDF5.1
+
 ## 2.6.1
+
 ### Features
 - Added option to place LVGL task stack to external RAM
 - Fixed callback for RGB display for IDF6

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,8 +1,8 @@
-version: "2.6.1"
+version: "2.6.2"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:
-  idf: ">=4.4"
+  idf: ">=5.1"
   lvgl/lvgl:
     version: ">=8,<10"
     public: true


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
- Changed minimum IDF version of LVGL port to IDF5.1
- Closes #643 