### PR TITLE
ci(hts221): Do not test deprecated component

### DIFF
--- a/bsp/esp32_c3_lcdkit/esp32_c3_lcdkit.c
+++ b/bsp/esp32_c3_lcdkit/esp32_c3_lcdkit.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "esp_timer.h"
 #include "driver/gpio.h"
 #include "driver/ledc.h"
 #include "driver/spi_master.h"

--- a/bsp/esp32_c3_lcdkit/idf_component.yml
+++ b/bsp/esp32_c3_lcdkit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.0.3"
 description: Board Support Package (BSP) for esp32_c3_lcdkit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_c3_lcdkit
 

--- a/bsp/esp32_p4_function_ev_board/CMakeLists.txt
+++ b/bsp/esp32_p4_function_ev_board/CMakeLists.txt
@@ -6,10 +6,14 @@ else()
     set(PRIV_REQ "")
 endif()
 
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_function_ev_board.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES ${REQ} fatfs
-    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram usb
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.0.2"
+version: "5.0.3"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 
@@ -27,6 +27,12 @@ dependencies:
   espressif/esp_lcd_lt8912b:
     version: ">=0.1.1,<1.0.0"
     override_path: "../../components/lcd/esp_lcd_lt8912b"
+
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
 
 examples:
   - path: ../../examples/display

--- a/bsp/esp32_s3_usb_otg/CMakeLists.txt
+++ b/bsp/esp32_s3_usb_otg/CMakeLists.txt
@@ -6,10 +6,14 @@ else()
     set(PRIV_REQ "")
 endif()
 
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_usb_otg.c" "esp32_s3_usb_otg_idf5.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES ${REQ} fatfs esp_adc
-    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram usb
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_s3_usb_otg/idf_component.yml
+++ b/bsp/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.3"
+version: "2.0.4"
 description: Board Support Package (BSP) for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg
 
@@ -19,6 +19,12 @@ dependencies:
     version: "^2"
     public: true
     override_path: "../../components/esp_lvgl_port"
+
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
 
 examples:
   - path: ../../examples/display

--- a/components/mpu6050/README.md
+++ b/components/mpu6050/README.md
@@ -1,29 +1,31 @@
 # MPU6050 Driver Component
 
 [![Component Registry](https://components.espressif.com/components/espressif/mpu6050/badge.svg)](https://components.espressif.com/components/espressif/mpu6050)
-![maintenance-status](https://img.shields.io/badge/maintenance-passively--maintained-yellowgreen.svg)
+![maintenance-status](https://img.shields.io/badge/maintenance-as--is-yellow.svg)
+
+:warning: **MPU6050 component is provided as-is with no further development and compatibility maintenance**
 
 C driver for Invensense MPU6050 6-axis gyroscope and accelerometer based on I2C communication.
 
 ## Features
 
-- Get 3-axis accelerometer and 3-axis gyroscope data, either raw or as floating point values. 
+- Get 3-axis accelerometer and 3-axis gyroscope data, either raw or as floating point values.
 - Read temperature from MPU6050 internal temperature sensor.
 - Configure gyroscope and accelerometer sensitivity.
 - MPU6050 power down mode.
-- Support for MPU6050 interrupt generation when data ready (occurs each time a write to all sensor data registers has been completed).  
+- Support for MPU6050 interrupt generation when data ready (occurs each time a write to all sensor data registers has been completed).
 
 ## Important Notes
 
 - Keep in mind that MPU6050 I2C address depends on the level of its AD0 pin (9) (0x68 when low, 0x69 when high).
-- In order to receive MPU6050 interrupts, its INT pin (12) must be conneced to a GPIO on the ESP32. 
+- In order to receive MPU6050 interrupts, its INT pin (12) must be conneced to a GPIO on the ESP32.
 
 ## Limitations
 
 - Only I2C communication is supported.
 - Driver has not been tested with MPU 6000 yet.
 - 9-axis support through MPU6050 I2C aux is not supported.
-- If MPU6050 interrupts are used, it is recommended to not read data using I2C directly from the ISR. 
+- If MPU6050 interrupts are used, it is recommended to not read data using I2C directly from the ISR.
 
 ## Get Started
 

--- a/test_apps/.build-test-rules.yml
+++ b/test_apps/.build-test-rules.yml
@@ -6,9 +6,5 @@ test_apps/noglib:
 # Legacy common components test_app: Build for changes in components which do not have their own test_app or example
 test_apps/components:
   depends_filepatterns:
-    - "components/fbm320/**"
-    - "components/hts221/**"
     - "components/lcd/esp_lcd_ra8875/**"
     - "components/lcd_touch/**"
-    - "components/mag3110/**"
-    - "components/mpu6050/**"

--- a/test_apps/components/CMakeLists.txt
+++ b/test_apps/components/CMakeLists.txt
@@ -10,15 +10,7 @@ set(EXTRA_COMPONENT_DIRS "../../components/lcd_touch")
 # Must be kept in sync with list in .build-test-rules.yml
 list(APPEND EXTRA_COMPONENT_DIRS
     "../../components/lcd/esp_lcd_ra8875"
-    "../../components/fbm320"
-    "../../components/hts221"
-    "../../components/mag3110"
-    "../../components/mpu6050"
     )
 
 include($ENV{IDF_PATH}/tools/cmake/version.cmake) # $ENV{IDF_VERSION} was added after v4.3...
-
-# Set the components to include the tests for.
-set(TEST_COMPONENTS mpu6050 mag3110 hts221 fbm320 CACHE STRING "List of components to test")
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp_bsp_test_app)


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Remove hts211 from CI for latest