### PR TITLE
feat(esp_bsp_devkit): Add support for ESP32-C3 and ESP32-C6 devkits

### DIFF
--- a/examples/generic_button_led/sdkconfig.esp32_c3_devkitm_1
+++ b/examples/generic_button_led/sdkconfig.esp32_c3_devkitm_1
@@ -1,0 +1,16 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32c3"
+
+# ESP32C3-DevKitM-1 Settings
+# Buttons
+CONFIG_BSP_BUTTONS_NUM=1
+CONFIG_BSP_BUTTON_1_TYPE_GPIO=y
+CONFIG_BSP_BUTTON_1_GPIO=9
+CONFIG_BSP_BUTTON_1_LEVEL=0
+# LEDs
+CONFIG_BSP_LEDS_NUM=1
+CONFIG_BSP_LED_TYPE_RGB=y
+CONFIG_BSP_LED_RGB_GPIO=8
+CONFIG_BSP_LED_RGB_BACKEND_RMT=y

--- a/examples/generic_button_led/sdkconfig.esp32_c6_devkitc_1
+++ b/examples/generic_button_led/sdkconfig.esp32_c6_devkitc_1
@@ -1,0 +1,16 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32c6"
+
+# ESP32C6-DevKitC-1 v1.2 Settings
+# Buttons
+CONFIG_BSP_BUTTONS_NUM=1
+CONFIG_BSP_BUTTON_1_TYPE_GPIO=y
+CONFIG_BSP_BUTTON_1_GPIO=9
+CONFIG_BSP_BUTTON_1_LEVEL=0
+# LEDs
+CONFIG_BSP_LEDS_NUM=1
+CONFIG_BSP_LED_TYPE_RGB=y
+CONFIG_BSP_LED_RGB_GPIO=8
+CONFIG_BSP_LED_RGB_BACKEND_RMT=y


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] CI passing

# Change description
- ~~Not tested on HW yet - I will test it soon in the office~~
- Closes #504 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add minimal `sdkconfig` files for `examples/generic_button_led` targeting ESP32-C3 and ESP32-C6 with 1 GPIO button and 1 RGB LED (RMT).
> 
> - **Examples**
>   - **`examples/generic_button_led`**:
>     - Add `sdkconfig.esp32_c3_devkitm_1` and `sdkconfig.esp32_c6_devkitc_1` defining:
>       - `CONFIG_IDF_TARGET` set to `esp32c3` and `esp32c6` respectively.
>       - 1 GPIO button: `GPIO9`, active level `0`.
>       - 1 RGB LED on `GPIO8` using RMT backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e07eb097d2684eb99356d62583cd70d0304100a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->