### PR TITLE
Add pytest to the SD card example

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -122,6 +122,7 @@ jobs:
           - "release-v5.5"
         runner:
           - example: "test_example_display"
+          - example: "test_example_sdcard"
           - example: "test_example_lvgl_demos"
           - example: "test_example_generic_button_led"
           - example: "test_example_lvgl_benchmark"

--- a/examples/display_sdcard/pytest_sdcard.py
+++ b/examples/display_sdcard/pytest_sdcard.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: CC0-1.0
+
+import pytest
+from pytest_embedded import Dut
+
+
+@pytest.mark.esp32_p4_function_ev_board
+@pytest.mark.esp32_s3_korvo_2
+def test_example_sdcard(dut: Dut) -> None:
+    dut.expect_exact('example: Testing of SD card passed!')


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] CI passing

# Change description
Added test run for the SD card example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pytest for the SD card example and includes it in the CI run matrix.
> 
> - **Tests**:
>   - Add `examples/display_sdcard/pytest_sdcard.py` with `test_example_sdcard` asserting `'example: Testing of SD card passed!'` and board markers.
> - **CI**:
>   - Update `.github/workflows/build-run-applications.yml` to include `test_example_sdcard` in the `run-target` job matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20e096d3db656c4b0c0098ad69c8fb9a4a76da05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->