### PR TITLE
fix(ci): Fixed noglib generating

### DIFF
--- a/.github/ci/bsp_noglib.py
+++ b/.github/ci/bsp_noglib.py
@@ -35,13 +35,14 @@ def select_bsp_config_no_graphic_lib(bsp_path):
 
 def remove_esp_lvgl_port(bsp_path):
     manager = ManifestManager(bsp_path, 'bsp')
+    deps = manager.manifest.dependencies
     try:
-        del manager.manifest_tree["dependencies"]["espressif/esp_lvgl_port"]
+        del deps["espressif/esp_lvgl_port"]
     except KeyError:
         print("{}: could not remove esp_lvgl_port".format(str(bsp_path)))
         return 1
     try:
-        del manager.manifest_tree["dependencies"]["lvgl/lvgl"]
+        del deps["lvgl/lvgl"]
     except KeyError:
         print("{}: no lvgl dependency found".format(str(bsp_path)))
     manager.manifest_tree["description"] = manager.manifest_tree["description"] + ' with no graphical library'
@@ -58,7 +59,7 @@ def remove_esp_lvgl_port(bsp_path):
 def remove_examples(bsp_path):
     manager = ManifestManager(bsp_path, 'bsp')
     try:
-        del manager.manifest_tree["examples"]
+        del manager.manifest.examples
     except KeyError:
         print("{}: no examples section found".format(str(bsp_path)))
         return 0

--- a/bsp/esp32_p4_eye/idf_component.yml
+++ b/bsp/esp32_p4_eye/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.0.0"
+version: "2.0.0~1"
 description: Board Support Package (BSP) for ESP32-P4-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_eye
 

--- a/bsp/esp32_p4_function_ev_board/README.md
+++ b/bsp/esp32_p4_function_ev_board/README.md
@@ -96,29 +96,29 @@ This BSP supports HDMI converter Lontium LT8912B. Follow these rules for using i
 
 ## LVGL Benchmark
 
-**DATE:** 27.10.2025 03:03
+**DATE:** 07.11.2025 09:03
 
 **LVGL version:** 9.4.0
 
 | Name | Avg. CPU | Avg. FPS | Avg. time | render time | flush time |
 | ---- | :------: | :------: | :-------: | :---------: | :--------: |
-| Empty screen | 55%  | 88  | 5  | 4  | 1  |
+| Empty screen | 61%  | 88  | 5  | 3  | 2  |
 | Moving wallpaper | 89%  | 71  | 10  | 7  | 3  |
-| Single rectangle | 23%  | 89  | 1  | 1  | 0  |
-| Multiple rectangles | 40%  | 90  | 2  | 2  | 0  |
-| Multiple RGB images | 23%  | 94  | 1  | 1  | 0  |
-| Multiple ARGB images | 52%  | 90  | 6  | 6  | 0  |
-| Rotated ARGB images | 77%  | 76  | 10  | 10  | 0  |
-| Multiple labels | 92%  | 61  | 14  | 13  | 1  |
-| Screen sized text | 99%  | 14  | 68  | 66  | 2  |
-| Multiple arcs | 97%  | 46  | 18  | 15  | 3  |
-| Containers | 31%  | 90  | 3  | 3  | 0  |
-| Containers with overlay | 94%  | 28  | 31  | 29  | 2  |
-| Containers with opa | 36%  | 91  | 5  | 5  | 0  |
-| Containers with opa_layer | 60%  | 72  | 13  | 13  | 0  |
-| Containers with scrolling | 97%  | 29  | 31  | 29  | 2  |
-| Widgets demo | 98%  | 17  | 50  | 48  | 2  |
-| All scenes avg. | 66%  | 65  | 16  | 15  | 1  |
+| Single rectangle | 23%  | 88  | 1  | 1  | 0  |
+| Multiple rectangles | 39%  | 90  | 2  | 2  | 0  |
+| Multiple RGB images | 31%  | 96  | 2  | 2  | 0  |
+| Multiple ARGB images | 58%  | 93  | 6  | 6  | 0  |
+| Rotated ARGB images | 87%  | 61  | 14  | 14  | 0  |
+| Multiple labels | 92%  | 61  | 12  | 12  | 0  |
+| Screen sized text | 99%  | 13  | 70  | 67  | 3  |
+| Multiple arcs | 98%  | 47  | 18  | 16  | 2  |
+| Containers | 29%  | 87  | 2  | 2  | 0  |
+| Containers with overlay | 88%  | 28  | 32  | 30  | 2  |
+| Containers with opa | 41%  | 89  | 4  | 4  | 0  |
+| Containers with opa_layer | 62%  | 72  | 12  | 12  | 0  |
+| Containers with scrolling | 96%  | 29  | 30  | 28  | 2  |
+| Widgets demo | 99%  | 17  | 49  | 48  | 1  |
+| All scenes avg. | 68%  | 64  | 15  | 15  | 0  |
 
 
 

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.1.0"
+version: "5.1.0~1"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
- Closes #677 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes noglib generator to edit manifest via `manager.manifest`, bumps BSP versions, and refreshes benchmark data.
> 
> - **CI**:
>   - Update `/.github/ci/bsp_noglib.py` to remove dependencies via `manager.manifest.dependencies` and examples via `manager.manifest.examples` instead of `manifest_tree`.
> - **BSP Versions**:
>   - Bump `bsp/esp32_p4_eye/idf_component.yml` to `"2.0.0~1"`.
>   - Bump `bsp/esp32_p4_function_ev_board/idf_component.yml` to `"5.1.0~1"`.
> - **Docs**:
>   - Refresh LVGL benchmark date and metrics in `bsp/esp32_p4_function_ev_board/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a60ba23cf88acbdb00458f4db445007b4c5db24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->