### PR TITLE
fix(ci): Fixed noglib tags and description generating

### DIFF
--- a/.github/ci/bsp_noglib.py
+++ b/.github/ci/bsp_noglib.py
@@ -45,12 +45,14 @@ def remove_esp_lvgl_port(bsp_path):
         del deps["lvgl/lvgl"]
     except KeyError:
         print("{}: no lvgl dependency found".format(str(bsp_path)))
-    manager.manifest_tree["description"] = manager.manifest_tree["description"] + ' with no graphical library'
+
+    manager.manifest.description = manager.manifest.description + ' with no graphical library'
 
     # Add 'noglib' tag
-    tags = manager.manifest_tree.get("tags", [])
-    tags.append("noglib")
-    manager.manifest_tree["tags"] = list(set(tags))  # make unique
+    tags = manager.manifest.tags or []
+    if "noglib" not in tags:
+        tags.append("noglib")
+    manager.manifest.tags = tags
 
     manager.dump()
     return 0

--- a/bsp/esp32_p4_eye/idf_component.yml
+++ b/bsp/esp32_p4_eye/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.0.0~1"
+version: "2.0.0~2"
 description: Board Support Package (BSP) for ESP32-P4-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_eye
 

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.1.0~1"
+version: "5.1.0~2"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [ ] CI passing

# Change description
- I forgot fix tags and description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes noglib script to properly update manifest description/tags and bumps versions of ESP32-P4 BSPs.
> 
> - **CI**:
>   - Update `/.github/ci/bsp_noglib.py` to modify `manager.manifest.description` and manage `manager.manifest.tags` (ensuring `"noglib"` is present without duplicates) after removing `esp_lvgl_port`/`lvgl` deps.
> - **BSP Versions**:
>   - Bump `bsp/esp32_p4_eye/idf_component.yml` to `"2.0.0~2"`.
>   - Bump `bsp/esp32_p4_function_ev_board/idf_component.yml` to `"5.1.0~2"`.}#endif енти
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 331d121a22837382f9342375f54e5bb931c06887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->