### PR TITLE
fix(ci): Small bugs in release checkeer

### DIFF
--- a/.github/ci/release_checker.py
+++ b/.github/ci/release_checker.py
@@ -55,7 +55,7 @@ for base_dir in target_dirs:
                 version = "N/A"
                 release_date = "?"
                 changes_since_version = "N/A"
-                commit_count = "?"
+                commit_count = "0"
 
                 if component_name in deprecated:
                     continue
@@ -70,7 +70,7 @@ for base_dir in target_dirs:
                 if version != "N/A":
                     try:
                         rel_yml_path = os.path.relpath(yml_path, repo_path).replace("\\", "/")
-                        log_output = run_git_command(["log", "-p", "--", rel_yml_path], cwd=repo_path)
+                        log_output = run_git_command(["log", "-p", "-m", "--", rel_yml_path], cwd=repo_path)
 
                         current_commit = None
                         current_date = None
@@ -142,7 +142,7 @@ for base_dir in target_dirs:
                                 changes_since_version = "✔️ No "
 
                             # count_output = run_git_command(["rev-list", f"{commit_hash}..HEAD", "--count", rel_component_path], cwd=repo_path)
-                            commit_count = len(changed_paths) if changed_paths else "?"
+                            commit_count = len(changed_paths) if changed_paths else "0"
 
                     except Exception as e:
                         print(f"Chyba: {e}")


### PR DESCRIPTION
- Number of commits defaults to "0" for nicer output
- Git log is invoked with `-m` to also process merge commits. This is important for:
    - Getting precise release date. The release happens after the commit is merged into master
    - Getting correct order of commits. Omitting 'merge commit' in the history can lead to incorrect order of commits, as they are sorted by their _creation time_, rather their _merge time_
