### PR TITLE
bsp(esp32_c3_lcdkit): bump led_strip version to 3.0.2

### DIFF
--- a/bsp/esp32_c3_lcdkit/idf_component.yml
+++ b/bsp/esp32_c3_lcdkit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.3"
+version: "2.0.4"
 description: Board Support Package (BSP) for esp32_c3_lcdkit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_c3_lcdkit
 
@@ -17,7 +17,7 @@ dependencies:
     override_path: "../../components/esp_lvgl_port"
 
   led_strip:
-    version: "^2"
+    version: "^3"
     public: true
 
   espressif/esp_lcd_gc9a01:


### PR DESCRIPTION
This should also fix the build issue: https://github.com/espressif/esp-bsp/actions/runs/20047585764/job/57496459620

Regression was introduced by this IDF change: https://github.com/espressif/esp-idf/commit/986481f616e98fcc4d5e0c0d74c64ade719a01f7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps esp32_c3_lcdkit BSP version and updates `led_strip` dependency to major version 3.
> 
> - **BSP config (`bsp/esp32_c3_lcdkit/idf_component.yml`)**:
>   - Bump `version` from `"2.0.3"` to `"2.0.4"`.
>   - Update dependency `led_strip` from `^2` to `^3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 357b72a5d4f39ab2b4c58ac1432508bcd74e8f04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->