### PR TITLE
Fix functional issues in the ICM42670 component

### DIFF
--- a/components/icm42670/CMakeLists.txt
+++ b/components/icm42670/CMakeLists.txt
@@ -4,4 +4,4 @@ else()
     set(REQ driver)
 endif()
 
-idf_component_register(SRCS "icm42670.c" INCLUDE_DIRS "include" REQUIRES ${REQ})
+idf_component_register(SRCS "icm42670.c" INCLUDE_DIRS "include" REQUIRES ${REQ} esp_timer)

--- a/components/icm42670/README.md
+++ b/components/icm42670/README.md
@@ -15,14 +15,13 @@ C driver for Invensense ICM42607/ICM42670 6-axis gyroscope and accelerometer bas
 ## Limitations
 
 - Only I2C communication is supported.
-- Driver has not been tested with ICM42670 yet.
 
 ## Get Started
 
 This driver, along with many other components from this repository, can be used as a package from [Espressif's IDF Component Registry](https://components.espressif.com). To include this driver in your project, run the following idf.py from the project's root directory:
 
 ```
-    idf.py add-dependency "espressif/icm42670==1.0.0"
+    idf.py add-dependency "espressif/icm42670==*"
 ```
 
 Another option is to manually create a `idf_component.yml` file. You can find more about using .yml files for components from [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).

--- a/components/icm42670/icm42670.c
+++ b/components/icm42670/icm42670.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -327,7 +327,7 @@ esp_err_t icm42670_get_temp_value(icm42670_handle_t sensor, float *value)
     ret = icm42670_get_temp_raw_value(sensor, &raw_value);
     ESP_RETURN_ON_ERROR(ret, TAG, "Get raw value error!");
 
-    *value = ((float)raw_value / 128.0) + 25.0;
+    *value = ((int16_t)raw_value / 128.0f) + 25.0f;
 
     return ESP_OK;
 }

--- a/components/icm42670/idf_component.yml
+++ b/components/icm42670/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.3"
+version: "2.0.4"
 description: I2C driver for ICM 42670 6-Axis MotionTracking
 url: https://github.com/espressif/esp-bsp/tree/master/components/icm42670
 dependencies:

--- a/components/icm42670/include/icm42670.h
+++ b/components/icm42670/include/icm42670.h
@@ -219,7 +219,7 @@ esp_err_t icm42670_get_gyro_sensitivity(icm42670_handle_t sensor, float *sensiti
  * @brief Read raw temperature measurements
  *
  * @param sensor object handle of icm42670
- * @param value raw temperature measurements
+ * @param value raw value of a temperature measurement in two's complement
  *
  * @return
  *     - ESP_OK Success


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [ ] CI passing

# Change description

- Fixed temperature reading
- Fixed complimentary filter implementation



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves measurement correctness and timing in the ICM42670 driver.
> 
> - Fixes temperature conversion by casting raw value to `int16_t` and adjusting constants in `icm42670_get_temp_value`
> - Reimplements `icm42670_complimentory_filter`:
>   - Uses `esp_timer_get_time()` for delta time and internal state tracking
>   - Corrects accelerometer roll/pitch angle calculations and integrates gyro with `ALPHA=0.97`
>   - Initializes filter on first measurement and persists previous angles
> - Cleans up driver state: removes `gettimeofday`/`struct timeval` usage and allocation/free logic
> - Adds `esp_timer` to component requirements in `CMakeLists.txt`
> - Updates docs: clarifies temp raw value comment; README dependency spec to `espressif/icm42670==*`
> - Bumps component version to `2.0.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9b8c5ed2b1f2993a5c4d8a0de04e68e9417fd5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->