### PR TITLE
ci(build): Set parallel count to 10, removed IDF 5.1, added IDF 6.0

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -41,16 +41,13 @@ jobs:
           - "release-v5.4"
           - "release-v5.3"
           - "release-v5.2"
-          - "release-v5.1"
-        parallel_index: [1, 2, 3, 4, 5]
+        parallel_index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
           # Default values for all versions
-          - parallel_count: 5
+          - parallel_count: 10
             allow_fail: false
           - idf_ver: "latest"
             allow_fail: true  # Do not fail CI, when fail "latest" build
-          - idf_ver: "release-v6.0" # TODO: Remove this section, when "release-v6.0" will be stable
-            allow_fail: true  # Do not fail CI, when fail "release-v6.0" build
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This repository provides **Board Support Packages (BSPs)** for various Espressif
 
 The following table shows the compatibility of this BSP with different ESP-IDF versions:
 
-| 4.x | 5.0 |         5.1        |         5.2        |         5.3        |         5.4        |         5.5        |
-| :-: | :-: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 4.x | 5.0 | 5.1 |         5.2        |         5.3        |         5.4        |         5.5        |         6.0        |
+| :-: | :-: | :-: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Supported Boards
 <!-- START_SUPPORTED_BOARDS -->

--- a/examples/.build-test-rules.yml
+++ b/examples/.build-test-rules.yml
@@ -3,16 +3,9 @@ examples:
   disable:
     - if: CONFIG_NAME in ["esp-box", "esp-box-lite", "esp32_azure_iot_kit", "esp32_s2_kaluga_kit"]
       reason: Do not build examples for deprecated BSPs
-    - if: (IDF_VERSION < "5.2.0") and CONFIG_NAME in ["esp_bsp_generic", "esp_bsp_devkit", "m5stack_core"]
-      reason: Example depends on BSP, which is supported only for IDF >= 5.2
     - if: (IDF_VERSION < "5.3.0") and CONFIG_NAME in ["esp-box-3", "esp32_s3_lcd_ev_board", "m5_atom_s3", "m5dial", "m5stack_core_2", "esp32_lyrat", "esp32_s3_korvo_1"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.3
     - if: (IDF_VERSION < "5.4.0") and CONFIG_NAME in ["m5stack_core_s3", "esp32_s3_korvo_2", "esp32_s3_eye", "esp32_p4_eye", "esp32_p4_function_ev_board", "m5stack_tab5"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.4
     - if: (IDF_VERSION >= "6.0.0") and CONFIG_NAME in ["esp32_lyrat"]
       reason: Example depends on BSP, which is supported only for IDF < 6.0 (LyraT incompatible Touch pad driver)
-
-examples/generic_button_led:
-  disable:
-    - if: IDF_VERSION < "5.2.0"
-      reason: Requires I2C Driver-NG which was introduced in v5.2


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Fix build CI on master - set parallel count to 10
- Removed IDF 5.1 from CI (updated in readme)
- Updated IDF 6.0 in CI (updated in readme)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns CI and docs with current ESP-IDF support and speeds up builds.
> 
> - In `.github/workflows/build-run-applications.yml`, expand `parallel_index` to 1–10 and set default `parallel_count` to `10`; remove `5.1` from the matrix and include `6.0` (keep `latest` as allow-fail)
> - Update `README.md` compatibility table: mark `5.1` unsupported and add `6.0` as supported
> - Simplify `examples/.build-test-rules.yml`: drop IDF < `5.2` restrictions and the `examples/generic_button_led` special rule; keep `esp32_lyrat` disabled for IDF >= `6.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a7a0cf6b13ca6d0f6bf29139c2f95b92f64da11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->