### PR TITLE
fix(ci): Temporary disabled IDF 6 CI - due to esp32-camera component

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -54,6 +54,8 @@ jobs:
             allow_fail: false
           - idf_ver: "latest"
             allow_fail: true  # Do not fail CI, when fail "latest" build
+          - idf_ver: "release-v6.0"
+            allow_fail: true  # Do not fail CI, when fail "latest" build
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- I decided to disable IDF6 in CI - esp32-camera component will be fixed after two weeks (at the earliest) - We need to merge some PRs and I want to finish other camera boards migration soon. 