### PR TITLE
feat(lcd): ST7796 Add Sleep command support (BSP-780)

### DIFF
--- a/components/lcd/esp_lcd_st7796/esp_lcd_st7796_general.c
+++ b/components/lcd/esp_lcd_st7796/esp_lcd_st7796_general.c
@@ -32,6 +32,7 @@ static esp_err_t panel_st7796_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool
 static esp_err_t panel_st7796_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
 static esp_err_t panel_st7796_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
 static esp_err_t panel_st7796_disp_on_off(esp_lcd_panel_t *panel, bool off);
+static esp_err_t panel_st7796_disp_sleep(esp_lcd_panel_t *panel, bool sleep);
 
 typedef struct {
     esp_lcd_panel_t base;
@@ -141,6 +142,8 @@ esp_err_t esp_lcd_new_panel_st7796_general(const esp_lcd_panel_io_handle_t io,
 #else
     st7796->base.disp_on_off = panel_st7796_disp_on_off;
 #endif
+    st7796->base.disp_sleep = panel_st7796_disp_sleep;
+
     *ret_panel = &(st7796->base);
     ESP_LOGD(TAG, "new st7796 panel @%p", st7796);
 
@@ -367,5 +370,25 @@ static esp_err_t panel_st7796_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
         command = LCD_CMD_DISPOFF;
     }
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
+    return ESP_OK;
+}
+
+static esp_err_t panel_st7796_disp_sleep(esp_lcd_panel_t *panel, bool sleep)
+{
+    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
+    esp_lcd_panel_io_handle_t io = st7796->io;
+    int command;
+
+    if (sleep) {
+        command = LCD_CMD_SLPIN;
+    } else {
+        command = LCD_CMD_SLPOUT;
+    }
+
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
+
+    /* According to the ST7796 datasheet, a delay of at least 120ms is required after sleep in/out commands */
+    vTaskDelay(pdMS_TO_TICKS(120));
+
     return ESP_OK;
 }

--- a/components/lcd/esp_lcd_st7796/esp_lcd_st7796_mipi.c
+++ b/components/lcd/esp_lcd_st7796/esp_lcd_st7796_mipi.c
@@ -143,6 +143,7 @@ esp_err_t esp_lcd_new_panel_st7796_mipi(const esp_lcd_panel_io_handle_t io,
     panel_handle->mirror = panel_st7796_mirror;
     panel_handle->invert_color = panel_st7796_invert_color;
     panel_handle->disp_on_off = panel_st7796_disp_on_off;
+    panel_handle->disp_sleep = panel_st7796_disp_sleep;
     panel_handle->user_data = st7796;
     *ret_panel = panel_handle;
     ESP_LOGD(TAG, "new st7796 panel @%p", st7796);
@@ -323,4 +324,23 @@ static esp_err_t panel_st7796_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
     return ESP_OK;
 }
+
+static esp_err_t panel_st7796_disp_sleep(esp_lcd_panel_t *panel, bool sleep)
+{
+    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
+    esp_lcd_panel_io_handle_t io = st7796->io;
+    int command;
+
+    if (sleep) {
+        command = LCD_CMD_SLPIN;
+    } else {
+        command = LCD_CMD_SLPOUT;
+    }
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
+
+    /* According to the ST7796 datasheet, a delay of at least 120ms is required after sleep in/out commands */
+    vTaskDelay(pdMS_TO_TICKS(120));
+    return ESP_OK;
+}
+
 #endif


### PR DESCRIPTION
# ST7796 Add Sleep command support

Add Sleep command support to ST7796

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `disp_sleep` panel op that sends standard ST7796 sleep in/out commands with a datasheet-required delay; existing init/draw logic is unchanged.
> 
> **Overview**
> Adds ST7796 sleep mode support by wiring up the `disp_sleep` panel operation for both the general and MIPI variants.
> 
> Implements `panel_st7796_disp_sleep()` to send `LCD_CMD_SLPIN`/`LCD_CMD_SLPOUT` and enforce a 120ms post-command delay per the datasheet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34fc5866be46d17247a833f7dbfa6ad8b48397f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->