### PR TITLE
fix(esp_lvgl_port): support CONFIG_LCD_RGB_ISR_IRAM_SAFE for RGB panels (BSP-787)

### DIFF
--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -319,7 +319,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
      * remains accessible when the cache is disabled during SPI flash operations. */
     lvgl_port_display_ctx_t *disp_ctx = heap_caps_malloc(sizeof(lvgl_port_display_ctx_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 #else
-    lvgl_port_display_ctx_t *disp_ctx = malloc(sizeof(lvgl_port_display_ctx_t));
+    lvgl_port_display_ctx_t *disp_ctx = heap_caps_malloc(sizeof(lvgl_port_display_ctx_t), MALLOC_CAP_DEFAULT);
 #endif
     ESP_GOTO_ON_FALSE(disp_ctx, ESP_ERR_NO_MEM, err, TAG, "Not enough memory for display context allocation!");
     memset(disp_ctx, 0, sizeof(lvgl_port_display_ctx_t));

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -82,8 +82,13 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
 static bool lvgl_port_flush_io_ready_callback(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata,
         void *user_ctx);
 #if CONFIG_IDF_TARGET_ESP32S3 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
+static IRAM_ATTR bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
+        const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx);
+#else
 static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
         const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx);
+#endif
 #endif
 #if (CONFIG_IDF_TARGET_ESP32P4 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
 static bool lvgl_port_flush_dpi_panel_ready_callback(esp_lcd_panel_handle_t panel_io,
@@ -195,10 +200,18 @@ lv_display_t *lvgl_port_add_disp_rgb(const lvgl_port_display_cfg_t *disp_cfg,
 #endif
         };
 
+        /* When LCD_RGB_ISR_IRAM_SAFE is enabled, the callback must be in IRAM and
+         * cannot call lv_display_get_driver_data() (which resides in flash).
+         * Pass disp_ctx directly as user_ctx to avoid flash access from ISR. */
+#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
+        void *cb_user_ctx = disp_ctx;
+#else
+        void *cb_user_ctx = disp_ctx->disp_drv;
+#endif
         if (rgb_cfg->flags.bb_mode && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 2))) {
-            ESP_ERROR_CHECK(esp_lcd_rgb_panel_register_event_callbacks(disp_ctx->panel_handle, &bb_cbs, disp_ctx->disp_drv));
+            ESP_ERROR_CHECK(esp_lcd_rgb_panel_register_event_callbacks(disp_ctx->panel_handle, &bb_cbs, cb_user_ctx));
         } else {
-            ESP_ERROR_CHECK(esp_lcd_rgb_panel_register_event_callbacks(disp_ctx->panel_handle, &vsync_cbs, disp_ctx->disp_drv));
+            ESP_ERROR_CHECK(esp_lcd_rgb_panel_register_event_callbacks(disp_ctx->panel_handle, &vsync_cbs, cb_user_ctx));
         }
 #else
         ESP_RETURN_ON_FALSE(false, NULL, TAG, "RGB is supported only on ESP32S3 and from IDF 5.0!");
@@ -509,6 +522,25 @@ static bool lvgl_port_flush_dpi_vsync_ready_callback(esp_lcd_panel_handle_t pane
 #endif
 
 #if CONFIG_IDF_TARGET_ESP32S3 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
+/* When LCD_RGB_ISR_IRAM_SAFE is enabled, this callback runs from IRAM.
+ * user_ctx is lvgl_port_display_ctx_t* to avoid calling lv_display_get_driver_data()
+ * which resides in flash and would crash when cache is disabled (e.g. during SPI flash ops). */
+static IRAM_ATTR bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
+        const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx)
+{
+    BaseType_t need_yield = pdFALSE;
+
+    lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)user_ctx;
+    assert(disp_ctx != NULL);
+
+    if (disp_ctx->trans_sem) {
+        xSemaphoreGiveFromISR(disp_ctx->trans_sem, &need_yield);
+    }
+
+    return (need_yield == pdTRUE);
+}
+#else
 static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
         const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx)
 {
@@ -525,6 +557,7 @@ static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t pane
 
     return (need_yield == pdTRUE);
 }
+#endif /* CONFIG_LCD_RGB_ISR_IRAM_SAFE */
 #endif
 #endif
 

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -82,13 +82,8 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
 static bool lvgl_port_flush_io_ready_callback(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata,
         void *user_ctx);
 #if CONFIG_IDF_TARGET_ESP32S3 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
-static IRAM_ATTR bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
-        const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx);
-#else
 static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
         const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx);
-#endif
 #endif
 #if (CONFIG_IDF_TARGET_ESP32P4 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
 static bool lvgl_port_flush_dpi_panel_ready_callback(esp_lcd_panel_handle_t panel_io,

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -313,7 +313,14 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
     }
 
     /* Display context */
+#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
+    /* When ISR IRAM safety is enabled, the display context is passed directly
+     * to the ISR callback as user_ctx. It must reside in internal RAM so it
+     * remains accessible when the cache is disabled during SPI flash operations. */
+    lvgl_port_display_ctx_t *disp_ctx = heap_caps_malloc(sizeof(lvgl_port_display_ctx_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+#else
     lvgl_port_display_ctx_t *disp_ctx = malloc(sizeof(lvgl_port_display_ctx_t));
+#endif
     ESP_GOTO_ON_FALSE(disp_ctx, ESP_ERR_NO_MEM, err, TAG, "Not enough memory for display context allocation!");
     memset(disp_ctx, 0, sizeof(lvgl_port_display_ctx_t));
     disp_ctx->io_handle = disp_cfg->io_handle;
@@ -532,7 +539,9 @@ static IRAM_ATTR bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_han
     BaseType_t need_yield = pdFALSE;
 
     lvgl_port_display_ctx_t *disp_ctx = (lvgl_port_display_ctx_t *)user_ctx;
-    assert(disp_ctx != NULL);
+    if (disp_ctx == NULL) {
+        return false;
+    }
 
     if (disp_ctx->trans_sem) {
         xSemaphoreGiveFromISR(disp_ctx->trans_sem, &need_yield);


### PR DESCRIPTION
## Problem

On ESP32-S3 with RGB LCD panels in bounce buffer mode, enabling
`CONFIG_LCD_RGB_ISR_IRAM_SAFE=y` causes a **LoadProhibited crash** at boot:


The root cause is that `lvgl_port_flush_rgb_vsync_ready_callback()` calls
`lv_display_get_driver_data()`, which resides in **flash**. When SPI flash
operations disable the cache, the ISR tries to execute from flash → crash.

Without `CONFIG_LCD_RGB_ISR_IRAM_SAFE`, the callback works but **DMA underruns**
can occur during flash operations, causing visible white horizontal lines on
the display (tearing artifacts).

## Solution

When `CONFIG_LCD_RGB_ISR_IRAM_SAFE` is enabled:
1. Mark the callback with `IRAM_ATTR`
2. Pass `disp_ctx` (already in SRAM) directly as `user_ctx` instead of
   `disp_drv` (`lv_display_t*`), avoiding the need to call
   `lv_display_get_driver_data()` from ISR context
3. Access `disp_ctx->trans_sem` directly (`xSemaphoreGiveFromISR` is always in IRAM)

When `CONFIG_LCD_RGB_ISR_IRAM_SAFE` is **not** set, behavior is 100% unchanged.

## Testing

- ESP32-S3 + ST7277 RGB 800×480 panel, bounce buffer mode, PSRAM canvas
- Verified no crash with `CONFIG_LCD_RGB_ISR_IRAM_SAFE=y`
- Verified white line artifacts eliminated during SPI flash operations
- Verified backward compatibility without the config option

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ISR callback wiring and memory placement for display contexts, which can impact stability on constrained targets if allocation/callback assumptions differ across IDF versions. Changes are gated by `CONFIG_LCD_RGB_ISR_IRAM_SAFE` and otherwise preserve existing behavior.
> 
> **Overview**
> Fixes ESP32-S3 RGB panel ISR crashes/tearing when `CONFIG_LCD_RGB_ISR_IRAM_SAFE` is enabled by making the RGB vsync/bounce-buffer callback IRAM-safe and avoiding flash-resident LVGL access.
> 
> When the config is on, RGB panel event callbacks now receive `disp_ctx` directly as `user_ctx`, `lvgl_port_flush_rgb_vsync_ready_callback()` is built with `IRAM_ATTR` and no longer calls `lv_display_get_driver_data()` from ISR context, and the display context allocation is forced into internal RAM via `heap_caps_malloc(..., MALLOC_CAP_INTERNAL)`; behavior is unchanged when the config is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b71d1f3ae5fefdecb983e5f94992dafcc79e088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->