### PR TITLE
fix(esp_lvgl_port): Put RGB vsync callback in IRAM when LCD_RGB_ISR_IRAM_SAFE=y

### DIFF
--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -43,6 +43,12 @@
 #define CONFIG_LV_DRAW_BUF_ALIGN 1
 #endif
 
+#if CONFIG_LCD_RGB_ISR_IRAM_SAFE
+#define LVGL_PORT_RGB_IRAM IRAM_ATTR
+#else
+#define LVGL_PORT_RBG_IRAM
+#endif
+
 static const char *TAG = "LVGL";
 
 /*******************************************************************************
@@ -509,7 +515,7 @@ static bool lvgl_port_flush_dpi_vsync_ready_callback(esp_lcd_panel_handle_t pane
 #endif
 
 #if CONFIG_IDF_TARGET_ESP32S3 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-static bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
+static LVGL_PORT_RGB_IRAM bool lvgl_port_flush_rgb_vsync_ready_callback(esp_lcd_panel_handle_t panel_io,
         const esp_lcd_rgb_panel_event_data_t *edata, void *user_ctx)
 {
     BaseType_t need_yield = pdFALSE;


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped -- **NO, do I need to do this for a small fix?**
- [ ] CI passing

# Change description
When `LCD_RGB_ISR_IRAM_SAFE=y`, RGB panel callbacks must be placed in IRAM, otherwise `lvgl_port_add_disp_rgb` fails due to `esp_lcd_rgb_panel_register_event_callbacks` refusing to accept callbacks outside of IRAM.

This patch places the `lvgl_port_flush_rgb_vsync_ready_callback` routine in IRAM when `LCD_RGB_ISR_IRAM_SAFE=y`.

Addresses e.g. #515 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ESP32S3 RGB panel ISR callback placement; incorrect attribute/macro handling could break builds or cause runtime issues depending on `CONFIG_LCD_RGB_ISR_IRAM_SAFE` and IDF version.
> 
> **Overview**
> Ensures the ESP32S3 RGB panel `on_vsync`/bounce-buffer completion callback (`lvgl_port_flush_rgb_vsync_ready_callback`) is annotated to run from IRAM when `CONFIG_LCD_RGB_ISR_IRAM_SAFE` is enabled, satisfying IDF requirements for ISR-safe RGB callbacks.
> 
> This introduces a compile-time macro to conditionally apply `IRAM_ATTR` to the callback so `esp_lcd_rgb_panel_register_event_callbacks` accepts the function under IRAM-safe configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70be5090e597701226c2ae22e01e1ea1384c679f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->