### PR TITLE
RFC: Noglib BSPs in menuconfig

### DIFF
--- a/bsp/esp_wrover_kit/Kconfig
+++ b/bsp/esp_wrover_kit/Kconfig
@@ -33,7 +33,7 @@ menu "Board Support Package"
     endmenu
 
     menu "uSD card - Virtual File System"
-        config BSP_uSD_FORMAT_ON_MOUNT_FAIL
+        config BSP_SD_FORMAT_ON_MOUNT_FAIL
             bool "Format uSD card if mounting fails"
             default n
             help
@@ -47,6 +47,13 @@ menu "Board Support Package"
 
     endmenu
     menu "Display"
+        config BSP_LVGL_INTEGRATION
+            bool "Build BSP with LVGL integration"
+            default y
+            help
+                When enabled, BSP headers and sources include LVGL and esp_lvgl_port.
+                Note: Run idf.py update-dependencies after changing this setting.
+
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
             int "LEDC channel index"
             default 1

--- a/bsp/esp_wrover_kit/idf_component.yml
+++ b/bsp/esp_wrover_kit/idf_component.yml
@@ -15,6 +15,8 @@ dependencies:
     version: "^2"
     public: true
     override_path: "../../components/esp_lvgl_port"
+    matches:
+      - if: "$CONFIG{BSP_LVGL_INTEGRATION} == True"
 
   button:
     version: "^4"

--- a/bsp/esp_wrover_kit/include/bsp/config.h
+++ b/bsp/esp_wrover_kit/include/bsp/config.h
@@ -1,16 +1,19 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
+#include "sdkconfig.h"
+
 /**************************************************************************************************
  * BSP configuration
  **************************************************************************************************/
-// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
-// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
-#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+/* LVGL integration: default on; disable via menuconfig (CONFIG_BSP_LVGL_INTEGRATION). */
+#if CONFIG_BSP_LVGL_INTEGRATION
 #define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#else
+#define BSP_CONFIG_NO_GRAPHIC_LIB (1)
 #endif


### PR DESCRIPTION
# Change description
This PR adds condition to `esp_lvgl_port` dependency on a new `BSP_LVGL_INTEGRATION` menuconfig symbol.
In the source code, already available `BSP_CONFIG_NO_GRAPHIC_LIB` macro is used to #ifdef the graphical library code.

User can convert a standard BSP to BSP_noglib with simple change in menuconfig and running `idf.py update-dependencies`

You can see the main advantage from the size of this diff; only minimal changes are required to make this work.

### Follow-ups
- Implement for all BSPs
- Update docs
- Remove old noglib CI
- Decide on default value of `BSP_LVGL_INTEGRATION`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes build-time configuration and dependency resolution (conditionally pulling `esp_lvgl_port`), which can affect compile/link outcomes across projects. Also introduces a new Kconfig toggle that may alter default binary contents and size.
> 
> **Overview**
> Adds a new `CONFIG_BSP_LVGL_INTEGRATION` Kconfig option (default *enabled*) that controls whether the BSP is built with LVGL support.
> 
> When disabled, the component manifest conditionally omits the `espressif/esp_lvgl_port` dependency and `bsp/config.h` derives `BSP_CONFIG_NO_GRAPHIC_LIB` from `sdkconfig` for `#ifdef`-based exclusion.
> 
> Renames the uSD “format on mount fail” Kconfig symbol to `BSP_SD_FORMAT_ON_MOUNT_FAIL` (aligning naming with the existing `CONFIG_BSP_SD_FORMAT_ON_MOUNT_FAIL` usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed743e527f2a5901046b5aed7fd61aaee0ad717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->