### PR TITLE
fix(ci): Disable idf plugin in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 python_files = pytest_*.py
 
 # set traceback to "short" to prevent the overwhelming tracebacks
-addopts = -s --embedded-services esp,idf --tb short
+addopts = -s --embedded-services esp,idf -p no:idf-ci --tb short
 markers =
   # env markers
   esp_box_3: esp-box-3 runner


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] CI passing

# Change description
Added an argument to pytest which fixes an issue with idf plugin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test configuration flag change; risk is limited to potentially altering pytest plugin behavior/coverage in CI.
> 
> **Overview**
> Disables the `idf-ci` pytest plugin by adding `-p no:idf-ci` to `pytest.ini` `addopts`, preventing that plugin from being auto-loaded during test runs (notably in CI with embedded services enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ac8fc31afdf580de1ce06dcd00bc2efb3e4924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->