### PR TITLE
Various small fixes

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -63,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get changed files
         if: github.event_name == 'pull_request' # This action is working only in pull-request (it fails in push to master)
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           separator: ';' # idf-build-apps expects files seprated with semicolon
 
@@ -99,7 +99,7 @@ jobs:
           echo "### ⚠️ Build failed for idf_ver=${{ matrix.idf_ver }}" >> $GITHUB_STEP_SUMMARY
           echo "This failure was ignored (continue-on-error enabled)." >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: github.repository_owner == 'espressif' # && needs.prepare.outputs.build_only == '0'
         with:
           name: app_binaries_${{ matrix.idf_ver }}_${{ matrix.parallel_index }}
@@ -158,13 +158,13 @@ jobs:
       image: espressif/idf:${{ matrix.idf_ver }}
       options: --privileged -v /dev/boards:/dev/boards/ # Privileged mode has access to serial ports
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: app_binaries_${{ matrix.idf_ver }}_*
           merge-multiple: true
       - name: Download latest results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: benchmark_*
           path: benchmark/
@@ -179,7 +179,7 @@ jobs:
           mkdir -p /tmp/pytest-embedded-cache-dummy
           pytest --suppress-no-test-exit-code --ignore-glob '*/managed_components/*' --ignore=.github --junit-xml=${{ env.TEST_RESULT_FILE }} -k "${{ matrix.runner.example }} and not test_example_display_sensors" -n auto ${{ env.PYTEST_BENCHMARK_IGNORE }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ env.TEST_RESULT_NAME }}
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test_results_*
           path: test_results

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,5 +12,5 @@ jobs:
     name: Build Doxygen documentation
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: mattnotmitt/doxygen-action@v1.12.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ on:
   push:
       branches:
       - master
-      
+
 permissions:
   pages: write
   id-token: write
@@ -26,7 +26,7 @@ jobs:
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -47,7 +47,7 @@ jobs:
           config_file: examples/.idf_build_apps.toml
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: built_files
           path: binaries/
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # all git history
 
@@ -72,7 +72,7 @@ jobs:
           python .github/ci/release_checker.py > site/release_checker.html
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_checker
           path: site/
@@ -93,13 +93,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download built files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: built_files
           path: binaries/
 
       - name: Download built files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release_checker
           path: site/

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - name: Install doxygen
       run: sudo apt-get install -y doxygen
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v5.2.0
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/squareline.yml
+++ b/.github/workflows/squareline.yml
@@ -16,12 +16,12 @@ jobs:
   create-squareline-packages:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Generate the packages
         run: |
           cd SquareLine
           python3 gen.py -o out_dir
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts
           path: SquareLine/out_dir/espressif/
@@ -31,7 +31,7 @@ jobs:
     needs: [ create-squareline-packages ]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: espressif

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -46,7 +46,7 @@ jobs:
           - m5stack_tab5
           - esp_vocat
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Prepare BSP examples
         run: |
@@ -65,7 +65,7 @@ jobs:
   upload_other_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Upload Other components
         uses: espressif/upload-components-ci-action@v2
         with:

--- a/.github/workflows/upload_component_noglib.yml
+++ b/.github/workflows/upload_component_noglib.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches:
       - master
-    paths: 
+    paths:
       - 'bsp/**'
   pull_request:
     types: [opened, reopened, synchronize]
-    paths: 
+    paths:
       - 'bsp/**'
 
 jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Upload noglib version of BSPs
         # TODO: Extend this part to all BSPs

--- a/bsp/esp32_s3_eye/idf_component.yml
+++ b/bsp/esp32_s3_eye/idf_component.yml
@@ -19,6 +19,7 @@ dependencies:
   espressif/esp_lvgl_port:
     version: "^2"
     public:  true
+    override_path: "../../components/esp_lvgl_port"
 
   esp_video:
     version: "~2.0"

--- a/examples/display_lvgl_benchmark/main/main.c
+++ b/examples/display_lvgl_benchmark/main/main.c
@@ -31,6 +31,52 @@ void app_main(void)
     };
     cfg.lvgl_port_cfg.task_stack = 10000;
     bsp_display_start_with_config(&cfg);
+#elif defined(BSP_BOARD_ESP_BOX_3)
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
+        .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
+#if CONFIG_BSP_LCD_DRAW_BUF_DOUBLE
+        .double_buffer = 1,
+#else
+        .double_buffer = 0,
+#endif
+        .flags = {
+            .buff_dma = true,
+            .buff_spiram = false,
+        }
+    };
+    cfg.lvgl_port_cfg.task_stack = 10000;
+    bsp_display_start_with_config(&cfg);
+#elif defined(BSP_BOARD_ESP32_S3_EYE)
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
+        .buffer_size = BSP_LCD_H_RES * CONFIG_BSP_LCD_DRAW_BUF_HEIGHT,
+#if CONFIG_BSP_LCD_DRAW_BUF_DOUBLE
+        .double_buffer = 1,
+#else
+        .double_buffer = 0,
+#endif
+        .flags = {
+            .buff_dma = true,
+            .buff_spiram = false,
+            .sw_rotate = false,
+        }
+    };
+    cfg.lvgl_port_cfg.task_stack = 10000;
+    bsp_display_start_with_config(&cfg);
+#elif defined(BSP_BOARD_M5DIAL) || defined(BSP_BOARD_M5STACK_CORE_S3)
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
+        .flags = {
+            .buff_dma = true,
+            .buff_spiram = false,
+        }
+    };
+    cfg.lvgl_port_cfg.task_stack = 10000;
+    bsp_display_start_with_config(&cfg);
+#else
     bsp_display_start();
 #endif
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] CI passing

# Change description
Added a missing LVGL port path to ESP32S3 EYE which sometimes causes the build to fail
Bumped versions of deprecating github actions
Fixed stack overflow in LVGL benchmark example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI action version bumps and small build/config fixes; minimal behavioral impact beyond improving build reliability and display init in an example.
> 
> **Overview**
> Modernizes CI workflows by bumping `actions/checkout`, `upload-artifact`, and `download-artifact` versions (plus `tj-actions/changed-files`) across build/test, docs, pages, and component-upload pipelines.
> 
> Fixes occasional ESP32-S3-EYE build failures by adding an `override_path` for the `espressif/esp_lvgl_port` dependency, and updates the `display_lvgl_benchmark` example to use board-specific `bsp_display_start_with_config()` settings (buffer sizing/flags) instead of a one-size-fits-all `bsp_display_start()` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4906cfe1b72b443bee278e1f9f96871acaad91dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->