### PR TITLE
let LV_COLOR_FORMAT_RGB565_SWAPPED be a valid color format

### DIFF
--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -280,6 +280,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
 
     /* Check supported display color formats */
     ESP_RETURN_ON_FALSE(disp_cfg->color_format == 0 || disp_cfg->color_format == LV_COLOR_FORMAT_RGB565
+                        || disp_cfg->color_format == LV_COLOR_FORMAT_RGB565_SWAPPED
                         || disp_cfg->color_format == LV_COLOR_FORMAT_RGB888 || disp_cfg->color_format == LV_COLOR_FORMAT_XRGB8888
                         || disp_cfg->color_format == LV_COLOR_FORMAT_ARGB8888
                         || disp_cfg->color_format == LV_COLOR_FORMAT_I1, NULL, TAG, "Not supported display color format!");
@@ -289,7 +290,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
     uint8_t color_bytes = lv_color_format_get_size(display_color_format);
     if (disp_cfg->flags.swap_bytes) {
         /* Swap bytes can be used only in RGB565 color format */
-        ESP_RETURN_ON_FALSE(display_color_format == LV_COLOR_FORMAT_RGB565, NULL, TAG,
+        ESP_RETURN_ON_FALSE(display_color_format == LV_COLOR_FORMAT_RGB565 || display_color_format == LV_COLOR_FORMAT_RGB565_SWAPPED, NULL, TAG,
                             "Swap bytes can be used only in display color format RGB565!");
     }
 


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
_Please describe your change here_

In "esp_lvgl_port" the colorspace to be used is set in `lvcl_port_display_cfg_t`.

To change the endian of the color space with some ICs (ie: ST77916) it is necessary to enable swapping.

This patch permits `LV_COLOR_FORMAT_RGB565_SWAPPED` to be a valid color space (set in `color_format`).
