### PR TITLE
added reset callback to esp_lcd_touch_point_data_t; implemented in cst816s

### DIFF
--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -280,6 +280,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
 
     /* Check supported display color formats */
     ESP_RETURN_ON_FALSE(disp_cfg->color_format == 0 || disp_cfg->color_format == LV_COLOR_FORMAT_RGB565
+                        || disp_cfg->color_format == LV_COLOR_FORMAT_RGB565_SWAPPED
                         || disp_cfg->color_format == LV_COLOR_FORMAT_RGB888 || disp_cfg->color_format == LV_COLOR_FORMAT_XRGB8888
                         || disp_cfg->color_format == LV_COLOR_FORMAT_ARGB8888
                         || disp_cfg->color_format == LV_COLOR_FORMAT_I1, NULL, TAG, "Not supported display color format!");
@@ -289,7 +290,7 @@ static lv_display_t *lvgl_port_add_disp_priv(const lvgl_port_display_cfg_t *disp
     uint8_t color_bytes = lv_color_format_get_size(display_color_format);
     if (disp_cfg->flags.swap_bytes) {
         /* Swap bytes can be used only in RGB565 color format */
-        ESP_RETURN_ON_FALSE(display_color_format == LV_COLOR_FORMAT_RGB565, NULL, TAG,
+        ESP_RETURN_ON_FALSE(display_color_format == LV_COLOR_FORMAT_RGB565 || display_color_format == LV_COLOR_FORMAT_RGB565_SWAPPED, NULL, TAG,
                             "Swap bytes can be used only in display color format RGB565!");
     }
 

--- a/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
+++ b/components/lcd_touch/esp_lcd_touch/include/esp_lcd_touch.h
@@ -40,12 +40,14 @@ typedef void (*esp_lcd_touch_interrupt_callback_t)(esp_lcd_touch_handle_t tp);
  * @brief Touch Configuration Type
  *
  */
-typedef struct {
+typedef struct esp_lcd_touch_config_s {
     uint16_t x_max; /*!< X coordinates max (for mirroring) */
     uint16_t y_max; /*!< Y coordinates max (for mirroring) */
 
     gpio_num_t rst_gpio_num;    /*!< GPIO number of reset pin */
     gpio_num_t int_gpio_num;    /*!< GPIO number of interrupt pin */
+
+    esp_err_t (*reset_cb)( struct esp_lcd_touch_config_s * );
 
     struct {
         unsigned int reset: 1;    /*!< Level of reset pin in reset */

--- a/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/esp_lcd_touch_cst816s.c
@@ -79,6 +79,8 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
             .pin_bit_mask = BIT64(cst816s->config.rst_gpio_num)
         };
         ESP_GOTO_ON_ERROR(gpio_config(&rst_gpio_config), err, TAG, "GPIO reset config failed");
+    } else if (cst816s->config.reset_cb ) {
+        ESP_GOTO_ON_ERROR( cst816s->config.reset_cb( &cst816s->config ), err, TAG, "reset callback failed");
     }
     /* Reset controller */
     ESP_GOTO_ON_ERROR(touch_cst816s_reset(cst816s), err, TAG, "Reset failed");


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [ ] Version of modified component bumped
- [ ] CI passing

# Change description

The existing esp_lcd_touch can only reset chips if the reset pin is connected to a primary GPIO.

This patch permits a reset callback to be specified (reset_cb in esp_lcd_touch_point_data_t) that will be called if defined and rst_gpio_num is GPIO_NUM_NC.

reset_cb has been implemented in esp_lcd_touch_cst816s.