### PR TITLE
feat(esp_bsp_devkit): Added support for ESP32C5, ESP32C61, ESP32H21, ESP32H4 and ESP32S31 into bsp_devkit and bsp_generic

### DIFF
--- a/bsp/esp_bsp_devkit/Kconfig
+++ b/bsp/esp_bsp_devkit/Kconfig
@@ -521,7 +521,7 @@ menu "Board Support Package (generic)"
 
     menu "uSD card - Virtual File System"
         menu "Pins"
-            depends on (IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32P4)
+            depends on SOC_SDMMC_USE_GPIO_MATRIX
             config BSP_SD_CLK
                 int "uSD GPIO CLK"
                 default -1
@@ -687,7 +687,23 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 30
-            # GPIOs 16/17 are always used by UART in examples
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32C61
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 29
 
         config ENV_GPIO_IN_RANGE_MAX
             int
@@ -705,7 +721,40 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 27
-            # GPIOs 23/24 are always used by UART in examples
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32H21
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 18
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32H4
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 39
 
         config ENV_GPIO_IN_RANGE_MAX
             int
@@ -757,6 +806,23 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 48
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32S31
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 62
 
         config ENV_GPIO_IN_RANGE_MAX
             int

--- a/bsp/esp_bsp_devkit/idf_component.yml
+++ b/bsp/esp_bsp_devkit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.2"
+version: "3.0.3"
 description: DevKit Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_devkit
 

--- a/bsp/esp_bsp_generic/Kconfig
+++ b/bsp/esp_bsp_generic/Kconfig
@@ -823,7 +823,7 @@ menu "Board Support Package (generic)"
 
     menu "uSD card - Virtual File System"
         menu "Pins"
-            depends on (IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32P4)
+            depends on SOC_SDMMC_USE_GPIO_MATRIX
             config BSP_SD_CLK
                 int "uSD GPIO CLK"
                 default -1
@@ -964,6 +964,23 @@ menu "Board Support Package (generic)"
             int
             default ENV_GPIO_RANGE_MAX
     endif
+    if IDF_TARGET_ESP32C5
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 28
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
     if IDF_TARGET_ESP32C6
         config ENV_GPIO_RANGE_MIN
             int
@@ -972,7 +989,23 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 30
-            # GPIOs 16/17 are always used by UART in examples
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32C61
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 29
 
         config ENV_GPIO_IN_RANGE_MAX
             int
@@ -990,7 +1023,40 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 27
-            # GPIOs 23/24 are always used by UART in examples
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32H21
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 18
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32H4
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 39
 
         config ENV_GPIO_IN_RANGE_MAX
             int
@@ -1042,6 +1108,23 @@ menu "Board Support Package (generic)"
         config ENV_GPIO_RANGE_MAX
             int
             default 48
+
+        config ENV_GPIO_IN_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+
+        config ENV_GPIO_OUT_RANGE_MAX
+            int
+            default ENV_GPIO_RANGE_MAX
+    endif
+    if IDF_TARGET_ESP32S31
+        config ENV_GPIO_RANGE_MIN
+            int
+            default 0
+
+        config ENV_GPIO_RANGE_MAX
+            int
+            default 62
 
         config ENV_GPIO_IN_RANGE_MAX
             int

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "3.1.0"
+version: "3.1.1"
 description: Generic Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
 


### PR DESCRIPTION

# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# description
- Added support for ESP32C5, ESP32C61, ESP32H21, ESP32H4 and ESP32S31 into bsp_devkit and bsp_generic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily Kconfig changes that affect which options are available and valid GPIO ranges across multiple targets; mis-specified ranges or dependencies could lead to invalid pin configs or build-time configuration issues on the newly added chips.
> 
> **Overview**
> Adds BSP Kconfig support for additional ESP-IDF targets (`ESP32C5`, `ESP32C61`, `ESP32H21`, `ESP32H4`, `ESP32S31`) by defining their valid GPIO min/max ranges (and corresponding in/out max values) in both `esp_bsp_devkit` and `esp_bsp_generic`.
> 
> Updates the uSD “Pins” menu to depend on `SOC_SDMMC_USE_GPIO_MATRIX` instead of a hardcoded target list, and bumps component versions (`esp_bsp_devkit` `3.0.2`→`3.0.3`, `esp_bsp_generic` `3.1.0`→`3.1.1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f78773602fd3767c831bfee8f9bd87f4e846f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->