### PR TITLE
ci(BSP Wall): Add ESP VoCat and M5Stack Tab5 to BSP Wall

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 import os
 import uuid
@@ -93,6 +93,14 @@ def pytest_generate_tests(metafunc):
                      '/dev/boards/esp32_p4_eye',
                      'build_esp32_p4_eye',
                      id='esp32_p4_eye'),
+        pytest.param('/dev/boards/esp_vocat',
+                     '/dev/boards/esp_vocat',
+                     'build_esp_vocat',
+                     id='esp_vocat'),
+        pytest.param('/dev/boards/m5stack_tab5',
+                     '/dev/boards/m5stack_tab5',
+                     'build_m5stack_tab5',
+                     id='m5stack_tab5'),
     ]
 
     # filter by markers

--- a/examples/display/pytest_display.py
+++ b/examples/display/pytest_display.py
@@ -21,6 +21,8 @@ from pytest_embedded import Dut
 @pytest.mark.m5stack_core_s3_se
 @pytest.mark.m5_atom_s3
 @pytest.mark.esp32_p4_eye
+@pytest.mark.esp_vocat
+@pytest.mark.m5stack_tab5
 def test_example_display(dut: Dut) -> None:
     dut.expect_exact('example: Display LVGL animation')
     dut.expect_exact('main_task: Returned from app_main()')

--- a/examples/display_camera_video/pytest_camera_video.py
+++ b/examples/display_camera_video/pytest_camera_video.py
@@ -9,6 +9,7 @@ from pytest_embedded import Dut
 @pytest.mark.esp32_s3_eye
 @pytest.mark.esp32_s3_korvo_2
 @pytest.mark.m5stack_core_s3
+@pytest.mark.m5stack_tab5
 def test_example_camera_video(dut: Dut) -> None:
     dut.expect_exact('example: Camera example running.')
     dut.expect_exact('main_task: Returned from app_main()')

--- a/examples/display_lvgl_demos/pytest_display_lvgl_demos.py
+++ b/examples/display_lvgl_demos/pytest_display_lvgl_demos.py
@@ -13,6 +13,8 @@ from pytest_embedded import Dut
 @pytest.mark.m5dial
 @pytest.mark.m5stack_core_s3
 @pytest.mark.m5stack_core_s3_se
+@pytest.mark.esp_vocat
+@pytest.mark.m5stack_tab5
 def test_example_lvgl_demos(dut: Dut) -> None:
     dut.expect_exact('app_main: Display LVGL demo')
     dut.expect_exact('main_task: Returned from app_main()')

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,9 @@ markers =
   esp_bsp_generic: esp32_s3_devkitc_1_1 runner
   esp32_s3_korvo_2: esp32_s3_korvo_2 runner
   m5_atom_s3: m5 Atom S3 runner
+  esp32_p4_eye: esp32_p4_eye runner
+  esp_vocat: esp_vocat runner
+  m5stack_tab5: m5stack_tab5 runner
 
 # log related
 log_cli = True


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Description
- Added ESP VoCat and M5Stack Tab5 to BSP Wall

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is CI/test selection wiring only, expanding coverage to two more boards without touching runtime/product code.
> 
> **Overview**
> Adds **ESP VoCat** and **M5Stack Tab5** to the BSP Wall pytest board matrix by registering new `pytest` markers in `pytest.ini`, adding them to `conftest.py` parametrization (including build dirs), and enabling the existing display/LVGL/camera example tests to run on these boards via new `@pytest.mark.*` annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd246d1418b5f088145fd52069dab406e9c05a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->