### PR TITLE
SH1107 new features and fixes

### DIFF
--- a/components/esp_lvgl_port/examples/i2c_oled/main/CMakeLists.txt
+++ b/components/esp_lvgl_port/examples/i2c_oled/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "i2c_oled_example_main.c" "lvgl_demo_ui.c"
     INCLUDE_DIRS "."
-    REQUIRES driver
+    REQUIRES driver esp_timer
 )

--- a/components/esp_lvgl_port/examples/i2c_oled/main/i2c_oled_example_main.c
+++ b/components/esp_lvgl_port/examples/i2c_oled/main/i2c_oled_example_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -101,6 +101,11 @@ void app_main(void)
     ESP_LOGI(TAG, "Install SSD1306 panel driver");
     ESP_ERROR_CHECK(esp_lcd_new_panel_ssd1306(io_handle, &panel_config, &panel_handle));
 #elif CONFIG_EXAMPLE_LCD_CONTROLLER_SH1107
+    esp_lcd_panel_sh1107_config_t sh1107_config = {
+        .contrast = 128,
+        .offset = 0x60,
+    };
+    panel_config.vendor_config = &sh1107_config;
     ESP_LOGI(TAG, "Install SH1107 panel driver");
     ESP_ERROR_CHECK(esp_lcd_new_panel_sh1107(io_handle, &panel_config, &panel_handle));
 #endif
@@ -126,7 +131,7 @@ void app_main(void)
         .vres = EXAMPLE_LCD_V_RES,
         .monochrome = true,
 #if LVGL_VERSION_MAJOR >= 9
-        .color_format = LV_COLOR_FORMAT_RGB565,
+        .color_format = LV_COLOR_FORMAT_I1,
 #endif
         .rotation = {
             .swap_xy = false,

--- a/components/esp_lvgl_port/examples/i2c_oled/main/idf_component.yml
+++ b/components/esp_lvgl_port/examples/i2c_oled/main/idf_component.yml
@@ -1,7 +1,10 @@
 dependencies:
   idf: ">=5.2"
-  lvgl/lvgl: "^8"
-  esp_lcd_sh1107: "^1"
+
+  esp_lcd_sh1107:
+    version: "^1"
+    override_path: "../../../../lcd/esp_lcd_sh1107"
+
   esp_lvgl_port:
     version: "*"
     override_path: "../../../"

--- a/components/esp_lvgl_port/examples/i2c_oled/sdkconfig.defaults
+++ b/components/esp_lvgl_port/examples/i2c_oled/sdkconfig.defaults
@@ -2,4 +2,6 @@
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #
 CONFIG_LV_USE_USER_DATA=y
-CONFIG_LV_COLOR_DEPTH_1=y
+
+# Enable this for LVGL8
+#CONFIG_LV_COLOR_DEPTH_1=y

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.0"
+version: "2.8.0~1"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/lcd/esp_lcd_sh1107/README.md
+++ b/components/lcd/esp_lcd_sh1107/README.md
@@ -18,6 +18,29 @@ You can add them to your project via `idf.py add-dependancy`, e.g.
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
 
+### Hardware Connection
+
+The connection between ESP Board and the LCD is as follows:
+
+```
+      ESP Board                       OLED LCD (I2C)
++------------------+              +-------------------+
+|              GND +--------------+ GND               |
+|                  |              |                   |
+|              3V3 +--------------+ VCC               |
+|                  |              |                   |
+|          I2C SDA +--------------+ DIN               |
+|                  |              |                   |
+|          I2C SCL +--------------+ CLK               |
+|                  |              |                   |
+|              3V3 +--------------+ CS                |
+|                  |              |                   |
+|              GND +--------------+ DC                |
+|                  |              |                   |
+|       3V3 / GPIO +--------------+ RST               |
++------------------+              +-------------------+
+```
+
 ## Usage
 
 For detailed usage, please go to [LCD documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/lcd.html).
@@ -39,9 +62,15 @@ esp_lcd_panel_io_i2c_config_t io_config = ESP_LCD_IO_I2C_SH1107_CONFIG();
 ESP_ERROR_CHECK(esp_lcd_new_panel_io_i2c(i2c_handle, &io_config, &io_handle));
 
 esp_lcd_panel_handle_t lcd_panel_handle = NULL;
+/* Custom configuration */
+esp_lcd_panel_sh1107_config_t sh1107_config = {
+    .contrast = 128,
+    .offset = 0x60,
+};
 esp_lcd_panel_dev_config_t panel_config = {
     .bits_per_pixel = 1,
     .reset_gpio_num = BOARD_DISP_I2C_RST,
+    .vendor_config = &sh1107_config,
 };
 ESP_ERROR_CHECK(esp_lcd_new_panel_sh1107(io_handle, &panel_config, &lcd_panel_handle));
 

--- a/components/lcd/esp_lcd_sh1107/esp_lcd_sh1107.c
+++ b/components/lcd/esp_lcd_sh1107/esp_lcd_sh1107.c
@@ -42,6 +42,8 @@ static esp_err_t panel_sh1107_disp_on_off(esp_lcd_panel_t *panel, bool off);
 typedef struct {
     esp_lcd_panel_t base;
     esp_lcd_panel_io_handle_t io;
+    uint8_t contrast;
+    uint8_t offset;
     int reset_gpio_num;
     bool reset_level;
     int x_gap;
@@ -57,6 +59,7 @@ esp_err_t esp_lcd_new_panel_sh1107(const esp_lcd_panel_io_handle_t io,
     sh1107_panel_t *sh1107 = NULL;
     ESP_GOTO_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
     ESP_GOTO_ON_FALSE(panel_dev_config->bits_per_pixel == 1, ESP_ERR_INVALID_ARG, err, TAG, "bpp must be 1");
+    esp_lcd_panel_sh1107_config_t *sh1107_spec_config = (esp_lcd_panel_sh1107_config_t *)panel_dev_config->vendor_config;
     sh1107 = calloc(1, sizeof(sh1107_panel_t));
     ESP_GOTO_ON_FALSE(sh1107, ESP_ERR_NO_MEM, err, TAG, "no mem for sh1107 panel");
 
@@ -72,6 +75,9 @@ esp_err_t esp_lcd_new_panel_sh1107(const esp_lcd_panel_io_handle_t io,
     sh1107->bits_per_pixel = panel_dev_config->bits_per_pixel;
     sh1107->reset_gpio_num = panel_dev_config->reset_gpio_num;
     sh1107->reset_level = panel_dev_config->flags.reset_active_high;
+    sh1107->contrast = (sh1107_spec_config != NULL
+                        && sh1107_spec_config->contrast != 0) ? sh1107_spec_config->contrast : 128;
+    sh1107->offset = (sh1107_spec_config != NULL) ? sh1107_spec_config->offset : 0x60;
     sh1107->base.del = panel_sh1107_del;
     sh1107->base.reset = panel_sh1107_reset;
     sh1107->base.init = panel_sh1107_init;
@@ -136,15 +142,13 @@ static const uint8_t vendor_specific_init[] = {
     0x2f,   /* 128 */
 
     0x20,   /* Set Memory addressing mode (0x20/0x21) */
+    0x00,
 
     0xA0,   /* Non-flipped horizontal */
     0xC7,   /* Non-flipped vertical */
 
     0xa8,   /* multiplex ratio */
     0x7f,   /* duty = 1/64 */
-
-    0xd3,   /* set display offset */
-    0x60,
 
     0xd5,   /* set osc division */
     0x51,
@@ -155,16 +159,12 @@ static const uint8_t vendor_specific_init[] = {
     0xdb,   /* set vcomh */
     0x35,
 
-    0xB0,   /* Set page address */
-
     0xDA,   /* Set com pins */
     0x12,
 
     0xa4,   /* output ram to display */
 
     0xa6,   /* normal / inverted colors */
-
-    0xFF, //END
 };
 
 static esp_err_t panel_sh1107_init(esp_lcd_panel_t *panel)
@@ -173,14 +173,20 @@ static esp_err_t panel_sh1107_init(esp_lcd_panel_t *panel)
     esp_lcd_panel_io_handle_t io = sh1107->io;
 
     // vendor specific initialization, it can be different between manufacturers
-    // should consult the LCD supplier for initialization sequence code
-    int cmd = 0;
-    while (vendor_specific_init[cmd] != 0xff) {
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
-            vendor_specific_init[cmd]
-        }, 1);
-        cmd++;
-    }
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, vendor_specific_init,
+                        sizeof(vendor_specific_init)), TAG, "io tx param init commands failed");
+
+    /* contrast control */
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        0x81, sh1107->contrast
+    }, 2), TAG, "io tx param contrast control failed");
+
+    /* offset control */
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        0xD3, sh1107->offset
+    }, 2), TAG, "io tx param offset control failed");
+
+    vTaskDelay(pdMS_TO_TICKS(200));
 
     return ESP_OK;
 }
@@ -223,19 +229,19 @@ static esp_err_t panel_sh1107_draw_bitmap(esp_lcd_panel_t *panel, int x_start, i
 
     for (int i = row_start; i < row_end; i++) {
         /* Start column */
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
             0x10 | column_high
-        }, 1);
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        }, 1), TAG, "io tx param column set failed");
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
             0x00 | column_low
-        }, 1);
+        }, 1), TAG, "io tx param column set failed");
         /* Page */
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
             0xB0 | i
-        }, 1);
+        }, 1), TAG, "io tx param page set failed");
 
         ptr = color_data + i * x_end;
-        esp_lcd_panel_io_tx_color(io, LCD_SH1107_I2C_RAM, (uint8_t *)ptr, size);
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_color(io, LCD_SH1107_I2C_RAM, (uint8_t *)ptr, size), TAG, "io tx color failed");
     }
 
     return ESP_OK;
@@ -247,13 +253,13 @@ static esp_err_t panel_sh1107_invert_color(esp_lcd_panel_t *panel, bool invert_c
     esp_lcd_panel_io_handle_t io = sh1107->io;
 
     if (invert_color_data) {
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
             (LCD_SH1107_PARAM_INVERT_COLOR)
-        }, 1);
+        }, 1), TAG, "io tx param LCD_SH1107_PARAM_INVERT_COLOR failed");
     } else {
-        esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
             (LCD_SH1107_PARAM_INVERT_COLOR | 0x01)
-        }, 1);
+        }, 1), TAG, "io tx param LCD_SH1107_PARAM_INVERT_COLOR failed");
     }
     return ESP_OK;
 }
@@ -272,12 +278,12 @@ static esp_err_t panel_sh1107_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool
         param_y = (LCD_SH1107_PARAM_MIRROR_Y | 0x08);
     }
 
-    esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
         param_x
-    }, 1);
-    esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+    }, 1), TAG, "io tx param mirror failed");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
         param_y
-    }, 1);
+    }, 1), TAG, "io tx param mirror failed");
 
     return ESP_OK;
 }
@@ -314,9 +320,9 @@ static esp_err_t panel_sh1107_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
         param = LCD_SH1107_PARAM_ONOFF;
     }
 
-    esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_SH1107_I2C_CMD, (uint8_t[]) {
         param
-    }, 1);
+    }, 1), TAG, "io tx param disp on/off failed");
 
     return ESP_OK;
 }

--- a/components/lcd/esp_lcd_sh1107/idf_component.yml
+++ b/components/lcd/esp_lcd_sh1107/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~1"
+version: "1.2.0"
 description: ESP LCD SH1107
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_sh1107
 dependencies:

--- a/components/lcd/esp_lcd_sh1107/include/esp_lcd_sh1107.h
+++ b/components/lcd/esp_lcd_sh1107/include/esp_lcd_sh1107.h
@@ -17,6 +17,23 @@ extern "C" {
 #endif
 
 /**
+ * @brief SH1107 configuration structure
+ *
+ * To be used as esp_lcd_panel_dev_config_t.vendor_config.
+ * See esp_lcd_new_panel_sh1107().
+ */
+typedef struct {
+    /**
+     * @brief Display's contrast (128(default) or 1~255)
+     */
+    uint8_t contrast;
+    /**
+     * @brief Display's offset (0x60(default) or 0~127)
+     */
+    uint8_t offset;
+} esp_lcd_panel_sh1107_config_t;
+
+/**
  * @brief Create LCD panel for model SH1107
  *
  * @param[in] io LCD panel IO handle
@@ -26,6 +43,23 @@ extern "C" {
  *          - ESP_ERR_INVALID_ARG   if parameter is invalid
  *          - ESP_ERR_NO_MEM        if out of memory
  *          - ESP_OK                on success
+ *
+ * @note The default panel size is 128x64.
+ * @note Use esp_lcd_panel_sh1107_config_t to set the correct size.
+ * Example usage:
+ * @code {c}
+ *
+ * esp_lcd_panel_sh1107_config_t sh1107_config = {
+ *     .height = 32
+ * };
+ * esp_lcd_panel_dev_config_t panel_config = {
+ *     <...>
+ *     .vendor_config = &sh1107_config
+ * };
+ *
+ * esp_lcd_panel_handle_t panel_handle = NULL;
+ * esp_lcd_new_panel_sh1107(io_handle, &panel_config, &panel_handle);
+ * @endcode
  */
 esp_err_t esp_lcd_new_panel_sh1107(const esp_lcd_panel_io_handle_t io,
                                    const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel);


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Description
- SH1107 new features and fixes
- Updated I2C monochome example in LVGL port

- Closes #583


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the SH1107 panel driver init sequence and adds new user-facing vendor configuration, which could affect display bring-up and rendering on existing hardware variants. Example/dependency tweaks are low risk but may change build behavior for the i2c_oled sample.
> 
> **Overview**
> Improves the `esp_lcd_sh1107` driver by introducing `esp_lcd_panel_sh1107_config_t` (passed via `vendor_config`) to configure **contrast** and **display offset**, and refactors initialization to send command blocks with consistent `ESP_RETURN_ON_ERROR` handling.
> 
> Updates the LVGL `i2c_oled` example to use the new SH1107 vendor config, set LVGL9 monochrome `color_format` to `LV_COLOR_FORMAT_I1`, adjust component dependencies/overrides, and bump component versions (`esp_lcd_sh1107` to `1.2.0`, `esp_lvgl_port` to `2.8.0~1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a05a7343c69a057331289caef12c389a3d8a47c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->