### PR TITLE
ci(idf): Add IDF6.1 to test matrix

### DIFF
--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -38,6 +38,7 @@ jobs:
       matrix:
         idf_ver:
           - "latest"
+          - "release-v6.1"
           - "release-v6.0"
           - "release-v5.5"
           - "release-v5.4"
@@ -49,8 +50,6 @@ jobs:
           - parallel_count: 10
             allow_fail: false
           - idf_ver: "latest"
-            allow_fail: true  # Do not fail CI, when fail "latest" build
-          - idf_ver: "release-v6.0"
             allow_fail: true  # Do not fail CI, when fail "latest" build
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This repository provides **Board Support Packages (BSPs)** for various Espressif
 
 The following table shows the compatibility of this BSP with different ESP-IDF versions:
 
-| 4.x | 5.0 | 5.1 |         5.2        |         5.3        |         5.4        |         5.5        |         6.0        |
-| :-: | :-: | :-: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 4.x | 5.0 | 5.1 |         5.2        |         5.3        |         5.4        |         5.5        |         6.0        |        6.1        |
+| :-: | :-: | :-: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Supported Boards
 <!-- START_SUPPORTED_BOARDS -->


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Change description
- Add IDF6.1 to test matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI matrix changes only; no application or BSP runtime code is modified.
> 
> **Overview**
> Adds **ESP-IDF 6.1** (`release-v6.1`) to the `build-run-applications` workflow matrix so examples and test apps are built in the `espressif/idf:release-v6.1` container alongside existing IDF versions.
> 
> The **Supported IDF versions** table in `README.md` gains a **6.1** column marked as supported (same as 5.2–6.0).
> 
> CI policy tweak: **`release-v6.0` no longer has `allow_fail: true`**, so a failing v6.0 build will fail the PR check (only `latest` remains allowed to fail with continue-on-error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22f6d9eccb365010a94b65f69c026eb6e2e046a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->