### PR TITLE
fix(esp_lvgl_port): Fixed callbacks for DPI by IDF update

### DIFF
--- a/components/esp_lvgl_port/CHANGELOG.md
+++ b/components/esp_lvgl_port/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.1
+
+### Fixes
+
+- Fixed callbacks for DPI by IDF update (`on_refresh_done` --> `on_frame_buf_complete`)
+
 ## 2.8.0
 
 ### Features

--- a/components/esp_lvgl_port/idf_component.yml
+++ b/components/esp_lvgl_port/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.0~1"
+version: "2.8.1"
 description: ESP LVGL port
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lvgl_port
 dependencies:

--- a/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl8/esp_lvgl_port_disp.c
@@ -130,7 +130,11 @@ lv_display_t *lvgl_port_add_disp_dsi(const lvgl_port_display_cfg_t *disp_cfg,
 #if (SOC_MIPI_DSI_SUPPORTED && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
         esp_lcd_dpi_panel_event_callbacks_t cbs = {0};
         if (dsi_cfg->flags.avoid_tearing) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+            cbs.on_frame_buf_complete = lvgl_port_flush_dpi_vsync_ready_callback;
+#else
             cbs.on_refresh_done = lvgl_port_flush_dpi_vsync_ready_callback;
+#endif
         } else {
             cbs.on_color_trans_done = lvgl_port_flush_dpi_panel_ready_callback;
         }

--- a/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
+++ b/components/esp_lvgl_port/src/lvgl9/esp_lvgl_port_disp.c
@@ -156,7 +156,11 @@ lv_display_t *lvgl_port_add_disp_dsi(const lvgl_port_display_cfg_t *disp_cfg,
 #if (SOC_MIPI_DSI_SUPPORTED && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
         esp_lcd_dpi_panel_event_callbacks_t cbs = {0};
         if (dsi_cfg->flags.avoid_tearing) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+            cbs.on_frame_buf_complete = lvgl_port_flush_dpi_vsync_ready_callback;
+#else
             cbs.on_refresh_done = lvgl_port_flush_dpi_vsync_ready_callback;
+#endif
         } else {
             cbs.on_color_trans_done = lvgl_port_flush_dpi_panel_ready_callback;
         }


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [ ] CI passing

# Description
- Fixed callbacks for DPI by IDF update (`on_refresh_done` --> `on_frame_buf_complete`)
