### PR TITLE
Match struct elements order in the default config define

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -96,7 +96,7 @@ jobs:
           path: |
             ${{ env.BENCHMARK_PROJECT_DIR }}/build_*/benchmark_*.json
             ${{ env.BENCHMARK_PROJECT_DIR }}/build_*/size.json
-            *.log
+            /tmp/pytest-embedded/**/*.log
       - name: Upload benchmark metrics
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/build-run-applications.yml
+++ b/.github/workflows/build-run-applications.yml
@@ -169,4 +169,4 @@ jobs:
           name: ${{ env.TEST_RESULT_NAME }}
           path: |
             ${{ env.TEST_RESULT_FILE }}
-            *.log
+            /tmp/pytest-embedded/**/*.log

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1~1"
+version: "1.1.1~2"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/include/esp_lcd_touch_cst816s.h
@@ -44,8 +44,8 @@ esp_err_t esp_lcd_touch_new_i2c_cst816s(const esp_lcd_panel_io_handle_t io, cons
  */
 #define ESP_LCD_TOUCH_IO_I2C_CST816S_CONFIG()             \
     {                                                     \
-        .scl_speed_hz = 100000,                           \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_CST816S_ADDRESS, \
+        .scl_speed_hz = 100000,                           \
         .on_color_trans_done = 0,                         \
         .user_ctx = 0,                                    \
         .control_phase_bytes = 1,                         \

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~1"
+version: "1.1.0~2"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/include/esp_lcd_touch_ft5x06.h
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/include/esp_lcd_touch_ft5x06.h
@@ -44,8 +44,8 @@ esp_err_t esp_lcd_touch_new_i2c_ft5x06(const esp_lcd_panel_io_handle_t io, const
  */
 #define ESP_LCD_TOUCH_IO_I2C_FT5x06_CONFIG()                \
     {                                                       \
-        .scl_speed_hz = 100000,                             \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_FT5x06_ADDRESS,    \
+        .scl_speed_hz = 100000,                             \
         .control_phase_bytes = 1,                           \
         .dc_bit_offset = 0,                                 \
         .lcd_cmd_bits = 8,                                  \

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~1"
+version: "1.1.0~2"
 description: ESP LCD Touch GT1151 - touch controller GT1151
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt1151/include/esp_lcd_touch_gt1151.h
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/include/esp_lcd_touch_gt1151.h
@@ -43,8 +43,8 @@ esp_err_t esp_lcd_touch_new_i2c_gt1151(const esp_lcd_panel_io_handle_t io, const
  */
 #define ESP_LCD_TOUCH_IO_I2C_GT1151_CONFIG()             \
     {                                                    \
-        .scl_speed_hz = 100000,                          \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_GT1151_ADDRESS, \
+        .scl_speed_hz = 100000,                          \
         .control_phase_bytes = 1,                        \
         .dc_bit_offset = 0,                              \
         .lcd_cmd_bits = 16,                              \

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0~2"
+version: "1.2.0~3"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/include/esp_lcd_touch_gt911.h
+++ b/components/lcd_touch/esp_lcd_touch_gt911/include/esp_lcd_touch_gt911.h
@@ -56,8 +56,8 @@ typedef struct {
  */
 #define ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG()             \
     {                                                   \
-        .scl_speed_hz = 100000,                         \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS, \
+        .scl_speed_hz = 100000,                         \
         .control_phase_bytes = 1,                       \
         .dc_bit_offset = 0,                             \
         .lcd_cmd_bits = 16,                             \

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0~1"
+version: "1.2.0~2"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_tt21100/include/esp_lcd_touch_tt21100.h
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/include/esp_lcd_touch_tt21100.h
@@ -44,8 +44,8 @@ esp_err_t esp_lcd_touch_new_i2c_tt21100(const esp_lcd_panel_io_handle_t io, cons
  */
 #define ESP_LCD_TOUCH_IO_I2C_TT21100_CONFIG()               \
     {                                                       \
-        .scl_speed_hz = 100000,                             \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_TT21100_ADDRESS,   \
+        .scl_speed_hz = 100000,                             \
         .control_phase_bytes = 1,                           \
         .dc_bit_offset = 0,                                 \
         .lcd_cmd_bits = 16,                                 \


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [ ] CI passing

# Change description
Fixes #797 by correcting the define order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Designated-initializer reordering is behavior-neutral; CI changes only affect which log files are uploaded.
> 
> **Overview**
> Reorders fields in the `ESP_LCD_TOUCH_IO_I2C_*_CONFIG()` macros for CST816S, FT5x06, GT1151, GT911, and TT21100 so **`.dev_addr` precedes `.scl_speed_hz`**, matching the underlying ESP LCD panel IO struct and addressing #797. Component versions are bumped for each affected touch driver.
> 
> CI artifact uploads in **benchmark** and **build-run-applications** workflows now collect **`/tmp/pytest-embedded/**/*.log`** instead of workspace `*.log`, so pytest-embedded logs are included in test artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e493b3f0e95f785950b336393b3cb1197a6e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->