### PR TITLE
Add BWP and performance mode API to BMI270

### DIFF
--- a/components/sensors/bmi270/idf_component.yml
+++ b/components/sensors/bmi270/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.2
+version: 1.1.0
 description: I2C driver for BMI270 inertial measurement unit
 url: https://github.com/espressif/esp-bsp/tree/master/components/bmi270
 tags:

--- a/components/sensors/bmi270/include/bmi270.h
+++ b/components/sensors/bmi270/include/bmi270.h
@@ -79,6 +79,28 @@ typedef enum {
     BMI270_GYR_RANGE_125_DPS
 } bmi270_gyro_range_e;
 
+typedef enum {
+    BMI270_ACC_BWP_OSR4_AVG1 = 0,
+    BMI270_ACC_BWP_OSR2_AVG2,
+    BMI270_ACC_BWP_NORM_AVG4,
+    BMI270_ACC_BWP_CIC_AVG8,
+    BMI270_ACC_BWP_RES_AVG16,
+    BMI270_ACC_BWP_RES_AVG32,
+    BMI270_ACC_BWP_RES_AVG64,
+    BMI270_ACC_BWP_RES_AVG128
+} bmi270_acce_bwp_e;
+
+typedef enum {
+    BMI270_GYR_BWP_OSR4 = 0,
+    BMI270_GYR_BWP_OSR2,
+    BMI270_GYR_BWP_NORM
+} bmi270_gyro_bwp_e;
+
+typedef enum {
+    BMI270_POWER_OPTIMIZED = 0,
+    BMI270_PERFORMANCE_OPTIMIZED
+} bmi270_perf_e;
+
 /**
  * @brief Driver interface configuration structure
  * @note The SPI interface is currently not supported
@@ -250,6 +272,66 @@ esp_err_t bmi270_set_acce_range(bmi270_handle_t *dev_handle, bmi270_acce_range_e
  *     - Or other errors from the underlying I2C driver
  */
 esp_err_t bmi270_set_gyro_range(bmi270_handle_t *dev_handle, bmi270_gyro_range_e range);
+
+/**
+ * @brief Set accelerometer bandwidth parameter
+ *
+ * @param[in]  dev_handle   Initialized BMI270 handle
+ * @param[in]  bwp          Accelerometer bandwidth parameter
+ *
+ * @return
+ *     - ESP_OK             Success
+ *     - Or other errors from the underlying I2C driver
+ */
+esp_err_t bmi270_set_acce_bwp(const bmi270_handle_t *dev_handle, bmi270_acce_bwp_e bwp);
+
+/**
+ * @brief Set accelerometer filter performance mode
+ *
+ * @param[in]  dev_handle   Initialized BMI270 handle
+ * @param[in]  perf         Accelerometer filter performance mode
+ *
+ * @return
+ *     - ESP_OK             Success
+ *     - Or other errors from the underlying I2C driver
+ */
+esp_err_t bmi270_set_acce_filter_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf);
+
+/**
+ * @brief Set gyroscope bandwidth parameter
+ *
+ * @param[in]  dev_handle   Initialized BMI270 handle
+ * @param[in]  bwp          Gyroscope bandwidth parameter
+ *
+ * @return
+ *     - ESP_OK             Success
+ *     - Or other errors from the underlying I2C driver
+ */
+esp_err_t bmi270_set_gyro_bwp(const bmi270_handle_t *dev_handle, bmi270_gyro_bwp_e bwp);
+
+/**
+ * @brief Set gyroscope noise performance mode
+ *
+ * @param[in]  dev_handle   Initialized BMI270 handle
+ * @param[in]  perf         Gyroscope noise performance mode
+ *
+ * @return
+ *     - ESP_OK             Success
+ *     - Or other errors from the underlying I2C driver
+ */
+esp_err_t bmi270_set_gyro_noise_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf);
+
+/**
+ * @brief Set gyroscope filter performance mode
+ *
+ * @param[in]  dev_handle   Initialized BMI270 handle
+ * @param[in]  perf         Gyroscope filter performance mode
+ *
+ * @return
+ *     - ESP_OK             Success
+ *     - Or other errors from the underlying I2C driver
+ */
+esp_err_t bmi270_set_gyro_filter_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf);
 
 #ifdef __cplusplus
 }

--- a/components/sensors/bmi270/include_priv/bmi270_priv.h
+++ b/components/sensors/bmi270/include_priv/bmi270_priv.h
@@ -20,6 +20,12 @@ extern "C" {
 #define BMI270_SOFT_RESET_TIME_MS           10
 #define BMI270_STATUS_CHECK_PERIOD_MS       50
 
+#define BMI270_ACC_BWP_POS                  4
+#define BMI270_ACC_FILTER_PERF_POS          7
+#define BMI270_GYR_BWP_POS                  4
+#define BMI270_GYR_NOISE_PERF_POS           6
+#define BMI270_GYR_FILTER_PERF_POS          7
+
 #define BMI270_CMD_SOFT_RESET               0xB6
 #define BMI270_STATUS_INIT_OK               0x01
 
@@ -27,6 +33,11 @@ extern "C" {
 #define BMI270_ACC_EN_MSK                   0x04
 #define BMI270_TEMP_EN_MSK                  0x08
 #define BMI270_ODR_MSK                      0xF0
+#define BMI270_ACC_BWP_MSK                  0x8F
+#define BMI270_ACC_FILTER_PERF_MSK          0x7F
+#define BMI270_GYR_BWP_MSK                  0xCF
+#define BMI270_GYR_NOISE_PERF_MSK           0xBF
+#define BMI270_GYR_FILTER_PERF_MSK          0x7F
 #define BMI270_GYR_RANGE_MSK                0xF8
 
 #define BMI270_CHIP_ID_REG                  0x00

--- a/components/sensors/bmi270/src/bmi270.c
+++ b/components/sensors/bmi270/src/bmi270.c
@@ -326,6 +326,93 @@ esp_err_t bmi270_set_gyro_range(bmi270_handle_t *dev_handle, bmi270_gyro_range_e
     return ESP_OK;
 }
 
+esp_err_t bmi270_set_acce_bwp(const bmi270_handle_t *dev_handle, bmi270_acce_bwp_e bwp)
+{
+    ESP_RETURN_ON_FALSE(dev_handle != NULL, ESP_ERR_INVALID_ARG, TAG, "Pointer to the device handle must not be NULL");
+
+    uint8_t data;
+
+    if (!dev_handle->initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_RETURN_ON_ERROR(read_register(dev_handle, BMI270_ACC_CONF_REG, &data, 1), TAG,
+                        "Failed to read accelerometer configuration");
+    data = (data & BMI270_ACC_BWP_MSK) | ((uint8_t)bwp << BMI270_ACC_BWP_POS);
+    ESP_RETURN_ON_ERROR(write_register(dev_handle, BMI270_ACC_CONF_REG, &data, 1), TAG,
+                        "Failed to configure accelerometer BWP");
+    return ESP_OK;
+}
+
+esp_err_t bmi270_set_acce_filter_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf)
+{
+    ESP_RETURN_ON_FALSE(dev_handle != NULL, ESP_ERR_INVALID_ARG, TAG, "Pointer to the device handle must not be NULL");
+
+    uint8_t data;
+
+    if (!dev_handle->initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    ESP_RETURN_ON_ERROR(read_register(dev_handle, BMI270_ACC_CONF_REG, &data, 1), TAG,
+                        "Failed to read accelerometer configuration");
+    data = (data & BMI270_ACC_FILTER_PERF_MSK) | ((uint8_t)perf << BMI270_ACC_FILTER_PERF_POS);
+    ESP_RETURN_ON_ERROR(write_register(dev_handle, BMI270_ACC_CONF_REG, &data, 1), TAG,
+                        "Failed to configure accelerometer filter performance mode");
+    return ESP_OK;
+}
+
+esp_err_t bmi270_set_gyro_bwp(const bmi270_handle_t *dev_handle, bmi270_gyro_bwp_e bwp)
+{
+    ESP_RETURN_ON_FALSE(dev_handle != NULL, ESP_ERR_INVALID_ARG, TAG, "Pointer to the device handle must not be NULL");
+
+    uint8_t data;
+
+    if (!dev_handle->initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_RETURN_ON_ERROR(read_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to read gyroscope configuration");
+    data = (data & BMI270_GYR_BWP_MSK) | ((uint8_t)bwp << BMI270_GYR_BWP_POS);
+    ESP_RETURN_ON_ERROR(write_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to configure gyroscope BWP");
+    return ESP_OK;
+}
+
+esp_err_t bmi270_set_gyro_noise_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf)
+{
+    ESP_RETURN_ON_FALSE(dev_handle != NULL, ESP_ERR_INVALID_ARG, TAG, "Pointer to the device handle must not be NULL");
+
+    uint8_t data;
+
+    if (!dev_handle->initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    ESP_RETURN_ON_ERROR(read_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to read gyroscope configuration");
+    data = (data & BMI270_GYR_NOISE_PERF_MSK) | ((uint8_t)perf << BMI270_GYR_NOISE_PERF_POS);
+    ESP_RETURN_ON_ERROR(write_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to configure gyroscope noise performance mode");
+    return ESP_OK;
+}
+
+esp_err_t bmi270_set_gyro_filter_perf(const bmi270_handle_t *dev_handle, bmi270_perf_e perf)
+{
+    ESP_RETURN_ON_FALSE(dev_handle != NULL, ESP_ERR_INVALID_ARG, TAG, "Pointer to the device handle must not be NULL");
+
+    uint8_t data;
+
+    if (!dev_handle->initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    ESP_RETURN_ON_ERROR(read_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to read gyroscope configuration");
+    data = (data & BMI270_GYR_FILTER_PERF_MSK) | ((uint8_t)perf << BMI270_GYR_FILTER_PERF_POS);
+    ESP_RETURN_ON_ERROR(write_register(dev_handle, BMI270_GYR_CONF_REG, &data, 1), TAG,
+                        "Failed to configure gyroscope filter performance mode");
+    return ESP_OK;
+}
+
 /*******************************************************************************
 * Private functions
 *******************************************************************************/


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [ ] CI passing

# Change description
Added bandwidth and filter performance API
Closes #792 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in sensor driver API with no changes to default init or data paths; risk is mainly misconfigured register values affecting IMU quality or power.
> 
> **Overview**
> Bumps the **bmi270** component to **1.1.0** and exposes optional tuning for accelerometer and gyroscope beyond existing ODR/range setters.
> 
> New public enums cover accelerometer bandwidth (`bmi270_acce_bwp_e`), gyro bandwidth (`bmi270_gyro_bwp_e`), and power vs performance (`bmi270_perf_e`). Five setters read-modify-write `BMI270_ACC_CONF_REG` / `BMI270_GYR_CONF_REG` with the same validation as other config helpers: **`bmi270_set_acce_bwp`**, **`bmi270_set_acce_filter_perf`**, **`bmi270_set_gyro_bwp`**, **`bmi270_set_gyro_noise_perf`**, and **`bmi270_set_gyro_filter_perf`**. Private bit masks and field positions were added to support those writes.
> 
> **`bmi270_start`** and **`bmi270_config_t`** are unchanged, so apps must call the new APIs explicitly when they want different filtering or performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42bc0fb5ffed3ef400b0a3c126bdd74d3f46f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->