### PR TITLE
bsp(esp32-s31-korvo-1): Added examples and support NoGlib

### DIFF
--- a/.github/workflows/upload_component_noglib.yml
+++ b/.github/workflows/upload_component_noglib.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Upload noglib version of BSPs
         # TODO: Extend this part to all BSPs
         env:
-          BSPs: "bsp/esp_wrover_kit bsp/esp32_s3_eye bsp/esp32_p4_function_ev_board bsp/m5stack_core_s3 bsp/m5stack_core_2 bsp/m5stack_core bsp/m5dial bsp/m5_atom_s3 bsp/esp-box-3 bsp/esp32_s3_lcd_ev_board bsp/esp32_s3_korvo_2 bsp/esp32_p4_eye bsp/m5stack_tab5 bsp/esp_vocat"
+          BSPs: "bsp/esp_wrover_kit bsp/esp32_s3_eye bsp/esp32_p4_function_ev_board bsp/m5stack_core_s3 bsp/m5stack_core_2 bsp/m5stack_core bsp/m5dial bsp/m5_atom_s3 bsp/esp-box-3 bsp/esp32_s3_lcd_ev_board bsp/esp32_s3_korvo_2 bsp/esp32_p4_eye bsp/m5stack_tab5 bsp/esp_vocat bsp/esp32_s31_korvo_1"
         run: |
           pip install idf-component-manager==2.* py-markdown-table --upgrade
           python .github/ci/bsp_noglib.py ${BSPs}
@@ -41,6 +41,7 @@ jobs:
             bsp/esp32_p4_eye_noglib;
             bsp/m5stack_tab5_noglib;
             bsp/esp_vocat_noglib;
+            bsp/esp32_s31_korvo_1_noglib;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
           dry_run: ${{ github.ref_name != 'master' || github.repository_owner != 'espressif' }}

--- a/bsp/esp32_s31_korvo_1/idf_component.yml
+++ b/bsp/esp32_s31_korvo_1/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0"
+version: "1.0.0~1"
 description: Board Support Package (BSP) for ESP32-S31-Korvo-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32-s31-korvo-1
 
@@ -41,3 +41,12 @@ dependencies:
   usb:
     version: "^1"
     public: true
+
+examples:
+  - path: ../../examples/display
+  - path: ../../examples/display_audio_photo
+  - path: ../../examples/display_camera_video
+  - path: ../../examples/display_lvgl_demos
+  - path: ../../examples/display_lvgl_benchmark
+  - path: ../../examples/display_sdcard
+  - path: ../../examples/display_usb_hid

--- a/examples/display_camera_video/pytest_camera_video.py
+++ b/examples/display_camera_video/pytest_camera_video.py
@@ -6,7 +6,7 @@ from pytest_embedded import Dut
 
 
 @pytest.mark.esp32_p4_eye
-@pytest.mark.esp32_s3_eye
+# @pytest.mark.esp32_s3_eye // Temporary disabled due to dead HW
 @pytest.mark.esp32_s3_korvo_2
 @pytest.mark.m5stack_core_s3
 @pytest.mark.m5stack_tab5


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

- [x] Version of modified component bumped
- [x] CI passing

# Description
- Added missing examples to esp32-s31-korvo-1 BSP component
- Add support for esp32-s31-korvo-1 NoGlib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and component metadata changes only; the pytest skip reduces flaky failures and does not alter runtime BSP code.
> 
> **Overview**
> Extends **ESP32-S31-Korvo-1** packaging so the board is published like other BSPs and discoverable with the shared display examples.
> 
> The **noglib** upload workflow now includes `bsp/esp32_s31_korvo_1` in the BSP build list and registers `bsp/esp32_s31_korvo_1_noglib` for the Espressif component registry. The Korvo-1 `idf_component.yml` is bumped to **`1.0.0~1`** and wires in seven shared example paths (display, audio/photo, camera video, LVGL demos/benchmark, SD card, USB HID).
> 
> CI for **`display_camera_video`** no longer runs on **esp32_s3_eye** (marker commented out) because that hardware is temporarily unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7779f33fd34cacc69582f799c77cbca77efd31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->