### PR TITLE
examples(generic_button_led): Add default sdkconfig for esp32_c3_devkit_rust_2

### DIFF
--- a/examples/generic_button_led/sdkconfig.esp32_c3_devkit_rust_2
+++ b/examples/generic_button_led/sdkconfig.esp32_c3_devkit_rust_2
@@ -1,0 +1,17 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32c3"
+CONFIG_BSP_SELECT_ESP_BSP_DEVKIT=y
+
+# ESP32-C3-DevKit-RUST-2 Settings
+# Buttons
+CONFIG_BSP_BUTTONS_NUM=1
+CONFIG_BSP_BUTTON_1_TYPE_GPIO=y
+CONFIG_BSP_BUTTON_1_GPIO=9
+CONFIG_BSP_BUTTON_1_LEVEL=0
+# LEDs
+CONFIG_BSP_LEDS_NUM=1
+CONFIG_BSP_LED_TYPE_RGB=y
+CONFIG_BSP_LED_RGB_GPIO=2
+CONFIG_BSP_LED_RGB_BACKEND_RMT=y


### PR DESCRIPTION

# ESP-BSP Pull Request checklist

- [ ] Version of modified component bumped
- [x] CI passing

# Description
_Please describe your change here_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only Kconfig defaults with no runtime or library logic changes.
> 
> **Overview**
> Adds **`sdkconfig.esp32_c3_devkit_rust_2`** so the generic button/LED example can be built for the **ESP32-C3-DevKit-RUST-2** without hand-editing Kconfig.
> 
> The defaults target **esp32c3**, select the generic BSP devkit profile, and wire **one GPIO button** (GPIO 9, active low) plus **one RGB LED** on GPIO 2 using the **RMT** backend—matching that board’s layout. Use it like other board presets via `SDKCONFIG_DEFAULTS=sdkconfig.esp32_c3_devkit_rust_2` when running `idf.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a29967c5f9201d3971cd8f0a8694bcf45c7587e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->