### PR TITLE
fix(esp32-s31-korvo-1): Corrected ADC button voltage thresholds

### DIFF
--- a/bsp/esp32_s31_korvo_1/esp32_s31_korvo_1.json
+++ b/bsp/esp32_s31_korvo_1/esp32_s31_korvo_1.json
@@ -206,16 +206,16 @@
             "BSP_BUTTON_ADC_CHANNEL": "ADC_CHANNEL_0",
             "BSP_BUTTON_1_NAME": "SET",
             "BSP_BUTTON_1_TYPE": "ADC",
-            "BSP_BUTTON_1_ADC_VALUE": "1870",
+            "BSP_BUTTON_1_ADC_VALUE": "344",
             "BSP_BUTTON_2_NAME": "MODE",
             "BSP_BUTTON_2_TYPE": "ADC",
-            "BSP_BUTTON_2_ADC_VALUE": "1340",
+            "BSP_BUTTON_2_ADC_VALUE": "743",
             "BSP_BUTTON_3_NAME": "VOLP",
             "BSP_BUTTON_3_TYPE": "ADC",
-            "BSP_BUTTON_3_ADC_VALUE": "819",
+            "BSP_BUTTON_3_ADC_VALUE": "1700",
             "BSP_BUTTON_4_NAME": "VOLM",
             "BSP_BUTTON_4_TYPE": "ADC",
-            "BSP_BUTTON_4_ADC_VALUE": "380"
+            "BSP_BUTTON_4_ADC_VALUE": "1218"
         },
         {
             "name": "LED",

--- a/bsp/esp32_s31_korvo_1/idf_component.yml
+++ b/bsp/esp32_s31_korvo_1/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0~2"
+version: "1.0.1"
 description: Board Support Package (BSP) for ESP32-S31-Korvo-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32-s31-korvo-1
 

--- a/bsp/esp32_s31_korvo_1/idf_component.yml
+++ b/bsp/esp32_s31_korvo_1/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0~1"
+version: "1.0.0~2"
 description: Board Support Package (BSP) for ESP32-S31-Korvo-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32-s31-korvo-1
 

--- a/bsp/esp32_s31_korvo_1/src/bsp_button.c
+++ b/bsp/esp32_s31_korvo_1/src/bsp_button.c
@@ -38,8 +38,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_SET,
-            .min = (185), // middle is 285
-            .max = (385)
+            .min = (244), // middle is 344
+            .max = (444)
         }
 
     },
@@ -49,8 +49,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_MODE,
-            .min = (671), // middle is 771
-            .max = (871)
+            .min = (643), // middle is 743
+            .max = (843)
         }
 
     },
@@ -60,8 +60,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_VOLP,
-            .min = (1550), // middle is 1650
-            .max = (1750)
+            .min = (1600), // middle is 1700
+            .max = (1800)
         }
 
     },
@@ -71,8 +71,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_VOLM,
-            .min = (1145), // middle is 1245
-            .max = (1345)
+            .min = (1118), // middle is 1218
+            .max = (1318)
         }
 
     },

--- a/bsp/esp32_s31_korvo_1/src/bsp_button.c
+++ b/bsp/esp32_s31_korvo_1/src/bsp_button.c
@@ -38,8 +38,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_SET,
-            .min = (1770), // middle is 1870
-            .max = (1970)
+            .min = (185), // middle is 285
+            .max = (385)
         }
 
     },
@@ -49,8 +49,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_MODE,
-            .min = (1240), // middle is 1340
-            .max = (1440)
+            .min = (671), // middle is 771
+            .max = (871)
         }
 
     },
@@ -60,8 +60,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_VOLP,
-            .min = (719), // middle is 819
-            .max = (919)
+            .min = (1550), // middle is 1650
+            .max = (1750)
         }
 
     },
@@ -71,8 +71,8 @@ static const bsp_button_config_t bsp_button_config[BSP_BUTTON_NUM] = {
             .adc_handle = &bsp_adc_handle,
             .adc_channel = ADC_CHANNEL_0,
             .button_index = BSP_BUTTON_VOLM,
-            .min = (280), // middle is 380
-            .max = (480)
+            .min = (1145), // middle is 1245
+            .max = (1345)
         }
 
     },


### PR DESCRIPTION
# esp32_s31_korvo_1: ADC button thresholds do not match the hardware

Board: ESP32-S31-Korvo-1 **V1.1**. Component `espressif/esp32_s31_korvo_1` v1.0.0~1,
also present on esp-bsp master (f57f4ed1). ESP-IDF master (v6.2.0), `button` v4.2.0.

## Symptom

Out of the box, one of the four buttons never reports an event, and the other three report
under the wrong names.

With all four buttons registered via `bsp_iot_button_create()` and callbacks on
`BUTTON_PRESS_DOWN`, pressing the buttons in silkscreen order SET, MODE, VOL-, VOL+ gives:

| pressed | reported as |
|---|---|
| SET | `BSP_BUTTON_VOLM` |
| MODE | `BSP_BUTTON_VOLP` |
| VOL- | `BSP_BUTTON_MODE` |
| VOL+ | *nothing* |

## Measurements

The four buttons share one resistor ladder on `ADC_CHANNEL_0`. Reading that channel
directly with `adc_oneshot_read()` while each button is held (idle reads 0):

| button | raw | after button_adc's conversion |
|---|---|---|
| SET | 316 | 285 |
| MODE | 849 | 771 |
| VOL- | 1370 | 1245 |
| VOL+ | 1815 | 1650 |

The conversion is the ESP32-S31 branch of `get_adc_voltage()` in
`components/button/button_adc.c` (calibration is unavailable on this target - the driver
logs *"ADC calibration is not supported, skip software calibration"*):

```c
#if CONFIG_IDF_TARGET_ESP32S31
voltage = (int32_t)adc_reading * 4 * 1000 / 4393 - 2;
```

## Two separate problems

### 1. The window-to-button assignment is inverted

This is independent of any scaling. The ladder ascends SET < MODE < VOL- < VOL+, but
`bsp_button_config[]` assigns windows that ascend VOLM < VOLP < MODE < SET. SET measures
lowest on the ladder yet is given the highest window (1770-1970), so it can never match
regardless of how raw values are converted.

### 2. The thresholds look like raw counts, not millivolts

The existing midpoints (380, 819, 1340, 1870) are close to the measured **raw** values
(316, 849, 1370, 1815), but `button_adc.c` compares against the **converted** value, which
is about 9% lower. Because the error scales with magnitude it exceeds the +/-100 window
half-width only at the top of the ladder: 1650 falls in the dead zone between MODE's max
(1440) and SET's min (1770), which is why VOL+ never fires. SET and VOL- clear their
window floors by just 5 mV (285 vs 280, 1245 vs 1240), so with
`CONFIG_ADC_BUTTON_SAMPLE_TIMES=1` (no averaging) those two are marginal even when they do
work.

## Proposed change

The branch changes the four windows to +/-100 around the converted measurements:

| button | min | max |
|---|---|---|
| SET | 185 | 385 |
| MODE | 671 | 871 |
| VOLM | 1145 | 1345 |
| VOLP | 1550 | 1750 |

Verified on hardware: each button pressed three times reports its own name, 12/12 events,
no misses; `BUTTON_LONG_PRESS_START` and `BUTTON_DOUBLE_CLICK` also work on all four.

## Caveats - please check before merging

- **Values come from a single V1.1 unit.** The ladder is resistor-defined so it should be
  consistent, but they have not been checked against a second board or against the
  schematic's nominal divider values. Deriving them from the schematic would be better
  than trusting my measurements.
- **The conversion formula itself may be the real bug.** `raw * 4000 / 4393` maps a
  full-scale 12-bit reading (4095) to about 3728 mV, which is higher than the supply. If
  that formula is wrong for ESP32-S31, the fix belongs in `button_adc.c` and these
  thresholds should stay in whatever unit was originally intended. I could not determine
  which side is authoritative, so please treat this branch as one of two options.
- Consider raising `CONFIG_ADC_BUTTON_SAMPLE_TIMES` above 1 for this board, or widening the
  windows, given how little headroom the original thresholds had.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Board-specific BSP constants only; no auth, networking, or shared infrastructure changes.
> 
> **Overview**
> Fixes broken **ADC resistor-ladder button** handling on ESP32-S31-Korvo-1 V1.1 by aligning BSP thresholds with values the `button_adc` driver actually compares (converted mV, not raw counts) and reordering windows so SET → MODE → VOL- → VOL+ match ascending ladder readings.
> 
> **`bsp_button.c`** updates each button’s `min`/`max` (±100 around new midpoints: 344, 743, 1700, 1218). **`esp32_s31_korvo_1.json`** mirrors those midpoints for code generation. Component version bumps to **1.0.1** in `idf_component.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f93ebf5e61965d032ab9b7b6c80e60e9bc0e06b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->