### PR TITLE
fix(lcd_touch): Require esp_lcd_touch when the component manager is off

### DIFF
--- a/components/lcd_touch/esp_lcd_touch_cst816s/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_cst816s.c" INCLUDE_DIRS "include" REQUIRES "driver" "esp_lcd")
+set(REQ "driver" "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_cst816s.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_cst816s/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1~2"
+version: "1.1.2"
 description: ESP LCD Touch CST816S - touch controller CST816S
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_cst816s
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_ft5x06.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+set(REQ "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_ft5x06.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_ft5x06/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~2"
+version: "1.1.1"
 description: ESP LCD Touch FT5x06 - touch controller FT5x06
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_ft5x06
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt1151/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_gt1151.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+set(REQ "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_gt1151.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt1151/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0~2"
+version: "1.1.1"
 description: ESP LCD Touch GT1151 - touch controller GT1151
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt1151
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_gt911/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_gt911/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_gt911.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+set(REQ "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_gt911.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_gt911/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0~3"
+version: "1.2.1"
 description: ESP LCD Touch GT911 - touch controller GT911
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_gt911
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_stmpe610.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+set(REQ "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_stmpe610.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_stmpe610/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.8"
+version: "1.0.9"
 description: ESP LCD Touch STMPE610 - touch controller STMPE610
 url: https://github.com/espressif/esp-bsp/tree/master/components/esp_lcd_touch_stmpe610
 dependencies:

--- a/components/lcd_touch/esp_lcd_touch_tt21100/CMakeLists.txt
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/CMakeLists.txt
@@ -1,1 +1,10 @@
-idf_component_register(SRCS "esp_lcd_touch_tt21100.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+set(REQ "esp_lcd")
+
+# esp_lcd_touch is declared in idf_component.yml, which is only acted upon by the
+# component manager. Add it explicitly when the component manager is disabled.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND REQ esp_lcd_touch)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_tt21100.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
+++ b/components/lcd_touch/esp_lcd_touch_tt21100/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0~2"
+version: "1.2.1"
 description: ESP LCD Touch TT21100 - touch controller TT21100
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_tt21100
 dependencies:


### PR DESCRIPTION
# ESP-BSP Pull Request checklist

> Note: For new BSPs create a PR with this [link](https://github.com/espressif/esp-bsp/compare/main...my-branch?quick_pull=1&template=pr_template_bsp.md).
- [x] Version of modified component bumped
- [ ] CI passing

# Change description
Every touch driver includes esp_lcd_touch.h but declares the dependency only in idf_component.yml, which nothing acts on when the component manager is disabled, leaving the include path unset and the build broken.

The requirement is added only in that case: with the component manager enabled the dependency is registered as espressif__esp_lcd_touch, so an unconditional REQUIRES esp_lcd_touch would name a component that does not exist in that path (the same split esp_lvgl_port already handles via BUILD_COMPONENTS).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-system dependency wiring only; no runtime or driver logic changes.
> 
> **Overview**
> Fixes builds of six LCD touch drivers when the IDF component manager is disabled. Those drivers include `esp_lcd_touch.h` but previously declared the dependency only in `idf_component.yml`, so include paths were missing without the manager.
> 
> Each driver's `CMakeLists.txt` now checks `IDF_COMPONENT_MANAGER` and adds `esp_lcd_touch` to `REQUIRES` only in that case (avoiding a name clash with the managed `espressif__esp_lcd_touch` component). Component versions are bumped accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df6ea55593668302db2127b6b41760d5d1b5ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->