### PR TITLE
fix(m5stack_core_2): Fully cut LCD backlight rail on Core2 v1.1 off

### DIFF
--- a/bsp/m5stack_core_2/idf_component.yml
+++ b/bsp/m5stack_core_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.2"
+version: "3.0.3"
 description: Board Support Package (BSP) for M5Stack Core2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/m5stack_core_2
 

--- a/bsp/m5stack_core_2/m5stack_core_2.c
+++ b/bsp/m5stack_core_2/m5stack_core_2.c
@@ -35,6 +35,7 @@ static const char *TAG = "M5Stack";
 /* AXP2101 register map differs from the AXP192 - these are AXP2101-only. */
 #define BSP_AXP2101_REG_ALDO_EN  0x90   // ALDO1~4 / BLDO1~2 enable
 #define BSP_AXP2101_ALDO2_BIT    0x02   // ALDO2 = LCD/touch reset rail (Core2 v1.1)
+#define BSP_AXP2101_BLDO1_BIT    0x10   // BLDO1 = LCD backlight rail (Core2 v1.1)
 #endif
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
@@ -130,8 +131,8 @@ static uint8_t read8bit(uint8_t sub_addr)
 // Like read8bit(), but propagates I2C read failures instead of silently
 // returning 0. Use this where a failed read must NOT be treated as a valid
 // register value (e.g. read-modify-write of a power rail control register,
-// where a bogus 0 would disable rails). AXP2101-only: it is only used by the
-// Core2 v1.1 LCD reset path below.
+// where a bogus 0 would disable rails). AXP2101-only: used by the Core2 v1.1
+// LCD reset path and the backlight rail control below.
 #if defined(CONFIG_BSP_PMU_AXP2101)
 static esp_err_t read8bit_checked(uint8_t sub_addr, uint8_t *out)
 {
@@ -542,6 +543,24 @@ esp_err_t bsp_display_brightness_set(int brightness_percent)
 
     ESP_LOGI(TAG, "Setting LCD backlight: %d%%", brightness_percent);
 #if defined(CONFIG_BSP_PMU_AXP2101)
+    // Reg 0x96 only sets the BLDO1 voltage, whose usable floor (~2.5 V) still
+    // lights the panel, so treat 0% as a rail cut (0x90 bit4) rather than a dim.
+    // read8bit_checked() so a failed read can't be seen as 0 and clear all rails.
+    const uint8_t aldo_en_reg = BSP_AXP2101_REG_ALDO_EN;
+    uint8_t aldo_ctrl = 0;
+    ESP_RETURN_ON_ERROR(read8bit_checked(aldo_en_reg, &aldo_ctrl), TAG,
+                        "Failed to read PMU reg 0x%02X", aldo_en_reg);
+    const uint8_t desired_en = (brightness_percent == 0)
+                               ? (uint8_t)(aldo_ctrl & (uint8_t)(~BSP_AXP2101_BLDO1_BIT))
+                               : (uint8_t)(aldo_ctrl | BSP_AXP2101_BLDO1_BIT);
+    if (desired_en != aldo_ctrl) {
+        const uint8_t bl_en[] = {aldo_en_reg, desired_en};
+        ESP_RETURN_ON_ERROR(i2c_master_transmit(axp2101_h, bl_en, sizeof(bl_en), 1000),
+                            TAG, "I2C write failed");
+    }
+    if (brightness_percent == 0) {
+        return ESP_OK;
+    }
     const uint8_t reg_val      = 20 + ((8 * brightness_percent) / 100);  // 0b00000 ~ 0b11100; under 20, it is too dark
     const uint8_t lcd_bl_val[] = {0x96, reg_val};                        // AXP BLDO1 voltage
     ESP_RETURN_ON_ERROR(i2c_master_transmit(axp2101_h, lcd_bl_val, sizeof(lcd_bl_val), 1000),


### PR DESCRIPTION
## Description

On the M5Stack Core2 v1.1 (AXP2101 PMU) the LCD backlight is driven by the **BLDO1** rail, and `bsp_display_brightness_set()` controls brightness by writing the BLDO1 output **voltage** (reg `0x96`). That scale bottoms out at a non-zero floor:

```c
const uint8_t reg_val = 20 + ((8 * brightness_percent) / 100);  // under 20, it is too dark
```

So `bsp_display_backlight_off()` → `bsp_display_brightness_set(0)` still leaves BLDO1 at ~2.5 V and the panel stays **faintly lit** instead of off. On a device that dims/sleeps the screen after inactivity this is a visible glow and a screen burn-in risk.

## Fix

- `bsp_display_backlight_off()` now disables the **BLDO1 rail** itself by clearing bit4 of the ALDO/BLDO enable register (`0x90`), instead of just setting brightness to 0.
- `bsp_display_backlight_on()` re-enables BLDO1, then restores full brightness.
- The enable register is read via `read8bit_checked()` so a failed I²C read is **not** treated as `0` — otherwise the read-modify-write would clear every ALDO/BLDO enable bit and power down rails we depend on (e.g. ALDO2, the LCD/touch reset rail).

The **AXP192** (original Core2) path is unchanged. **CoreS3** is unaffected: its `bsp_display_brightness_set()` already special-cases `0%` by zeroing the backlight voltage.

## Depends on

This is stacked on top of #813 (Core2 v1.1 ALDO2 LCD-reset fix), which introduces the `read8bit_checked()` helper and the `BSP_AXP2101_REG_ALDO_EN` define this change reuses. Please merge #813 first; the diff here will narrow to just the backlight change once #813 lands (I'll rebase onto master).

## Testing

Verified on M5Stack Core2 v1.1 hardware: after this change the backlight fully turns off (rail cut, panel completely dark) and turns back on cleanly, with no I²C errors on the shared AXP2101 handle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PMU power-rail control over I²C on a shared enable register; mitigated by checked reads and narrow BLDO1 bit masking, but a bad write could still affect display power.
> 
> **Overview**
> On **M5Stack Core2 v1.1** (AXP2101), `bsp_display_brightness_set()` no longer treats **0%** as “minimum BLDO1 voltage” only. The BLDO1 enable bit in PMU register **0x90** is cleared so the backlight rail is actually off; non-zero brightness re-enables BLDO1 and then writes reg **0x96** as before.
> 
> Adds **`BSP_AXP2101_BLDO1_BIT`** and uses **`read8bit_checked()`** for the enable register read-modify-write so an I²C failure cannot be mistaken for zero and wipe other ALDO/BLDO enables. **AXP192** behavior is unchanged. Component version bumps **3.0.2 → 3.0.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00df724cc4b8677e099a9b25a1f1c797e2d330ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->