### PR TITLE
fix(bsp): Replaced lv_disp_rotation_t with lv_display_rotation_t

### DIFF
--- a/bsp/esp-box-3/API.md
+++ b/bsp/esp-box-3/API.md
@@ -933,7 +933,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp-box-3/API.md
+++ b/bsp/esp-box-3/API.md
@@ -1218,7 +1218,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp-box-3/esp-box-3.c
+++ b/bsp/esp-box-3/esp-box-3.c
@@ -791,7 +791,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp-box-3/idf_component.yml
+++ b/bsp/esp-box-3/idf_component.yml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.2.0~1
 description: Board Support Package (BSP) for ESP32-S3-BOX-3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box-3
 

--- a/bsp/esp-box-3/include/bsp/esp-box-3.h
+++ b/bsp/esp-box-3/include/bsp/esp-box-3.h
@@ -582,7 +582,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp-box-lite/API.md
+++ b/bsp/esp-box-lite/API.md
@@ -997,7 +997,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp-box-lite/API.md
+++ b/bsp/esp-box-lite/API.md
@@ -762,7 +762,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp-box-lite/esp-box-lite.c
+++ b/bsp/esp-box-lite/esp-box-lite.c
@@ -430,7 +430,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp-box-lite/idf_component.yml
+++ b/bsp/esp-box-lite/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0~2"
+version: "2.1.0~3"
 description: Board Support Package (BSP) for ESP32-S3-BOX-Lite
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box-lite
 

--- a/bsp/esp-box-lite/include/bsp/esp-box-lite.h
+++ b/bsp/esp-box-lite/include/bsp/esp-box-lite.h
@@ -408,7 +408,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
 /** @} */ // end of display
 

--- a/bsp/esp-box/API.md
+++ b/bsp/esp-box/API.md
@@ -706,7 +706,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp-box/API.md
+++ b/bsp/esp-box/API.md
@@ -951,7 +951,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp-box/esp-box.c
+++ b/bsp/esp-box/esp-box.c
@@ -439,7 +439,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp-box/idf_component.yml
+++ b/bsp/esp-box/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "3.1.0~2"
+version: "3.1.0~3"
 description: Board Support Package (BSP) for ESP-BOX
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box
 

--- a/bsp/esp-box/include/bsp/esp-box.h
+++ b/bsp/esp-box/include/bsp/esp-box.h
@@ -409,7 +409,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
 /** @} */ // end of display
 

--- a/bsp/esp32_azure_iot_kit/API.md
+++ b/bsp/esp32_azure_iot_kit/API.md
@@ -912,7 +912,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_azure_iot_kit/API.md
+++ b/bsp/esp32_azure_iot_kit/API.md
@@ -735,7 +735,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_azure_iot_kit/esp32_azure_iot_kit.c
+++ b/bsp/esp32_azure_iot_kit/esp32_azure_iot_kit.c
@@ -449,7 +449,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return NULL;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_azure_iot_kit/idf_component.yml
+++ b/bsp/esp32_azure_iot_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.0~2"
+version: "3.0.0~3"
 description: Board Support Package (BSP) for ESP32-Azure-IoT-Kit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_azure_iot_kit
 

--- a/bsp/esp32_azure_iot_kit/include/bsp/esp32_azure_iot_kit.h
+++ b/bsp/esp32_azure_iot_kit/include/bsp/esp32_azure_iot_kit.h
@@ -418,7 +418,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
 /** @} */ // end of display
 

--- a/bsp/esp32_c3_lcdkit/API.md
+++ b/bsp/esp32_c3_lcdkit/API.md
@@ -945,7 +945,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_c3_lcdkit/API.md
+++ b/bsp/esp32_c3_lcdkit/API.md
@@ -594,7 +594,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_c3_lcdkit/idf_component.yml
+++ b/bsp/esp32_c3_lcdkit/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.1.0"
+version: "2.1.0~1"
 description: Board Support Package (BSP) for ESP32-C3-LCDKit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_c3_lcdkit
 

--- a/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
+++ b/bsp/esp32_c3_lcdkit/include/bsp/esp32_c3_lcdkit.h
@@ -329,7 +329,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_c3_lcdkit/src/esp32_c3_lcdkit.c
+++ b/bsp/esp32_c3_lcdkit/src/esp32_c3_lcdkit.c
@@ -462,7 +462,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_enc;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_p4_eye/API.md
+++ b/bsp/esp32_p4_eye/API.md
@@ -938,7 +938,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_p4_eye/API.md
+++ b/bsp/esp32_p4_eye/API.md
@@ -1214,7 +1214,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_p4_eye/idf_component.yml
+++ b/bsp/esp32_p4_eye/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "2.0.2"
+version: "2.0.2~1"
 description: Board Support Package (BSP) for ESP32-P4-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_eye
 

--- a/bsp/esp32_p4_eye/include/bsp/esp32_p4_eye.h
+++ b/bsp/esp32_p4_eye/include/bsp/esp32_p4_eye.h
@@ -552,7 +552,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_p4_eye/src/esp32_p4_eye.c
+++ b/bsp/esp32_p4_eye/src/esp32_p4_eye.c
@@ -717,7 +717,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_enc;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_p4_function_ev_board/API.md
+++ b/bsp/esp32_p4_function_ev_board/API.md
@@ -886,7 +886,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_stop**](#function-bsp_display_stop) (lv\_display\_t \*display) <br>_Deinitialize display._ |

--- a/bsp/esp32_p4_function_ev_board/API.md
+++ b/bsp/esp32_p4_function_ev_board/API.md
@@ -1228,7 +1228,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
+++ b/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c
@@ -1062,7 +1062,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_p4_function_ev_board/idf_component.yml
+++ b/bsp/esp32_p4_function_ev_board/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.2.3"
+version: "5.2.3~1"
 description: Board Support Package (BSP) for ESP32-P4 Function EV Board (preview)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_p4_function_ev_board
 

--- a/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
+++ b/bsp/esp32_p4_function_ev_board/include/bsp/esp32_p4_function_ev_board.h
@@ -504,7 +504,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_s2_kaluga_kit/API.md
+++ b/bsp/esp32_s2_kaluga_kit/API.md
@@ -927,7 +927,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_s2_kaluga_kit/API.md
+++ b/bsp/esp32_s2_kaluga_kit/API.md
@@ -745,7 +745,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display and graphics library._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
+++ b/bsp/esp32_s2_kaluga_kit/esp32_s2_kaluga_kit.c
@@ -415,7 +415,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return NULL;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_s2_kaluga_kit/idf_component.yml
+++ b/bsp/esp32_s2_kaluga_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.0.1~1"
+version: "5.0.1~2"
 description: Board Support Package (BSP) for ESP32-S2-Kaluga kit
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s2_kaluga_kit
 

--- a/bsp/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
+++ b/bsp/esp32_s2_kaluga_kit/include/bsp/esp32_s2_kaluga_kit.h
@@ -441,7 +441,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
 /** @} */ // end of display
 

--- a/bsp/esp32_s31_korvo_1/API.md
+++ b/bsp/esp32_s31_korvo_1/API.md
@@ -961,7 +961,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_s31_korvo_1/API.md
+++ b/bsp/esp32_s31_korvo_1/API.md
@@ -1343,7 +1343,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_s31_korvo_1/idf_component.yml
+++ b/bsp/esp32_s31_korvo_1/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.1"
+version: "1.0.1~1"
 description: Board Support Package (BSP) for ESP32-S31-Korvo-1
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32-s31-korvo-1
 

--- a/bsp/esp32_s31_korvo_1/include/bsp/esp32_s31_korvo_1.h
+++ b/bsp/esp32_s31_korvo_1/include/bsp/esp32_s31_korvo_1.h
@@ -598,7 +598,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_s31_korvo_1/src/bsp_display.c
+++ b/bsp/esp32_s31_korvo_1/src/bsp_display.c
@@ -304,7 +304,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_s3_eye/API.md
+++ b/bsp/esp32_s3_eye/API.md
@@ -1289,7 +1289,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_s3_eye/API.md
+++ b/bsp/esp32_s3_eye/API.md
@@ -938,7 +938,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_s3_eye/idf_component.yml
+++ b/bsp/esp32_s3_eye/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "6.0.0"
+version: "6.0.0~1"
 description: Board Support Package (BSP) for ESP32-S3-EYE
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_eye
 

--- a/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
+++ b/bsp/esp32_s3_eye/include/bsp/esp32_s3_eye.h
@@ -546,7 +546,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_s3_eye/src/bsp_display.c
+++ b/bsp/esp32_s3_eye/src/bsp_display.c
@@ -257,7 +257,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return NULL;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_s3_korvo_2/API.md
+++ b/bsp/esp32_s3_korvo_2/API.md
@@ -1322,7 +1322,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_s3_korvo_2/API.md
+++ b/bsp/esp32_s3_korvo_2/API.md
@@ -954,7 +954,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_s3_korvo_2/idf_component.yml
+++ b/bsp/esp32_s3_korvo_2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.0.0"
+version: "5.0.0~1"
 description: Board Support Package (BSP) for ESP32-S3-Korvo-2
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_korvo_2
 

--- a/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
+++ b/bsp/esp32_s3_korvo_2/include/bsp/esp32_s3_korvo_2.h
@@ -569,7 +569,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp32_s3_korvo_2/src/bsp_display.c
+++ b/bsp/esp32_s3_korvo_2/src/bsp_display.c
@@ -317,7 +317,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_s3_usb_otg/API.md
+++ b/bsp/esp32_s3_usb_otg/API.md
@@ -688,7 +688,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp32_s3_usb_otg/API.md
+++ b/bsp/esp32_s3_usb_otg/API.md
@@ -925,7 +925,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg.c
+++ b/bsp/esp32_s3_usb_otg/esp32_s3_usb_otg.c
@@ -513,7 +513,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return NULL;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_s3_usb_otg/idf_component.yml
+++ b/bsp/esp32_s3_usb_otg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.4"
+version: "2.0.4~1"
 description: Board Support Package (BSP) for ESP32-S3-USB-OTG
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg
 

--- a/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
+++ b/bsp/esp32_s3_usb_otg/include/bsp/esp32_s3_usb_otg.h
@@ -397,7 +397,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 
 /** @} */ // end of display
 

--- a/bsp/esp_bsp_generic/idf_component.yml
+++ b/bsp/esp_bsp_generic/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "3.1.1"
+version: "3.1.1~1"
 description: Generic Board Support Package (BSP)
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_bsp_generic
 

--- a/bsp/esp_bsp_generic/include/bsp/esp_bsp_generic.h
+++ b/bsp/esp_bsp_generic/include/bsp/esp_bsp_generic.h
@@ -340,7 +340,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif //CONFIG_BSP_DISPLAY_ENABLED
 /**************************************************************************************************
  *

--- a/bsp/esp_bsp_generic/src/esp_bsp_generic.c
+++ b/bsp/esp_bsp_generic/src/esp_bsp_generic.c
@@ -709,7 +709,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp_sensairshuttle/API.md
+++ b/bsp/esp_sensairshuttle/API.md
@@ -1057,7 +1057,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp_sensairshuttle/API.md
+++ b/bsp/esp_sensairshuttle/API.md
@@ -690,7 +690,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp_sensairshuttle/idf_component.yml
+++ b/bsp/esp_sensairshuttle/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.0"
+version: "1.0.0~1"
 description: Board Support Package (BSP) for ESP-SensairShuttle
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/sensairshuttle
 

--- a/bsp/esp_sensairshuttle/include/bsp/esp_sensairshuttle.h
+++ b/bsp/esp_sensairshuttle/include/bsp/esp_sensairshuttle.h
@@ -404,7 +404,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp_sensairshuttle/src/bsp_display.c
+++ b/bsp/esp_sensairshuttle/src/bsp_display.c
@@ -287,7 +287,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp_vocat/API.md
+++ b/bsp/esp_vocat/API.md
@@ -1264,7 +1264,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp_vocat/API.md
+++ b/bsp/esp_vocat/API.md
@@ -899,7 +899,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp_vocat/idf_component.yml
+++ b/bsp/esp_vocat/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.1.0"
+version: "1.1.0~1"
 description: Board Support Package (BSP) for ESP-VoCat
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_vocat
 

--- a/bsp/esp_vocat/include/bsp/esp_vocat.h
+++ b/bsp/esp_vocat/include/bsp/esp_vocat.h
@@ -540,7 +540,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/esp_vocat/src/bsp_display.c
+++ b/bsp/esp_vocat/src/bsp_display.c
@@ -336,7 +336,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp_wrover_kit/API.md
+++ b/bsp/esp_wrover_kit/API.md
@@ -631,7 +631,7 @@ Below are some of the most relevant predefined constants:
 |  lv\_indev\_t \* | [**bsp\_display\_get\_input\_dev**](#function-bsp_display_get_input_dev) (void) <br>_Get pointer to input device (touch, buttons, ...)._ |
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/esp_wrover_kit/API.md
+++ b/bsp/esp_wrover_kit/API.md
@@ -869,7 +869,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/esp_wrover_kit/esp_wrover_kit.c
+++ b/bsp/esp_wrover_kit/esp_wrover_kit.c
@@ -473,7 +473,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return NULL;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp_wrover_kit/idf_component.yml
+++ b/bsp/esp_wrover_kit/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.0.2~1"
 description: Board Support Package (BSP) for ESP-WROVER-KIT
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/esp_wrover_kit
 

--- a/bsp/esp_wrover_kit/include/bsp/esp_wrover_kit.h
+++ b/bsp/esp_wrover_kit/include/bsp/esp_wrover_kit.h
@@ -466,7 +466,7 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 /** @} */ // end of display
 
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0

--- a/bsp/m5stack_core_s3/API.md
+++ b/bsp/m5stack_core_s3/API.md
@@ -1343,7 +1343,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/m5stack_core_s3/API.md
+++ b/bsp/m5stack_core_s3/API.md
@@ -975,7 +975,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/m5stack_core_s3/idf_component.yml
+++ b/bsp/m5stack_core_s3/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "4.0.0"
+version: "4.0.0~1"
 description: Board Support Package (BSP) for M5Stack Core S3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/m5stack_core_s3
 

--- a/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
+++ b/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
@@ -564,7 +564,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/m5stack_core_s3/src/bsp_display.c
+++ b/bsp/m5stack_core_s3/src/bsp_display.c
@@ -274,7 +274,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/m5stack_tab5/API.md
+++ b/bsp/m5stack_tab5/API.md
@@ -1275,7 +1275,7 @@ _Rotate screen._
 ```c
 void bsp_display_rotate (
     lv_display_t *disp,
-    lv_disp_rotation_t rotation
+    lv_display_rotation_t rotation
 ) 
 ```
 

--- a/bsp/m5stack_tab5/API.md
+++ b/bsp/m5stack_tab5/API.md
@@ -903,7 +903,7 @@ Below are some of the most relevant predefined constants:
 |  bool | [**bsp\_display\_lock**](#function-bsp_display_lock) (uint32\_t timeout\_ms) <br>_Take LVGL mutex._ |
 |  esp\_err\_t | [**bsp\_display\_new**](#function-bsp_display_new) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, esp\_lcd\_panel\_handle\_t \*ret\_panel, esp\_lcd\_panel\_io\_handle\_t \*ret\_io) <br>_Create new display panel._ |
 |  esp\_err\_t | [**bsp\_display\_new\_with\_handles**](#function-bsp_display_new_with_handles) (const [**bsp\_display\_config\_t**](#struct-bsp_display_config_t) \*config, [**bsp\_lcd\_handles\_t**](#struct-bsp_lcd_handles_t) \*ret\_handles) <br>_Create new display panel._ |
-|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_disp\_rotation\_t rotation) <br>_Rotate screen._ |
+|  void | [**bsp\_display\_rotate**](#function-bsp_display_rotate) (lv\_display\_t \*disp, lv\_display\_rotation\_t rotation) <br>_Rotate screen._ |
 |  lv\_display\_t \* | [**bsp\_display\_start**](#function-bsp_display_start) (void) <br>_Initialize display._ |
 |  lv\_display\_t \* | [**bsp\_display\_start\_with\_config**](#function-bsp_display_start_with_config) (const [**bsp\_display\_cfg\_t**](#struct-bsp_display_cfg_t) \*cfg) <br>_Initialize display._ |
 |  void | [**bsp\_display\_unlock**](#function-bsp_display_unlock) (void) <br>_Give LVGL mutex._ |

--- a/bsp/m5stack_tab5/idf_component.yml
+++ b/bsp/m5stack_tab5/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.2.0~1"
+version: "1.2.0~2"
 description: Board Support Package (BSP) for M5Stack Tab5
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/m5stack_tab5
 

--- a/bsp/m5stack_tab5/include/bsp/m5stack_tab5.h
+++ b/bsp/m5stack_tab5/include/bsp/m5stack_tab5.h
@@ -510,7 +510,7 @@ esp_err_t bsp_display_exit_sleep(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /** @} */ // end of display

--- a/bsp/m5stack_tab5/src/bsp_display.c
+++ b/bsp/m5stack_tab5/src/bsp_display.c
@@ -508,7 +508,7 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev_touch;
 }
 
-void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/components/esp_lvgl_port/examples/touchscreen/main/main.c
+++ b/components/esp_lvgl_port/examples/touchscreen/main/main.c
@@ -217,7 +217,7 @@ static esp_err_t app_lvgl_init(void)
 
 static void _app_button_cb(lv_event_t *e)
 {
-    lv_disp_rotation_t rotation = lv_disp_get_rotation(lvgl_disp);
+    lv_display_rotation_t rotation = lv_disp_get_rotation(lvgl_disp);
     rotation++;
     if (rotation > LV_DISPLAY_ROTATION_270) {
         rotation = LV_DISPLAY_ROTATION_0;

--- a/components/esp_lvgl_port/test_apps/lvgl_port/main/test.c
+++ b/components/esp_lvgl_port/test_apps/lvgl_port/main/test.c
@@ -265,7 +265,7 @@ static esp_err_t app_lvgl_deinit(void)
 
 static void _app_button_cb(lv_event_t *e)
 {
-    lv_disp_rotation_t rotation = lv_disp_get_rotation(lvgl_disp);
+    lv_display_rotation_t rotation = lv_disp_get_rotation(lvgl_disp);
     rotation++;
     if (rotation > LV_DISPLAY_ROTATION_270) {
         rotation = LV_DISPLAY_ROTATION_0;

--- a/examples/display_rotation/main/main.c
+++ b/examples/display_rotation/main/main.c
@@ -25,7 +25,7 @@ LV_IMG_DECLARE(esp_logo)
 
 static lv_disp_t *display;
 static lv_obj_t *lbl_rotation;
-static lv_disp_rotation_t rotation = LV_DISPLAY_ROTATION_0;
+static lv_display_rotation_t rotation = LV_DISPLAY_ROTATION_0;
 #if BSP_CAPS_IMU
 static icm42670_handle_t imu = NULL;
 #endif
@@ -35,7 +35,7 @@ static icm42670_handle_t imu = NULL;
 * Private functions
 *******************************************************************************/
 
-static uint16_t app_lvgl_get_rotation_degrees(lv_disp_rotation_t rotation)
+static uint16_t app_lvgl_get_rotation_degrees(lv_display_rotation_t rotation)
 {
     switch (rotation) {
     case LV_DISPLAY_ROTATION_0:


### PR DESCRIPTION
## Problem

`bsp_display_rotate()` takes an `lv_disp_rotation_t`, which no longer exists in LVGL. Every affected BSP therefore fails to compile against current LVGL `master`:

```
error: unknown type name 'lv_disp_rotation_t'; did you mean 'lv_display_rotation_t'?
  bsp/esp32_s31_korvo_1/include/bsp/esp32_s31_korvo_1.h:601
```

LVGL 9.5.0 (the newest release on the component registry as of August 2026) still builds, so this only bites people who track `master` - which, for ESP32-S31, is currently necessary if you want the PPA draw unit (see lvgl/lvgl#10481).

## Why the name disappeared

`lv_disp_rotation_t` was never part of LVGL v8. It was a mistake in LVGL's own v8 compatibility header, fixed by **lvgl/lvgl#10095** (commit `879e7b9f6`, merged 11 May 2026):

```diff
-typedef lv_display_rotation_t       lv_disp_rotation_t;
+typedef lv_display_rotation_t       lv_disp_rot_t;
```

v8's real identifier was `lv_disp_rot_t`, so the alias these BSPs relied on was simply wrong, and removing it was a legitimate fix rather than a breaking change.

## Fix

Use `lv_display_rotation_t`, which is correct under **both** major versions:

- LVGL 9: it is the native name.
- LVGL 8: `components/esp_lvgl_port/include/esp_lvgl_port_compatibility.h` already provides it via `typedef lv_disp_rotation_t lv_display_rotation_t;`.

That compatibility header deliberately defines the LVGL 8 shim, so it is **left untouched** and is now the only place in the repository that mentions the old name.

## Scope

- 18 BSPs (header, source and `API.md`), plus two `esp_lvgl_port` examples/tests
- Component revisions bumped for the BSPs, following the `~N` convention used for fixes
- `esp_lvgl_port` itself is unchanged (only its examples/tests), so its version is not bumped

## Verification

Built the LVGL demo project for **ESP32-S31-Korvo-1 V1.1** against LVGL `master` with the PPA draw unit enabled. Before this change the build required patching this identifier by hand; after it, it succeeds unmodified.

I only had ESP32-S31-Korvo-1 hardware to hand, so the other 17 BSPs are verified by inspection - the change is a pure identifier rename with no behavioural component.

Two notes for reviewers:

- **doxygen was not available on my machine**, so the `doxygen-api-md` pre-commit hook could not run. The `API.md` files were updated with the same textual rename instead of being regenerated; please regenerate if the output differs. All other hooks (astyle, copyright, codespell, README/board-table updaters) pass and changed nothing.
- **The 18 version bumps are easy to drop** if you would rather handle versioning at release time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only API alignment with no logic changes; LVGL 8 still gets `lv_display_rotation_t` via esp_lvgl_port compatibility.
> 
> **Overview**
> Updates **`bsp_display_rotate()`** and related docs across **18 BSPs** so the rotation parameter uses **`lv_display_rotation_t`** instead of **`lv_disp_rotation_t`**, matching current LVGL and fixing builds against LVGL master where the old type was removed.
> 
> The same type rename is applied in **`esp_lvgl_port`** touchscreen/test code and the **`display_rotation`** example. Each touched BSP gets a **`idf_component.yml`** patch revision bump (`~N`); **`esp_lvgl_port`** itself is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd20773ff660759be43106594812c236571e253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->