### PR TITLE
Update README.md

### DIFF
--- a/components/ds18b20/README.md
+++ b/components/ds18b20/README.md
@@ -83,7 +83,7 @@ It can be started after initializing a onewire bus.
     ESP_ERROR_CHECK(iot_sensor_start(sensor_handle));
 ```
 
-NOTE: Only a single DS18B20 device is supported.
+NOTE: Only a single DS18B20 device is supported "by Sensor hub" (the DS18B20 device driver itself does not carry this limitation).
 
 ## Reference
 


### PR DESCRIPTION
Rewrote a comment to avoid misunderstandings.

# ESP-BSP Pull Request checklist

# Change description
The overall cleaner approach of textual presentation (of README.md), although easier on eyes, make it a little difficult, to the fast reader, to catch the appropriate context - of that particular comment, in that particular place -, as being not the device driver, just the sensor hub. So the rewrite, who aims to eliminate the ambiguity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API impact.
> 
> **Overview**
> Clarifies the **Sensor hub** section note so readers do not assume the whole DS18B20 component is limited to one device.
> 
> The NOTE now states that only a **single DS18B20 on the bus** applies to the sensor hub integration, while the standalone device driver still supports multiple sensors (as shown in the enumeration example above).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb52ed8e75a4af4c8b923d731d11c40fb8c294d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->