### PR TITLE
feat(m5stack_core_s3): make LCD SPI pixel clock configurable via Kconfig

### DIFF
--- a/bsp/m5stack_core_s3/Kconfig
+++ b/bsp/m5stack_core_s3/Kconfig
@@ -68,6 +68,18 @@ menu "Board Support Package (M5Stack Core S3)"
         default y
         help
             Whether to enable double framebuf.
+
+        config BSP_LCD_PIXEL_CLOCK_MHZ
+        int "LCD SPI pixel clock (MHz)"
+        default 40
+        range 1 80
+        help
+            SPI clock frequency (in MHz) used to drive the LCD panel.
+            A higher clock shortens the frame flush time and yields
+            smoother animation, but values above the panel/board wiring
+            tolerance can cause visual artifacts or tearing. The default
+            of 40 MHz is the conservative, board-validated value; raise it
+            only if your specific board tolerates it.
     endmenu
     menu "Camera"
     endmenu

--- a/bsp/m5stack_core_s3/idf_component.yml
+++ b/bsp/m5stack_core_s3/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "4.0.0"
+version: "4.1.0"
 description: Board Support Package (BSP) for M5Stack Core S3
 url: https://github.com/espressif/esp-bsp/tree/master/bsp/m5stack_core_s3
 

--- a/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
+++ b/bsp/m5stack_core_s3/include/bsp/m5stack_core_s3.h
@@ -469,7 +469,11 @@ esp_err_t bsp_sdcard_sdspi_mount(bsp_sdcard_cfg_t *cfg);
  *
  * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
  **************************************************************************************************/
+#ifdef CONFIG_BSP_LCD_PIXEL_CLOCK_MHZ
+#define BSP_LCD_PIXEL_CLOCK_HZ     (CONFIG_BSP_LCD_PIXEL_CLOCK_MHZ * 1000 * 1000)
+#else
 #define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
+#endif
 #define BSP_LCD_SPI_NUM            (SPI3_HOST)
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)


### PR DESCRIPTION
## Description

The M5Stack CoreS3 BSP hardcodes the LCD SPI pixel clock at 40 MHz:

```c
#define BSP_LCD_PIXEL_CLOCK_HZ     (40 * 1000 * 1000)
```

This PR makes it configurable via a new `BSP_LCD_PIXEL_CLOCK_MHZ` Kconfig option (under the existing **Display** menu, alongside `BSP_LCD_DRAW_BUF_HEIGHT`). `BSP_LCD_PIXEL_CLOCK_HZ` is derived from it, and falls back to the previous hardcoded 40 MHz when the option is unset. **The default is unchanged (40 MHz), so this is fully backward compatible.**

## Motivation

The LCD SPI clock is the dominant cost of a full-frame flush. On my CoreS3 patio-control hub (LVGL v9.5 over the SPI panel), raising the clock had a large, measurable effect on animation smoothness:

| SPI clock | Result |
|-----------|--------|
| 40 MHz (stock) | ~18 fps, full-frame flush ~30 ms |
| **60 MHz** | **~27 fps (+50%), stable, artifact-free** |
| 80 MHz | flush halved, but visual artifacts/tearing on this board |

The important observation: **the safe maximum varies by board wiring / signal integrity**, not just the panel controller. The ILI9341/ESP32-S3 GPSPI can be clocked to 80 MHz at the silicon level, but this particular CoreS3's traces artifacted at 80 and were clean at 60. So the right value is an integrator decision for their specific board — which is exactly why it belongs in Kconfig with a conservative default, rather than a fixed `#define`.

## Changes

- `Kconfig`: add `BSP_LCD_PIXEL_CLOCK_MHZ` (int, default `40`, range `1..80`) under the Display menu, with help text noting the smoothness/artifact tradeoff.
- `include/bsp/m5stack_core_s3.h`: derive `BSP_LCD_PIXEL_CLOCK_HZ` from `CONFIG_BSP_LCD_PIXEL_CLOCK_MHZ`, with a `40 MHz` fallback when unset.
- `idf_component.yml`: minor version bump `4.0.0` -> `4.1.0` (new backward-compatible feature).

## Testing

- Built and flashed on real M5Stack CoreS3 hardware at 40 / 60 / 80 MHz via this option; 60 MHz gives a stable +50% fps with no artifacts on my unit.
- Default (unset) build is byte-for-byte equivalent to the previous 40 MHz behavior.

## Notes / open questions for reviewers

- I scoped this to the CoreS3 only for a small, reviewable change. The same pattern generalizes to the other SPI BSPs (e.g. `esp32_s3_korvo_2`, which also hardcodes `BSP_LCD_PIXEL_CLOCK_HZ`) — happy to follow up if you would like it applied consistently.
- Opened as a **draft** for early feedback on the approach/naming before finalizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible BSP config only; default clock is unchanged. Higher user-chosen clocks can cause display artifacts, not security or data issues.
> 
> **Overview**
> Makes the M5Stack CoreS3 LCD SPI pixel clock tunable via `BSP_LCD_PIXEL_CLOCK_MHZ` (1–80 MHz, default **40**) instead of a hardcoded 40 MHz.
> 
> `BSP_LCD_PIXEL_CLOCK_HZ` is derived from that option and still falls back to 40 MHz if the Kconfig symbol is unset. Component version is bumped to **4.1.0**. Default behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba60bb37a5f593d55f314734c22fd665ea3cff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->